### PR TITLE
test(chat): FakeOpenAI stub + contract/SSE harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      # deps-lite: the 45 hermetic tests import only backend.models and
-      # backend.services.chatbot, whose module-level imports are stdlib +
-      # requests + pydantic (fastmcp is imported lazily, inside functions).
-      # Installing from pyproject.toml / requirements.txt would pull the heavy
-      # ML stack and the broken openai-whisper pin (#28) — deliberately avoided.
+      # deps-lite: the hermetic tests import only backend.models,
+      # backend.services.chatbot and the per-router endpoint modules, whose
+      # module-level imports are stdlib + requests + pydantic + fastapi
+      # (fastmcp is imported lazily, inside functions). fastapi + httpx back the
+      # FastAPI TestClient the contract/integration suite uses; httpx is
+      # starlette's test transport. Installing from pyproject.toml /
+      # requirements.txt would pull the heavy ML stack and the broken
+      # openai-whisper pin (#28) — deliberately avoided.
+      #
+      # The FakeOpenAI stub binds 127.0.0.1:1234; on the runner that port is
+      # free so the integration tests run. Locally, a dev's live LM Studio on
+      # :1234 makes them skip (never fail) — the documented MVP (Testing T-3,
+      # AUDIT_TESTING_QA §11); an env-configurable port is a separate enabler.
       - name: Install test deps
-        run: pip install pytest pytest-asyncio requests pydantic
+        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx
       - name: Run unit tests
         run: pytest tests/ -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,68 @@
-"""Pytest config — make the ``backend`` package importable from tests.
+"""Pytest config — make the ``backend`` package importable and share fixtures.
 
 The submodule keeps its source directly under ``backend/`` instead of the
 more conventional ``src/backend``, so we add the submodule root to
 ``sys.path`` here once per session.  This mirrors what the ``backend``
 package itself does at runtime via uvicorn's working directory.
