### PR TITLE
fix(data): repo-root walker honors .git dir + F1_STRAT_DATA_ROOT

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -24,12 +24,9 @@ from pydantic import BaseModel, Field
 # ---------------------------------------------------------------------------
 # Repo-root injection — `src/agents/` must be importable from here
 # ---------------------------------------------------------------------------
-_HERE = Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent
-while not (_REPO_ROOT / ".git").exists() and _REPO_ROOT != _REPO_ROOT.parent:
-    _REPO_ROOT = _REPO_ROOT.parent
-if not (_REPO_ROOT / ".git").exists():
-    _REPO_ROOT = Path("/app")
+from backend.core.paths import get_data_root, get_repo_root
+
+_REPO_ROOT = get_repo_root()
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
@@ -728,12 +725,12 @@ except ImportError:
 
 def _radio_corpus_root() -> Path:
     """Base path for the processed radio corpus."""
-    return _REPO_ROOT / "data" / "processed" / "race_radios"
+    return get_data_root() / "processed" / "race_radios"
 
 
 def _transcript_cache_root() -> Path:
     """Base path for cached Whisper transcripts."""
-    return _REPO_ROOT / "data" / "processed" / "radio_nlp"
+    return get_data_root() / "processed" / "radio_nlp"
 
 
 def _driver_number_to_code(year: int = 2025) -> dict:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -3,12 +3,10 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-# Walk up to repo root (.git marker) so we find the .env at the repo root
-# regardless of which directory uvicorn is launched from.
-_d = Path(__file__).resolve().parent
-while not (_d / ".git").exists() and _d != _d.parent:
-    _d = _d.parent
-load_dotenv(_d / ".env")
+from backend.core.paths import get_repo_root
+
+# Load the repo-root .env, then the submodule-local .env below as an override.
+load_dotenv(get_repo_root() / ".env")
 # Also load a local .env in src/telemetry/ if it exists (overrides)
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env", override=True)
 

--- a/backend/core/paths.py
+++ b/backend/core/paths.py
@@ -1,0 +1,53 @@
+"""Repo-root and data-root resolution for the telemetry backend.
+
+Single source of truth for "which directory is the repo / holds the data",
+shared by every module that used to carry its own ``.git`` walker.  Those
+walkers tested ``(dir / ".git").exists()``, which is satisfied by the **gitlink
+file** at ``src/telemetry/.git`` — so a bare-metal backend resolved the repo
+root to the submodule and every parquet path 503'd (#27).  The fix is to look
+for a ``.git`` *directory* and to honour ``$F1_STRAT_DATA_ROOT`` (set by
+docker-compose to ``/app/data``).
+
+--- WHERE TO CHANGE IF PATH RESOLUTION CHANGES ---
+Every site that needs the repo root (sys.path injection so ``src.agents`` /
+``src.f1_strat_manager`` import) or the data root (parquet + radio corpus)
+imports from here: ``core/config.py``, ``utils/laps_cache.py``,
+``mcp_tools.py``, ``api/v1/endpoints/strategy.py``,
+``services/simulation/simulator.py``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DOCKER_FALLBACK = Path("/app")
+
+
+def _find_git_root(start: Path) -> Path | None:
+    """Walk up from *start* for a directory containing a ``.git`` **directory**.
+
+    A ``.git`` *file* (the submodule gitlink) is deliberately ignored — treating
+    it as the repo root is the #27 bug that broke every bare-metal data path.
+    """
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").is_dir():
+            return candidate
+    return None
+
+
+def get_repo_root() -> Path:
+    """Resolve the repository root; fall back to ``/app`` (the Docker mount)."""
+    return _find_git_root(Path(__file__).resolve().parent) or _DOCKER_FALLBACK
+
+
+def get_data_root() -> Path:
+    """Resolve the ``data/`` directory.
+
+    Precedence: ``$F1_STRAT_DATA_ROOT`` (docker-compose sets ``/app/data``) →
+    ``<repo root>/data``.
+    """
+    override = os.getenv("F1_STRAT_DATA_ROOT")
+    if override:
+        return Path(override).expanduser()
+    return get_repo_root() / "data"

--- a/backend/mcp_tools.py
+++ b/backend/mcp_tools.py
@@ -25,12 +25,9 @@ from fastmcp import FastMCP
 # ---------------------------------------------------------------------------
 # Repo-root injection (same pattern as strategy.py)
 # ---------------------------------------------------------------------------
-_HERE = Path(__file__).resolve()
-_REPO = _HERE.parent
-while not (_REPO / ".git").exists() and _REPO != _REPO.parent:
-    _REPO = _REPO.parent
-if not (_REPO / ".git").exists():
-    _REPO = Path("/app")
+from backend.core.paths import get_repo_root
+
+_REPO = get_repo_root()
 if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
 

--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -35,12 +35,9 @@ from pydantic import BaseModel, ConfigDict, Field
 # module is loaded standalone (smoke tests, MCP tools) without the FastAPI
 # startup path having injected ``_REPO_ROOT`` first.
 # ---------------------------------------------------------------------------
-_HERE = Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent
-while not (_REPO_ROOT / ".git").exists() and _REPO_ROOT != _REPO_ROOT.parent:
-    _REPO_ROOT = _REPO_ROOT.parent
-if not (_REPO_ROOT / ".git").exists():
-    _REPO_ROOT = Path("/app")
+from backend.core.paths import get_data_root, get_repo_root
+
+_REPO_ROOT = get_repo_root()
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
@@ -197,17 +194,11 @@ def _set_provider_env(provider: str) -> None:
 def _data_root() -> Path:
     """Return the data root used by the CLI and every backend component.
 
