### PR TITLE
fix(llm): finite, configurable timeout for LM Studio requests

### DIFF
--- a/backend/services/chatbot/llm_service.py
+++ b/backend/services/chatbot/llm_service.py
@@ -37,7 +37,12 @@ OPENAI_DEFAULT_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-5.4-mini")
 _is_openai = LLM_PROVIDER.lower() == "openai"
 COMPLETIONS_URL = OPENAI_URL if _is_openai else LM_STUDIO_URL
 MODELS_URL = OPENAI_MODELS_URL if _is_openai else LM_STUDIO_MODELS_URL
-DEFAULT_TIMEOUT = 60 if _is_openai else None  # OpenAI has reasonable latency; LM Studio can be slow
+# Every provider call gets a FINITE timeout so a hung backend (a stuck local
+# model, a dead socket) errors instead of freezing the server forever
+# (Security S-5 / LLM-cost L-1). LM Studio gets a more generous default because
+# a large local model on modest hardware is legitimately slow; both are
+# overridable via F1_LLM_TIMEOUT (seconds).
+DEFAULT_TIMEOUT = float(os.getenv("F1_LLM_TIMEOUT", "60" if _is_openai else "120"))
 
 
 def _headers() -> dict:

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -1,0 +1,45 @@
+"""The provider request timeout must always be finite (Security S-5 / LLM-cost L-1).
+
+A ``None`` timeout on the LM Studio path let a hung local model freeze the
+backend forever (``requests`` treats ``timeout=None`` as "wait indefinitely").
+These tests pin that ``DEFAULT_TIMEOUT`` stays a real positive number for every
+provider, and that the ``F1_LLM_TIMEOUT`` env override is honored.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _reload_llm_service(monkeypatch, provider: str):
+    """Reload llm_service with a chosen provider and no env timeout override.
+
+    ``DEFAULT_TIMEOUT`` is computed at import time from the provider, so the
+    module has to be re-imported under the patched environment to observe it.
+    """
+    monkeypatch.setenv("F1_LLM_PROVIDER", provider)
+    monkeypatch.delenv("F1_LLM_TIMEOUT", raising=False)
+    import backend.services.chatbot.llm_service as svc
+
+    return importlib.reload(svc)
+
+
+def test_timeout_finite_for_lmstudio(monkeypatch):
+    svc = _reload_llm_service(monkeypatch, "lmstudio")
+    assert svc.DEFAULT_TIMEOUT is not None
+    assert svc.DEFAULT_TIMEOUT > 0
+
+
+def test_timeout_finite_for_openai(monkeypatch):
+    svc = _reload_llm_service(monkeypatch, "openai")
+    assert svc.DEFAULT_TIMEOUT is not None
+    assert svc.DEFAULT_TIMEOUT > 0
+
+
+def test_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("F1_LLM_PROVIDER", "lmstudio")
+    monkeypatch.setenv("F1_LLM_TIMEOUT", "42")
+    import backend.services.chatbot.llm_service as svc
+
+    svc = importlib.reload(svc)
+    assert svc.DEFAULT_TIMEOUT == 42.0


### PR DESCRIPTION
DEFAULT_TIMEOUT was None for LM Studio -> requests.post waited forever, so a hung local model froze the backend (Security S-5 / LLM-cost L-1). Now 120s default (overridable via F1_LLM_TIMEOUT), OpenAI stays 60s, never None. Hermetic test_llm_timeout.py + verified live against LM Studio (2.78s round-trip, bounded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a finite default timeout for LM Studio requests to prevent stalled chatbot requests.
  * OpenAI and LM Studio requests now fail or return control after a defined period instead of waiting indefinitely.
  * Added support for configuring the timeout through the `F1_LLM_TIMEOUT` environment setting.

* **Tests**
  * Added coverage verifying positive timeouts across supported providers and custom timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->