+
+Also exposes the two integration fixtures the FakeOpenAI harness needs:
+``fake_openai`` (the scripted OpenAI stub bound to :1234) and
+``chat_app_client`` (a bare FastAPI app carrying only the chat router).
 """
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
+
+# Point the backend's LLM client at exactly where the FakeOpenAI stub binds
+# (127.0.0.1), before any backend module is imported.  llm_service reads
+# LM_STUDIO_HOST at import time and defaults to "localhost", which can resolve
+# to ::1 first while the stub only listens on IPv4 — pinning removes that
+# address-family ambiguity so the integration tests are deterministic on CI.
+os.environ.setdefault("LM_STUDIO_HOST", "127.0.0.1")
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+from tests.fake_openai import FakeOpenAIServer  # noqa: E402  (needs sys.path patched first)
+
+
+@pytest.fixture
+def fake_openai():
+    """Start the FakeOpenAI stub on :1234 for one test, tear it down after.
+
+    Skips (never fails) when :1234 is already bound — a dev running a real LM
+    Studio locally should not see red tests; CI runners always have the port
+    free.  Removing this collision entirely is the env-configurable-port
+    enabler (Testing T-3), deliberately out of scope here.
+    """
+    try:
+        server = FakeOpenAIServer()
+    except OSError:
+        pytest.skip("port 1234 is occupied (a real LM Studio?) — FakeOpenAI cannot bind")
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def chat_app_client():
+    """A ``TestClient`` over a bare FastAPI app mounting only the chat router.
+
+    Mirrors the per-router isolation pattern (one router per app) so a chat
+    contract test never drags in the voice/strategy/FastMCP import surface.
+    Paths match production (``/api/v1/chat/...``) because the router carries its
+    own ``/chat`` prefix and is mounted here under ``/api/v1``.
+    """
+    from backend.api.v1.endpoints import chat
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(chat.router, prefix="/api/v1")
+    with TestClient(app) as client:
+        yield client

--- a/tests/fake_openai.py
+++ b/tests/fake_openai.py
@@ -1,0 +1,234 @@
+"""In-process FakeOpenAI stub — an OpenAI-compatible HTTP server for tests.
+
+Why this exists
+---------------
+Every LLM-touching path in F1 StratLab speaks the OpenAI wire protocol against a
+*real socket* at ``http://localhost:1234/v1``: the backend chat engine
+(``llm_service.send_message`` via ``requests.post``) and, in the parent repo, the
+six sub-agents + orchestrator (``ChatOpenAI(base_url=...:1234/v1)``).  Those call
+sites are hardcoded and ``src/agents`` is untouchable, so the test double cannot
+be an in-memory ASGI app monkeypatched over the client — it has to be an actual
+listening HTTP server on port 1234.  This module is exactly that: a stdlib
+``http.server`` bound to ``127.0.0.1:1234`` returning *scripted* completions, so a
+test can drive the whole chat/agent plumbing with no live model, no network, and
+zero changes to production code (Testing audit T-3, the harness linchpin).
+
+What it is NOT
+--------------
+A fidelity model of a real LLM.  It cannot catch prompt-quality regressions or
+provider quirks — that is the job of the (non-gating, local) real-LM-Studio smoke
+tier.  Its job is *plumbing* correctness: response shapes, tool-call tuples, SSE
+grammar, routing — which is where every escaped bug in the Testing audit lived.
+Never a real provider, never Anthropic.
+
+Scripting model
+---------------
+Responses are a FIFO queue: each ``/v1/chat/completions`` request pops the next
+scripted reply.  A chat turn that calls a tool makes two LLM round-trips (the
+tool-choice call, then the summary call), so scripting is by call order::
+
+    fake_openai.push_tool_call("predict_pace", {"driver": "VER"})  # round-trip 1
+    fake_openai.push_text("VER is projected 0.3s faster next lap.")  # round-trip 2
+
+When the queue is empty the stub returns a benign default reply (so a stray extra
+call never 500s a test) and still records the request for inspection.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+# ponytail: host/port hardcoded to match the app's hardcoded base_url. An
+# env-configurable port is a separate enabler (Testing T-3) — add it only if a
+# dev's real LM Studio on :1234 makes the collision-skip below actually annoying.
+STUB_HOST = "127.0.0.1"
+STUB_PORT = 1234
+
+_DEFAULT_MODEL = "fake-model"
+
+
+def build_completion(
+    content: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    *,
+    model: str = _DEFAULT_MODEL,
+    total_tokens: int = 11,
+) -> dict[str, Any]:
+    """Build an OpenAI ``chat.completion`` response dict.
+
+    Matches the exact shape the backend's extractors read: ``choices[0].message``
+    (``content`` and/or ``tool_calls``), ``model`` and ``usage.total_tokens`` (the
+    SSE ``done`` metadata).  ``content`` is ``None`` on a pure tool-call turn, per
+    the OpenAI contract.
+    """
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    completion = {
+        "id": "chatcmpl-fake",
+        "object": "chat.completion",
+        "created": 0,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": total_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+    return completion
+
+
+def build_tool_call(
+    name: str,
+    arguments: dict[str, Any] | str | None = None,
+    *,
+    call_id: str = "call_fake",
+) -> dict[str, Any]:
+    """Build one OpenAI ``tool_call``.
+
+    ``arguments`` is JSON-*encoded* in the wire protocol (a string, not an object),
+    so a dict is serialised here — the backend's ``coerce_tool_arguments`` decodes
+    it again.  Passing a raw string through lets a test script malformed JSON to
+    exercise that coercion path.
+    """
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments)
+    tool_call = {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+    return tool_call
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Serves the two endpoints the app hits; all state lives on the server."""
+
+    # Silence per-request stderr logging so the pytest output stays readable.
+    def log_message(self, *args: Any) -> None:  # noqa: D401
+        pass
+
+    def do_GET(self) -> None:
+        if self._path_is("/v1/models"):
+            self._send_json(200, {"object": "list", "data": [{"id": _DEFAULT_MODEL, "object": "model"}]})
+        else:
+            self._send_json(404, {"error": {"message": f"no route for GET {self.path}"}})
+
+    def do_POST(self) -> None:
+        body = self._read_json_body()
+        self.server.received.append(body)  # type: ignore[attr-defined]
+
+        if not self._path_is("/v1/chat/completions"):
+            self._send_json(404, {"error": {"message": f"no route for POST {self.path}"}})
+            return
+
+        status, payload = self.server.next_response()  # type: ignore[attr-defined]
+        self._send_json(status, payload)
+
+    def _path_is(self, suffix: str) -> bool:
+        """True when the request path ends with *suffix* (ignoring a trailing slash)."""
+        return self.path.rstrip("/").endswith(suffix)
+
+    def _read_json_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            return json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            return {"_unparsed": raw.decode("utf-8", "replace")}
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _StubHTTPServer(ThreadingHTTPServer):
+    """Threading HTTP server holding the scripted queue and received-request log."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address: tuple[str, int]) -> None:
+        super().__init__(address, _StubHandler)
+        self.script: deque[tuple[int, dict[str, Any]]] = deque()
+        self.received: list[dict[str, Any]] = []
+        self.default_response: tuple[int, dict[str, Any]] = (
+            200,
+            build_completion(content="(fake default reply)"),
+        )
+
+    def next_response(self) -> tuple[int, dict[str, Any]]:
+        """Pop the next scripted (status, payload), or the benign default."""
+        if self.script:
+            return self.script.popleft()
+        return self.default_response
+
+
+class FakeOpenAIServer:
+    """Handle to a running FakeOpenAI stub — script replies, inspect requests.
+
+    Bound to :1234 on construction (raises ``OSError`` if the port is taken — the
+    fixture turns that into a skip so a dev's live LM Studio never fails the run).
+    Every ``push_*`` returns ``self`` so a multi-round-trip turn can be scripted in
+    one chained expression.
+    """
+
+    def __init__(self) -> None:
+        self._server = _StubHTTPServer((STUB_HOST, STUB_PORT))
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    # ---- scripting -------------------------------------------------------
+    def push_text(self, text: str, **kwargs: Any) -> "FakeOpenAIServer":
+        """Enqueue a plain-text completion (no tool call)."""
+        self._server.script.append((200, build_completion(content=text, **kwargs)))
+        return self
+
+    def push_tool_call(
+        self,
+        name: str,
+        arguments: dict[str, Any] | str | None = None,
+        *,
+        call_id: str = "call_fake",
+    ) -> "FakeOpenAIServer":
+        """Enqueue a tool-call completion (content ``None``, one ``tool_calls`` entry)."""
+        tool_calls = [build_tool_call(name, arguments, call_id=call_id)]
+        self._server.script.append((200, build_completion(content=None, tool_calls=tool_calls)))
+        return self
+
+    def push_error(self, status: int = 500, message: str = "stub error") -> "FakeOpenAIServer":
+        """Enqueue an HTTP error, to exercise the provider-failure path."""
+        self._server.script.append((status, {"error": {"message": message}}))
+        return self
+
+    # ---- inspection ------------------------------------------------------
+    @property
+    def requests(self) -> list[dict[str, Any]]:
+        """The parsed request bodies received so far, in order."""
+        return self._server.received
+
+    @property
+    def url(self) -> str:
+        return f"http://{STUB_HOST}:{STUB_PORT}/v1"
+
+    # ---- lifecycle -------------------------------------------------------
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()

--- a/tests/fixtures/sse/README.md
+++ b/tests/fixtures/sse/README.md
@@ -1,0 +1,16 @@
+# Chat SSE transcript fixtures
+
+Recorded `event: <name>\ndata: <json>\n\n` streams from the chat
+`tool-message-stream` endpoint, driven by the FakeOpenAI stub.
+
+- `chat_plain.sse` — a no-tool turn: `stage` × N → `token` → `done`.
+- `chat_tool_call.sse` — a tool turn: `stage` × N → `tool_result` → `stage` → `token` → `done`.
+
+**One fixture, two consumers.** These files are the shared wire contract between
+the Python grammar tests (`tests/test_chat_sse.py`) and the SPA's TypeScript
+`RaceFeed` parser (migration W0). Both parse the *same* bytes, so client and
+server cannot drift apart silently (Testing audit T-7).
+
+**Regenerate** with `python tests/fixtures/sse/generate_transcripts.py` (from the
+submodule root, with port 1234 free). Commit the regenerated files in the same PR
+as any SSE grammar change — the fixture diff is the contract diff.

--- a/tests/fixtures/sse/chat_plain.sse
+++ b/tests/fixtures/sse/chat_plain.sse
@@ -1,0 +1,15 @@
+event: stage
+data: {"stage": "preparing_tools"}
+
+event: stage
+data: {"stage": "model_choosing_tool"}
+
+event: stage
+data: {"stage": "composing_response"}
+
+event: token
+data: {"token": "Hola, soy tu asistente de estrategia. ¿Qué piloto quieres analizar?"}
+
+event: done
+data: {"llm_model": "fake-model", "tokens_used": 11}
+

--- a/tests/fixtures/sse/chat_tool_call.sse
+++ b/tests/fixtures/sse/chat_tool_call.sse
@@ -1,0 +1,21 @@
+event: stage
+data: {"stage": "preparing_tools"}
+
+event: stage
+data: {"stage": "model_choosing_tool"}
+
+event: stage
+data: {"stage": "calling_predict_pace"}
+
+event: tool_result
+data: {"tool_result": {"tool_name": "predict_pace", "display_type": "metrics", "data": {"driver": "VER", "lap_time_pred": 91.2, "delta_vs_median": -0.31}, "summary": ""}}
+
+event: stage
+data: {"stage": "summarizing_with_llm"}
+
+event: token
+data: {"token": "VER is projected around 91.2s next lap, ~0.31s under the median."}
+
+event: done
+data: {"llm_model": "fake-model", "tokens_used": 11}
+

--- a/tests/fixtures/sse/generate_transcripts.py
+++ b/tests/fixtures/sse/generate_transcripts.py
@@ -1,0 +1,69 @@
+"""Regenerate the chat ``.sse`` transcript fixtures from the FakeOpenAI stub.
+
+Run this by hand whenever the chat SSE grammar changes (e.g. the P1 F-19 framing
+unification); commit the regenerated ``.sse`` files in the same PR so the fixture
+diff records the contract change.
+
+    # from the submodule root, with :1234 free (stop LM Studio first)
+    python tests/fixtures/sse/generate_transcripts.py
+
+Deterministic: the stub scripts fixed replies, so re-running produces byte-stable
+output unless the server's event grammar actually changed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]  # submodule root
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.api.v1.endpoints import chat  # noqa: E402
+from backend.services.chatbot import chat_engine  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from tests.fake_openai import FakeOpenAIServer  # noqa: E402
+
+OUT = Path(__file__).parent
+STREAM = "/api/v1/chat/tool-message-stream"
+
+
+async def _no_tools():
+    return []
+
+
+async def _one_tool():
+    return [{"type": "function", "function": {"name": "predict_pace", "parameters": {}}}]
+
+
+async def _fake_dispatch(name, args):
+    return {"driver": args.get("driver"), "lap_time_pred": 91.2, "delta_vs_median": -0.31}
+
+
+def main() -> None:
+    app = FastAPI()
+    app.include_router(chat.router, prefix="/api/v1")
+    client = TestClient(app)
+    server = FakeOpenAIServer()
+    try:
+        chat_engine.list_openai_tools = _no_tools
+        server.push_text("Hola, soy tu asistente de estrategia. ¿Qué piloto quieres analizar?")
+        plain = client.post(STREAM, json={"text": "hola"})
+        (OUT / "chat_plain.sse").write_text(plain.text, encoding="utf-8")
+        print("wrote chat_plain.sse")
+
+        chat_engine.list_openai_tools = _one_tool
+        chat_engine.call_mcp_tool = _fake_dispatch
+        server.push_tool_call("predict_pace", {"driver": "VER", "lap": 30})
+        server.push_text("VER is projected around 91.2s next lap, ~0.31s under the median.")
+        tool = client.post(STREAM, json={"text": "pace for VER at Monza lap 30"})
+        (OUT / "chat_tool_call.sse").write_text(tool.text, encoding="utf-8")
+        print("wrote chat_tool_call.sse")
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sse_utils.py
+++ b/tests/sse_utils.py
@@ -1,0 +1,39 @@
+"""Minimal Server-Sent-Events parsing shared by the SSE tests.
+
+The chat stream frames each event as ``event: <name>\\ndata: <json>\\n\\n`` (see
+``chat._sse``).  This is the Python mirror of what the SPA's TS ``RaceFeed``
+parser must implement, so the same ``.sse`` fixtures pin both sides of the wire
+(one fixture, two consumers — Testing audit T-7).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_sse(text: str) -> list[tuple[str | None, dict[str, Any] | None]]:
+    """Parse an SSE body into ``(event, data)`` tuples.
+
+    ``data`` is JSON-decoded; a frame missing either field yields ``None`` in
+    that slot so a malformed stream surfaces as a shape mismatch rather than a
+    crash.
+    """
+    events: list[tuple[str | None, dict[str, Any] | None]] = []
+    for block in text.strip().split("\n\n"):
+        if not block.strip():
+            continue
+        name: str | None = None
+        data: dict[str, Any] | None = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        events.append((name, data))
+    return events
+
+
+def event_sequence(text: str) -> list[str | None]:
+    """Return just the ordered event names of an SSE body (the grammar spine)."""
+    return [name for name, _ in parse_sse(text)]

--- a/tests/test_chat_contracts.py
+++ b/tests/test_chat_contracts.py
@@ -1,0 +1,149 @@
+"""Contract tests for the chat router — happy paths, error contracts, OpenAPI.
+
+Per-router isolation (a bare FastAPI app carrying only ``chat.router``) keeps the
+heavy strategy / telemetry / voice import surface out: those routers import
+pandas / fastf1 / ``src.agents`` at module top and need a backend-full test tier,
+not the hermetic deps-lite one this suite runs in.
+
+The load-bearing contract here is the escaped-bug class the Testing audit cares
+about: **a provider failure must not surface as HTTP 200.**  ``/message`` already
+maps it to 503 (pinned below).  ``/tool-message`` still swallows it into a 200
+with a fallback string — pinned as a strict ``xfail`` against the P1 F-11 error
+envelope so the gap is executable debt, not prose (flip it to a passing assert
+when F-11 lands).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from backend.services.chatbot import chat_engine
+
+CHAT = "/api/v1/chat"
+
+
+async def _no_tools():
+    """Isolate the chat flow from FastMCP — no tool is ever offered."""
+    return []
+
+
+# ---------------------------------------------------------------------------
+# health / models
+# ---------------------------------------------------------------------------
+
+def test_health_is_healthy_when_the_stub_is_reachable(fake_openai, chat_app_client):
+    resp = chat_app_client.get(f"{CHAT}/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "healthy"
+    assert body["lm_studio_reachable"] is True
+
+
+def test_models_lists_the_loaded_model(fake_openai, chat_app_client):
+    resp = chat_app_client.get(f"{CHAT}/models")
+    assert resp.status_code == 200
+    assert "fake-model" in resp.json()["models"]
+
+
+# ---------------------------------------------------------------------------
+# /message (legacy, non-tool)
+# ---------------------------------------------------------------------------
+
+def test_message_happy_path_returns_the_reply(fake_openai, chat_app_client):
+    fake_openai.push_text("Hola, ¿en qué te ayudo?")
+    resp = chat_app_client.post(f"{CHAT}/message", json={"text": "hola"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["response"] == "Hola, ¿en qué te ayudo?"
+    assert body["llm_model"] == "fake-model"
+
+
+def test_message_provider_failure_returns_503_not_200(fake_openai, chat_app_client):
+    """The correct error contract: a provider 500 becomes a backend 503."""
+    fake_openai.push_error(500, "boom")
+    resp = chat_app_client.post(f"{CHAT}/message", json={"text": "hola"})
+    assert resp.status_code == 503
+
+
+def test_message_requires_text(chat_app_client):
+    resp = chat_app_client.post(f"{CHAT}/message", json={})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /tool-message (tool-aware, non-streaming)
+# ---------------------------------------------------------------------------
+
+def test_tool_message_happy_path_returns_reply(fake_openai, chat_app_client, monkeypatch):
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _no_tools)
+    fake_openai.push_text("Necesito piloto, GP y vuelta para analizar la degradación.")
+    resp = chat_app_client.post(f"{CHAT}/tool-message", json={"text": "analiza degradación"})
+    assert resp.status_code == 200
+    assert "piloto" in resp.json()["response"]
+
+
+def test_tool_message_rejects_empty_text(chat_app_client):
+    resp = chat_app_client.post(f"{CHAT}/tool-message", json={"text": ""})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /status (smart-spinner poll target)
+# ---------------------------------------------------------------------------
+
+def test_status_returns_a_stage_field(chat_app_client):
+    resp = chat_app_client.get(f"{CHAT}/status", params={"request_id": "abc"})
+    assert resp.status_code == 200
+    assert "stage" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI meta — guards the SPA's typed-client generation (migration A5-4)
+# ---------------------------------------------------------------------------
+
+def test_chat_openapi_operations_are_typed_and_have_operation_ids():
+    from backend.api.v1.endpoints import chat
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(chat.router, prefix="/api/v1")
+    schema = app.openapi()
+
+    for path, methods in schema["paths"].items():
+        for method, operation in methods.items():
+            assert "operationId" in operation, f"{method.upper()} {path} lacks an operationId"
+
+    # Response models must be concrete (named components), not a bare object,
+    # so the generated client gets real return types.
+    dumped = json.dumps(schema)
+    assert "ToolMessageResponse" in dumped
+    assert "ChatResponse" in dumped
+    assert "HealthResponse" in dumped
+
+    # No chat route should leak a `year` query param (P1 F-15 was a strategy-route
+    # bug; the chat surface must stay clean as the typed client grows over it).
+    for methods in schema["paths"].values():
+        for operation in methods.values():
+            param_names = {p.get("name") for p in operation.get("parameters", [])}
+            assert "year" not in param_names
+
+
+# ---------------------------------------------------------------------------
+# PR-D — error envelope, written test-first (xfail until P1 F-11 lands)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "P1 F-11: /tool-message swallows provider errors into HTTP 200 with a "
+        "fallback string; the error envelope is not implemented yet. When F-11 "
+        "lands this will XPASS and (strict) fail — that is the signal to remove "
+        "the xfail and keep the assert."
+    ),
+)
+def test_tool_message_provider_failure_should_not_return_200(fake_openai, chat_app_client, monkeypatch):
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _no_tools)
+    fake_openai.push_error(500, "boom")
+    resp = chat_app_client.post(f"{CHAT}/tool-message", json={"text": "hola"})
+    assert resp.status_code >= 400  # currently 200 → xfail documents the gap

--- a/tests/test_chat_sse.py
+++ b/tests/test_chat_sse.py
@@ -1,0 +1,101 @@
+"""SSE grammar tests — the committed ``.sse`` transcripts are the wire contract.
+
+Two guarantees:
+  * the recorded transcripts are well-formed and carry the expected event
+    grammar (read-only, no stub — these also document the shape the SPA's TS
+    parser must handle);
+  * the *live* server output reproduces the recorded event-name sequence, so a
+    grammar change on either side (e.g. the P1 F-19 framing unification) shows up
+    as a fixture diff instead of a silent client/server drift.
+
+The transcripts were captured from the FakeOpenAI-driven flow (see
+``fixtures/sse/generate_transcripts.py``); regenerate them in the same PR as any
+grammar change — the fixture diff IS the contract diff (Testing audit T-7).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from backend.services.chatbot import chat_engine
+
+from tests.sse_utils import event_sequence, parse_sse
+
+FIXTURES = Path(__file__).parent / "fixtures" / "sse"
+PLAIN = FIXTURES / "chat_plain.sse"
+TOOL = FIXTURES / "chat_tool_call.sse"
+
+STREAM = "/api/v1/chat/tool-message-stream"
+
+
+async def _no_tools():
+    return []
+
+
+async def _one_tool():
+    return [{"type": "function", "function": {"name": "predict_pace", "parameters": {}}}]
+
+
+async def _fake_dispatch(name, args):
+    return {"driver": args.get("driver"), "lap_time_pred": 91.2, "delta_vs_median": -0.31}
+
+
+# ---------------------------------------------------------------------------
+# Recorded-transcript grammar (read-only, no stub)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path", [PLAIN, TOOL], ids=["plain", "tool_call"])
+def test_recorded_transcript_is_well_formed(path):
+    events = parse_sse(path.read_text(encoding="utf-8"))
+    assert events, f"{path.name} is empty"
+    for name, data in events:
+        assert name, f"frame without an event name in {path.name}"
+        assert isinstance(data, dict), f"frame data is not a JSON object in {path.name}"
+    # `done` terminates the stream, exactly once.
+    names = [name for name, _ in events]
+    assert names[-1] == "done"
+    assert names.count("done") == 1
+
+
+def test_plain_transcript_grammar():
+    names = event_sequence(PLAIN.read_text(encoding="utf-8"))
+    assert names[0] == "stage"
+    assert "tool_result" not in names  # no tool on a plain turn
+    assert "token" in names
+    assert names[-1] == "done"
+
+
+def test_tool_transcript_grammar():
+    events = parse_sse(TOOL.read_text(encoding="utf-8"))
+    names = [name for name, _ in events]
+    # A tool turn must emit the structured result before the summary token.
+    assert names.index("tool_result") < names.index("token")
+    assert names[-1] == "done"
+
+    tool_result = next(data["tool_result"] for name, data in events if name == "tool_result")
+    assert {"tool_name", "display_type", "data", "summary"} <= tool_result.keys()
+
+
+# ---------------------------------------------------------------------------
+# Live-output-matches-recorded-grammar (needs the stub)
+# ---------------------------------------------------------------------------
+
+def test_live_plain_stream_matches_recorded_grammar(fake_openai, chat_app_client, monkeypatch):
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _no_tools)
+    fake_openai.push_text("Hola, ¿qué piloto quieres analizar?")
+
+    resp = chat_app_client.post(STREAM, json={"text": "hola"})
+    assert resp.status_code == 200
+    assert event_sequence(resp.text) == event_sequence(PLAIN.read_text(encoding="utf-8"))
+
+
+def test_live_tool_stream_matches_recorded_grammar(fake_openai, chat_app_client, monkeypatch):
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _one_tool)
+    monkeypatch.setattr(chat_engine, "call_mcp_tool", _fake_dispatch)
+    fake_openai.push_tool_call("predict_pace", {"driver": "VER", "lap": 30})
+    fake_openai.push_text("VER is projected around 91.2s next lap.")
+
+    resp = chat_app_client.post(STREAM, json={"text": "pace for VER at Monza lap 30"})
+    assert resp.status_code == 200
+    assert event_sequence(resp.text) == event_sequence(TOOL.read_text(encoding="utf-8"))