-    Prefers :func:`f1_strat_manager.data_cache.get_data_root` (robust to the
-    ``src/telemetry`` git submodule that trips up generic ``.git`` walkers)
-    and falls back to the repo-relative layout for bare-bones environments
-    where the helper is not importable.
+    Routes through the shared resolver (``backend.core.paths.get_data_root``),
+    which honours ``$F1_STRAT_DATA_ROOT`` and walks for a ``.git`` *directory*
+    so the ``src/telemetry`` submodule gitlink no longer misresolves it (#27).
     """
-    try:
-        from src.f1_strat_manager.data_cache import get_data_root
-
-        return get_data_root()
-    except ImportError:
-        return _REPO_ROOT / "data"
+    return get_data_root()
 
 
 _laps_df_cache: dict[int, pd.DataFrame] = {}
@@ -216,9 +207,8 @@ _laps_df_cache: dict[int, pd.DataFrame] = {}
 def _load_laps_df(year: int) -> pd.DataFrame:
     """Load (and memoise) the featured laps parquet for ``year``.
 
-    Kept local to this module instead of reusing ``backend.utils.laps_cache``
-    because the shared helper's repo-root walker stops at the submodule
-    ``.git`` file inside ``src/telemetry`` and resolves to the wrong tree.
+    Kept as a small module-local cache (with raise-on-missing semantics the
+    simulator relies on) rather than importing ``backend.utils.laps_cache``.
     """
     if year in _laps_df_cache:
         return _laps_df_cache[year]

--- a/backend/utils/laps_cache.py
+++ b/backend/utils/laps_cache.py
@@ -1,19 +1,13 @@
 """Cached loader for the featured laps parquet (multi-year)."""
 
 import logging
-from pathlib import Path
 from typing import Dict, Optional
 
 import pandas as pd
 
-logger = logging.getLogger(__name__)
+from backend.core.paths import get_data_root
 
-_REPO_ROOT = Path(__file__).resolve().parent
-while not (_REPO_ROOT / ".git").exists() and _REPO_ROOT != _REPO_ROOT.parent:
-    _REPO_ROOT = _REPO_ROOT.parent
-# Docker fallback: no .git found → assume /app is the mount point
-if not (_REPO_ROOT / ".git").exists():
-    _REPO_ROOT = Path("/app")
+logger = logging.getLogger(__name__)
 
 _cache: Dict[int, pd.DataFrame] = {}
 
@@ -22,7 +16,7 @@ def get_laps_df(year: int = 2025) -> Optional[pd.DataFrame]:
     """Load the featured parquet for *year* and cache it in memory."""
     if year in _cache:
         return _cache[year]
-    path = _REPO_ROOT / "data" / "processed" / f"laps_featured_{year}.parquet"
+    path = get_data_root() / "processed" / f"laps_featured_{year}.parquet"
     if not path.exists():
         logger.warning("Featured parquet not found: %s", path)
         return None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,48 @@
+"""Tests for the shared repo-root / data-root resolver (#27).
+
+The bug these pin: a ``.git`` *file* (the submodule gitlink at
+``src/telemetry/.git``) must NOT be mistaken for the repo root, and
+``$F1_STRAT_DATA_ROOT`` must win when set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core import paths
+
+
+def _make_tree(root: Path) -> Path:
+    """Build root with a real ``.git`` dir + a nested submodule with a ``.git`` file.
+
+    Returns the deep directory a walker would start from.
+    """
+    (root / ".git").mkdir()
+    sub = root / "src" / "telemetry"
+    sub.mkdir(parents=True)
+    (sub / ".git").write_text("gitdir: ../../.git/modules/telemetry\n")
+    deep = sub / "backend" / "core"
+    deep.mkdir(parents=True)
+    return deep
+
+
+def test_find_git_root_ignores_gitlink_file(tmp_path):
+    deep = _make_tree(tmp_path)
+    assert paths._find_git_root(deep) == tmp_path
+
+
+def test_find_git_root_returns_none_without_git(tmp_path):
+    # No .git anywhere → None (get_repo_root then falls back to /app).
+    d = tmp_path / "a" / "b"
+    d.mkdir(parents=True)
+    assert paths._find_git_root(d) is None
+
+
+def test_get_data_root_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("F1_STRAT_DATA_ROOT", str(tmp_path / "mydata"))
+    assert paths.get_data_root() == Path(str(tmp_path / "mydata"))
+
+
+def test_get_data_root_defaults_to_repo_data(monkeypatch):
+    monkeypatch.delenv("F1_STRAT_DATA_ROOT", raising=False)
+    assert paths.get_data_root() == paths.get_repo_root() / "data"


### PR DESCRIPTION
Closes #27. Replaces 5 gitlink-fooled walkers with one shared resolver; parquet/radio paths now resolve on bare metal (verified: get_laps_df loads 22,760 rows locally). Behavior notes: config now loads the repo-root .env then the submodule .env as override; data paths honor F1_STRAT_DATA_ROOT. Test-first (tests/test_paths.py).