### PR TITLE
ci: run the 45 chat/mcp unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main", "feat/**", "fix/**", "docs/**", "chore/**", "ci/**"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev", "testVictor", "testSanti"]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -25,3 +25,21 @@ jobs:
       # existing codebase while catching real breakage; broadened once the SPA lands (see #25).
       - name: Ruff critical checks
         run: ruff check --output-format=github --select=E9,F63,F7,F82 .
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # deps-lite: the 45 hermetic tests import only backend.models and
+      # backend.services.chatbot, whose module-level imports are stdlib +
+      # requests + pydantic (fastmcp is imported lazily, inside functions).
+      # Installing from pyproject.toml / requirements.txt would pull the heavy
+      # ML stack and the broken openai-whisper pin (#28) — deliberately avoided.
+      - name: Install test deps
+        run: pip install pytest pytest-asyncio requests pydantic
+      - name: Run unit tests
+        run: pytest tests/ -v


### PR DESCRIPTION
Adds a pytest `test` job (deps-lite: pytest, pytest-asyncio, requests, pydantic) running the 45 hermetic chat-engine + mcp-bridge tests, which previously ran in no CI. Also lets PRs into dev/testVictor/testSanti trigger CI.

Closes #60