--- a/tests/test_fake_openai.py
+++ b/tests/test_fake_openai.py
@@ -1,0 +1,133 @@
+"""Tests for the FakeOpenAI stub and the chat plumbing that runs through it.
+
+Two tiers here:
+  * stub self-tests — hit the stub directly with ``requests`` and pin its wire
+    behaviour (models list, FIFO scripting, tool-call shape, request recording);
+  * chat integration — drive ``/api/v1/chat/tool-message-stream`` end to end
+    against the stub, proving the backend's two-round-trip LLM plumbing (tool
+    choice → dispatch → summary) works with no live model.
+
+MCP is monkeypatched out of the chat tests on purpose: the stub's job is the LLM
+plumbing, so tool *listing* and *dispatch* are replaced with deterministic fakes
+rather than spinning up FastMCP.  The real tool-call-over-SSE grammar is pinned
+separately against recorded transcripts (Testing audit item 9 / PR-C).
+"""
+
+from __future__ import annotations
+
+import json
+
+import requests
+from backend.services.chatbot import chat_engine
+
+from tests.sse_utils import parse_sse as _parse_sse
+
+# ---------------------------------------------------------------------------
+# Stub self-tests (talk to the stub directly, no backend)
+# ---------------------------------------------------------------------------
+
+def test_models_endpoint_lists_the_fake_model(fake_openai):
+    resp = requests.get(f"{fake_openai.url}/models", timeout=5)
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    assert "fake-model" in ids
+
+
+def test_completions_are_served_in_fifo_order(fake_openai):
+    fake_openai.push_text("first").push_text("second")
+
+    first = requests.post(f"{fake_openai.url}/chat/completions", json={"messages": []}, timeout=5)
+    second = requests.post(f"{fake_openai.url}/chat/completions", json={"messages": []}, timeout=5)
+
+    assert first.json()["choices"][0]["message"]["content"] == "first"
+    assert second.json()["choices"][0]["message"]["content"] == "second"
+
+
+def test_empty_queue_falls_back_to_a_benign_default(fake_openai):
+    resp = requests.post(f"{fake_openai.url}/chat/completions", json={"messages": []}, timeout=5)
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "(fake default reply)"
+
+
+def test_tool_call_completion_encodes_arguments_as_json_string(fake_openai):
+    fake_openai.push_tool_call("predict_pace", {"driver": "VER", "lap": 30})
+
+    resp = requests.post(f"{fake_openai.url}/chat/completions", json={"messages": []}, timeout=5)
+    message = resp.json()["choices"][0]["message"]
+
+    assert message["content"] is None
+    call = message["tool_calls"][0]
+    assert call["function"]["name"] == "predict_pace"
+    # arguments must be a JSON-encoded *string*, per the OpenAI wire protocol.
+    assert json.loads(call["function"]["arguments"]) == {"driver": "VER", "lap": 30}
+
+
+def test_requests_are_recorded_for_inspection(fake_openai):
+    requests.post(f"{fake_openai.url}/chat/completions", json={"messages": [{"role": "user"}], "tools": [1]}, timeout=5)
+
+    assert len(fake_openai.requests) == 1
+    assert fake_openai.requests[0]["tools"] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Chat integration (drive the real endpoint through the stub)
+# ---------------------------------------------------------------------------
+
+async def _no_tools():
+    return []
+
+
+async def _one_fake_tool():
+    return [{"type": "function", "function": {"name": "predict_pace", "parameters": {}}}]
+
+
+def test_plain_text_chat_streams_stage_token_done(fake_openai, chat_app_client, monkeypatch):
+    """A no-tool turn: the stub's text becomes the single ``token`` event."""
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _no_tools)
+    fake_openai.push_text("Hola, soy tu asistente de estrategia.")
+
+    resp = chat_app_client.post("/api/v1/chat/tool-message-stream", json={"text": "hola"})
+    assert resp.status_code == 200
+
+    events = _parse_sse(resp.text)
+    names = [name for name, _ in events]
+    assert "stage" in names
+    assert names[-1] == "done"
+
+    tokens = [data["token"] for name, data in events if name == "token"]
+    assert any("Hola" in t for t in tokens)
+    # The backend actually reached the stub (one round-trip, no tool call).
+    assert len(fake_openai.requests) == 1
+
+
+def test_tool_call_chat_streams_tool_result_then_summary(fake_openai, chat_app_client, monkeypatch):
+    """A tool turn makes two round-trips: tool-choice, then a no-tools summary."""
+    monkeypatch.setattr(chat_engine, "list_openai_tools", _one_fake_tool)
+
+    async def _fake_dispatch(name, args):
+        return {"driver": args.get("driver"), "lap_time_pred": 91.2}
+
+    monkeypatch.setattr(chat_engine, "call_mcp_tool", _fake_dispatch)
+
+    # Round-trip 1 → tool call; round-trip 2 → the summary text.
+    fake_openai.push_tool_call("predict_pace", {"driver": "VER"})
+    fake_openai.push_text("VER is projected around 91.2s next lap.")
+
+    resp = chat_app_client.post("/api/v1/chat/tool-message-stream", json={"text": "pace for VER at Monza lap 30"})
+    assert resp.status_code == 200
+
+    events = _parse_sse(resp.text)
+    names = [name for name, _ in events]
+    assert "tool_result" in names
+    assert names[-1] == "done"
+
+    tool_result = next(data["tool_result"] for name, data in events if name == "tool_result")
+    assert tool_result["tool_name"] == "predict_pace"
+
+    tokens = [data["token"] for name, data in events if name == "token"]
+    assert any("91.2" in t for t in tokens)
+
+    # Two LLM round-trips; the summary call must NOT carry tools= (OpenAI would
+    # otherwise expect another tool answer). This pins the single-tool contract.
+    assert len(fake_openai.requests) == 2
+    assert "tools" not in fake_openai.requests[1] or not fake_openai.requests[1]["tools"]


### PR DESCRIPTION
Delivers the hermetic chat test harness for VforVitorio/F1-StratLab#181: an in-process OpenAI stub on :1234, chat integration + per-route contracts + SSE grammar tests, and a test-first xfail for the F-11 error envelope. All hermetic (no live model, no network); the submodule test job now installs fastapi+httpx. Heavier routers (strategy/telemetry/voice) need a backend-full tier and are out of scope here.