### PR TITLE
fix(voice): map TTS rate wpm to Edge-TTS percent

### DIFF
--- a/backend/services/voice/tts_service.py
+++ b/backend/services/voice/tts_service.py
@@ -26,17 +26,28 @@ if str(backend_dir) not in sys.path:
 logger = logging.getLogger(__name__)
 
 
+# Neutral pace, in words per minute. TTSRequest.rate is expressed in wpm and
+# defaults to this value; keep the two in sync (this is the "+0%" point).
+_BASELINE_WPM = 175
+
+
 def _format_rate(rate: Optional[int]) -> str:
-    """Convert the legacy integer ``rate`` argument into the SSML-style string
-    Edge-TTS expects. Callers used to pass values like ``-10`` or ``+20`` to
-    mean "10 percent slower" or "20 percent faster"; Edge-TTS speaks that
-    shape directly once we prepend the sign. ``None`` maps to ``+0%`` so the
-    voice speaks at its natural pace.
+    """Convert the request's words-per-minute ``rate`` into the +/-N% string
+    Edge-TTS expects.
+
+    Edge-TTS has no absolute wpm control — it takes a percentage relative to the
+    voice's natural pace. ``TTSRequest.rate`` is in wpm, so we map it around a
+    neutral baseline of 175 wpm: 175 → +0% (natural), 350 → +100% (twice as
+    fast), 88 → -50%. ``None`` also maps to +0%.
+
+    Before this fix the wpm value was emitted verbatim as a percentage, so the
+    default 175 synthesized at +175% speed (#52).
     """
     if rate is None:
         return "+0%"
-    sign = "+" if rate >= 0 else ""
-    return f"{sign}{rate}%"
+    pct = round((rate - _BASELINE_WPM) / _BASELINE_WPM * 100)
+    sign = "+" if pct >= 0 else ""
+    return f"{sign}{pct}%"
 
 
 def _format_volume(volume: Optional[float]) -> str:

--- a/tests/test_voice_rate.py
+++ b/tests/test_voice_rate.py
@@ -1,0 +1,41 @@
+"""Tests for the TTS words-per-minute -> Edge-TTS percent conversion (#52).
+
+The bug: ``TTSRequest.rate`` is words-per-minute (default 175) but
+``_format_rate`` emitted it verbatim as an Edge-TTS percentage, so the default
+synthesized at +175% speed.  The fix maps wpm to a sane +/-N% around a 175
+baseline.
+"""
+
+from __future__ import annotations
+
+import re
+
+from backend.models.voice_models import TTSRequest
+from backend.services.voice.tts_service import _format_rate
+
+
+def _percent(rate_str: str) -> int:
+    m = re.fullmatch(r"([+-]\d+)%", rate_str)
+    assert m, f"not a signed Edge-TTS rate string: {rate_str!r}"
+    return int(m.group(1))
+
+
+def test_default_rate_is_neutral_not_a_speed_multiplier():
+    default_wpm = TTSRequest.model_fields["rate"].default
+    pct = _percent(_format_rate(default_wpm))
+    assert -50 <= pct <= 100  # sane band — never the +175% bug
+    assert pct == 0  # 175 wpm baseline speaks at natural pace
+
+
+def test_none_maps_to_neutral():
+    assert _format_rate(None) == "+0%"
+
+
+def test_slower_and_faster_straddle_zero():
+    assert _percent(_format_rate(120)) < 0
+    assert _percent(_format_rate(250)) > 0
+
+
+def test_output_is_always_signed_percent():
+    for wpm in (50, 175, 400):
+        assert re.fullmatch(r"[+-]\d+%", _format_rate(wpm))


### PR DESCRIPTION
Closes #52. Fixes the +175% default-speed bug: _format_rate now maps the words-per-minute rate to an Edge-TTS percentage around a 175 wpm baseline. No breaking model/API/frontend change. Test-first (tests/test_voice_rate.py).