### PR TITLE
fix(deps): drop dead openai-whisper, add fastmcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ dependencies = [
     "numpy==1.26.4",
     "pandas==2.2.0",
 
-    # Voice Chat
-    "openai-whisper==20231117",
+    # Voice Chat (STT uses transformers, not openai-whisper — see #28)
     "edge-tts==7.2.3",
     "nest-asyncio==1.6.0",
     "pydub==0.25.1",
@@ -38,6 +37,9 @@ dependencies = [
     "requests==2.31.0",
     "plotly==5.18.0",
     "httpx==0.26.0",
+
+    # MCP (Model Context Protocol) server — kept in sync with requirements.txt (#29)
+    "fastmcp==3.2.0",
     "streamlit>=1.37.0",
     "streamlit-shadcn-ui>=0.1.0",
     "streamlit-lottie>=0.0.5",


### PR DESCRIPTION
Closes #28. Closes #29. Reconciles pyproject.toml with backend/requirements.txt: removes the dead/broken openai-whisper pin and adds the missing fastmcp==3.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an MCP server dependency, enabling broader protocol integration.
* **Chores**
  * Updated voice chat configuration to use the current speech-to-text approach.
  * Removed an unused speech-to-text dependency and refreshed package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->