### PR TITLE
feat(security): throttle and time-box the unauthenticated surface (#226)

### DIFF
--- a/backend/api/v1/endpoints/chat.py
+++ b/backend/api/v1/endpoints/chat.py
@@ -9,7 +9,9 @@ import json
 import logging
 import uuid
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+from backend.core.rate_limit import rate_limit
 from fastapi.responses import StreamingResponse
 
 from backend.services.chatbot import chat_engine
@@ -72,7 +74,7 @@ async def get_models():
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/message", response_model=ChatResponse)
+@router.post("/message", response_model=ChatResponse, dependencies=[Depends(rate_limit("chat-message", capacity=10, per_minute=20))])
 async def send_chat_message(request: ChatRequest):
     """
     Send a message to LM Studio and get the complete response (non-streaming).
@@ -166,7 +168,7 @@ async def send_chat_message(request: ChatRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/stream")
+@router.post("/stream", dependencies=[Depends(rate_limit("chat-stream", capacity=10, per_minute=20))])
 async def stream_chat_message(request: ChatRequest):
     """
     Send a message to LM Studio and stream the response.
@@ -238,7 +240,7 @@ def chat_status(request_id: str):
     return {"stage": get_stage(request_id)}
 
 
-@router.post("/tool-message", response_model=ToolMessageResponse)
+@router.post("/tool-message", response_model=ToolMessageResponse, dependencies=[Depends(rate_limit("chat-tool-message", capacity=10, per_minute=20))])
 async def tool_message(
     request: ToolMessageRequest,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),
@@ -276,7 +278,7 @@ async def tool_message(
         clear_stage(request_id)
 
 
-@router.post("/tool-message-stream")
+@router.post("/tool-message-stream", dependencies=[Depends(rate_limit("chat-tool-stream", capacity=10, per_minute=20))])
 async def tool_message_stream(
     request: ToolMessageRequest,
     x_request_id: str | None = Header(default=None, alias="X-Request-Id"),

--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 # Repo-root injection — `src/agents/` must be importable from here
 # ---------------------------------------------------------------------------
 from backend.core.paths import get_data_root, get_repo_root
+from backend.core.rate_limit import rate_limit
 
 _REPO_ROOT = get_repo_root()
 if str(_REPO_ROOT) not in sys.path:
@@ -394,7 +395,7 @@ def get_lap_state(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pace", response_model=StrategyResponse)
+@router.post("/pace", response_model=StrategyResponse, dependencies=[Depends(rate_limit("pace", capacity=20, per_minute=60))])
 def predict_pace(request: PaceRequest):
     """Run the Pace Agent (N25) for a single lap."""
     try:
@@ -415,7 +416,7 @@ def predict_pace(request: PaceRequest):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pace-range")
+@router.post("/pace-range", dependencies=[Depends(rate_limit("pace-range", capacity=5, per_minute=10))])
 def predict_pace_range(request: PaceRangeRequest):
     """Run Pace Agent across a lap range and return actual vs predicted."""
     import numpy as np
@@ -534,7 +535,7 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
 # ---------------------------------------------------------------------------
 
 
-@router.post("/tire", response_model=StrategyResponse)
+@router.post("/tire", response_model=StrategyResponse, dependencies=[Depends(rate_limit("tire", capacity=20, per_minute=60))])
 def predict_tire(
     request: TireRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -560,7 +561,7 @@ def predict_tire(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/situation", response_model=StrategyResponse)
+@router.post("/situation", response_model=StrategyResponse, dependencies=[Depends(rate_limit("situation", capacity=20, per_minute=60))])
 def predict_situation(
     request: SituationRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -586,7 +587,7 @@ def predict_situation(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pit", response_model=StrategyResponse)
+@router.post("/pit", response_model=StrategyResponse, dependencies=[Depends(rate_limit("pit", capacity=20, per_minute=60))])
 def predict_pit(
     request: PitRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -612,7 +613,7 @@ def predict_pit(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/radio", response_model=StrategyResponse)
+@router.post("/radio", response_model=StrategyResponse, dependencies=[Depends(rate_limit("radio", capacity=20, per_minute=60))])
 def analyze_radio(
     request: RadioRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -652,7 +653,7 @@ def analyze_radio(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/rag", response_model=StrategyResponse)
+@router.post("/rag", response_model=StrategyResponse, dependencies=[Depends(rate_limit("rag", capacity=5, per_minute=10))])
 def query_rag(request: RagRequest):
     """Run the RAG Agent (N30) to answer a regulation question."""
     try:
@@ -673,7 +674,7 @@ def query_rag(request: RagRequest):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/recommend", response_model=StrategyResponse)
+@router.post("/recommend", response_model=StrategyResponse, dependencies=[Depends(rate_limit("recommend", capacity=5, per_minute=10))])
 def recommend_strategy(
     request: RecommendRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -895,7 +896,7 @@ class SimulateRequest(BaseModel):
     interval_s: float = Field(0.0, ge=0.0, le=10.0)
 
 
-@router.post("/simulate")
+@router.post("/simulate", dependencies=[Depends(rate_limit("simulate", capacity=3, per_minute=3))])
 def simulate(req: SimulateRequest):
     """Stream per-lap strategy decisions as Server-Sent Events.
 

--- a/backend/api/v1/endpoints/voice.py
+++ b/backend/api/v1/endpoints/voice.py
@@ -4,7 +4,9 @@ Voice Chat API Endpoints
 Provides endpoints for speech-to-text, text-to-speech, and full voice chat flow.
 """
 
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, status
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException, status
+
+from backend.core.rate_limit import rate_limit
 from fastapi.responses import Response
 import base64
 import time
@@ -136,17 +138,26 @@ def _read_audio_file(audio: UploadFile) -> bytes:
         HTTPException: If reading fails
     """
     try:
-        return audio.file.read()
+        data = audio.file.read()
     except Exception as e:
         logger.error(f"Failed to read audio file: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to read audio file"
         )
+    # Security C2: cap the upload so a huge body cannot exhaust memory / pin the STT worker.
+    max_bytes = 10 * 1024 * 1024
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Audio file too large ({len(data)} bytes); max {max_bytes}.",
+        )
+    return data
 
 
 @router.post(
     "/transcribe",
+    dependencies=[Depends(rate_limit("voice-transcribe", capacity=6, per_minute=12))],
     response_model=TranscriptionResponse,
     summary="Transcribe audio to text",
     description="Convert audio file to text using Whisper STT"
@@ -189,6 +200,7 @@ async def transcribe_audio(audio: UploadFile = File(...)):
 
 @router.post(
     "/synthesize",
+    dependencies=[Depends(rate_limit("voice-synthesize", capacity=6, per_minute=12))],
     summary="Convert text to speech",
     description="Generate audio from text using pyttsx3 TTS",
     response_class=Response
@@ -236,6 +248,7 @@ async def synthesize_speech(request: TTSRequest):
 
 @router.post(
     "/voice-chat",
+    dependencies=[Depends(rate_limit("voice-chat", capacity=6, per_minute=12))],
     response_model=VoiceChatResponse,
     summary="Full voice chat flow",
     description="Complete flow: STT (Nemotron, local) \u2192 LLM (provider via F1_LLM_PROVIDER) \u2192 TTS (Qwen3, local)"

--- a/backend/core/rate_limit.py
+++ b/backend/core/rate_limit.py
@@ -1,0 +1,94 @@
+"""In-process per-client rate limiting for the expensive unauthenticated endpoints.
+
+Security C2 / S-7: a single client (or a stray script) must not be able to pin
+the workers by hammering ``/simulate``, the prediction routes or voice. This is a
+local, single-process backend, so a stdlib token bucket keyed on the client IP is
+enough - no ``slowapi``/``limits`` dependency is pulled in for a few lines of code.
+
+Each ``rate_limit(...)`` call owns one bucket per route (via a closure), so the
+limits are independent. The dependency is evaluated at request admission, so an
+open SSE stream consumes exactly one token and then runs unmetered - the limiter
+never interferes with a long-lived sim/voice stream.
+
+--- WHERE TO CHANGE IF THE LIMITS CHANGE ---
+The per-route (capacity, per_minute) pairs live at each route's
+``dependencies=[Depends(rate_limit(...))]`` in the endpoint modules, not here.
+Set ``F1_RATE_LIMIT_OFF=1`` to disable entirely (load tests, benchmarking).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import HTTPException, Request
+
+_DISABLE_ENV = "F1_RATE_LIMIT_OFF"
+
+
+class TokenBucket:
+    """Per-key token bucket. Thread-safe (sync endpoints run in the threadpool).
+
+    ``capacity`` tokens are available at rest; they refill continuously at
+    ``refill_per_minute`` tokens/min. A request takes one token; when the bucket
+    is empty the caller is told how long to wait for the next token.
+    """
+
+    def __init__(self, capacity: int, refill_per_minute: float) -> None:
+        self._capacity = float(capacity)
+        self._refill_per_s = refill_per_minute / 60.0
+        self._lock = threading.Lock()
+        self._state: dict[str, tuple[float, float]] = {}  # key -> (tokens, last_ts)
+
+    def try_acquire(self, key: str) -> tuple[bool, float]:
+        """Take one token for ``key``; return ``(allowed, retry_after_seconds)``."""
+        now = time.monotonic()
+        with self._lock:
+            tokens, last = self._state.get(key, (self._capacity, now))
+            tokens = min(self._capacity, tokens + (now - last) * self._refill_per_s)
+            if tokens >= 1.0:
+                self._state[key] = (tokens - 1.0, now)
+                return True, 0.0
+            self._state[key] = (tokens, now)
+            deficit = 1.0 - tokens
+            retry_after = deficit / self._refill_per_s if self._refill_per_s > 0 else 60.0
+            return False, retry_after
+
+
+def _client_key(request: Request) -> str:
+    """Client IP as the bucket key; falls back to a constant for local/unknown clients.
+
+    ``X-Forwarded-For`` is deliberately NOT honored: without a trusted reverse
+    proxy it is client-spoofable, and the deployment target is a local process.
+    """
+    return request.client.host if request.client else "local"
+
+
+def rate_limit(name: str, capacity: int, per_minute: float) -> Callable[[Request], Awaitable[None]]:
+    """Build a FastAPI dependency that rate-limits one route via its own bucket.
+
+    Args:
+        name: Route label used in the 429 message (e.g. ``"simulate"``).
+        capacity: Burst size - tokens available at rest.
+        per_minute: Sustained refill rate in tokens per minute.
+
+    Returns:
+        An async dependency that raises 429 (with ``Retry-After``) when the
+        per-client bucket is empty, or does nothing when the limit is disabled.
+    """
+    bucket = TokenBucket(capacity, per_minute)
+
+    async def _dependency(request: Request) -> None:
+        if os.getenv(_DISABLE_ENV) == "1":
+            return
+        allowed, retry_after = bucket.try_acquire(_client_key(request))
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit for '{name}' exceeded; retry shortly.",
+                headers={"Retry-After": str(int(retry_after) + 1)},
+            )
+
+    return _dependency

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,11 +37,15 @@ async def lifespan(app):
 app = FastAPI(title="F1 Telemetry API", lifespan=lifespan)
 
 app.add_middleware(
+    # Security C3 / S-8: the origin is already specific (FRONTEND_URL). Credentials
+    # are dropped because no client authenticates by cookie (the Streamlit frontend
+    # calls the backend server-side, not from the browser), and the method/header
+    # allowlists are enumerated to the verbs/headers actually used instead of "*".
     CORSMiddleware,
     allow_origins=[FRONTEND_URL],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"]
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Accept", "X-Request-Id"],
 )
 
 # Add telemetry router

--- a/backend/models/chat_models.py
+++ b/backend/models/chat_models.py
@@ -2,10 +2,26 @@
 Chat Models
 
 Pydantic models for chat API request/response validation.
+
+Security C3 / S-8: the client-supplied ``chat_history`` and ``context`` reach the
+LLM prompt (``llm_service.build_messages``), so they are bounded and pruned here
+at the request boundary - before any LLM cost is paid - instead of trusting the
+raw payload. ``context`` is pruned to the four keys ``build_messages`` actually
+reads, dropping any injected keys; ``chat_history`` is capped in count and size.
 """
 
-from pydantic import BaseModel
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+# Bounds (kept as module constants so the validators and any tests share them).
+MAX_TEXT_CHARS = 8_000
+MAX_IMAGE_CHARS = 12_000_000  # ~9 MB of binary once base64-decoded
+MAX_HISTORY_MESSAGES = 40
+MAX_MESSAGE_CHARS = 12_000
+_ALLOWED_ROLES = {"user", "assistant", "system", "tool"}
+# The only context keys build_messages consumes; everything else is dropped.
+_ALLOWED_CONTEXT_KEYS = {"year", "grand_prix", "session", "drivers"}
 
 
 class ChatMessage(BaseModel):
@@ -16,13 +32,58 @@ class ChatMessage(BaseModel):
 
 class ChatRequest(BaseModel):
     """Request model for chat messages."""
-    text: str
-    image: Optional[str] = None  # Base64 encoded image (for future multimodal support)
+    text: str = Field(min_length=1, max_length=MAX_TEXT_CHARS)
+    image: Optional[str] = Field(default=None, max_length=MAX_IMAGE_CHARS)
     chat_history: Optional[List[Dict[str, Any]]] = None
     context: Optional[Dict[str, Any]] = None
-    model: Optional[str] = None
-    temperature: float = 0.7
-    max_tokens: int = 1000
+    model: Optional[str] = Field(default=None, max_length=128)
+    temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    max_tokens: int = Field(default=1000, ge=1, le=8192)
+
+    @field_validator("chat_history")
+    @classmethod
+    def _bound_history(cls, history: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+        """Cap the history length and each text message's size; reject unknown roles.
+
+        Non-string ``content`` is tolerated (the frontend history carries
+        ``tool_result`` entries that build_messages already filters out); only
+        string content is length-checked.
+        """
+        if history is None:
+            return None
+        if len(history) > MAX_HISTORY_MESSAGES:
+            raise ValueError(f"chat_history exceeds {MAX_HISTORY_MESSAGES} messages")
+        for msg in history:
+            role = msg.get("role")
+            if role is not None and role not in _ALLOWED_ROLES:
+                raise ValueError(f"invalid chat_history role: {role!r}")
+            content = msg.get("content")
+            if isinstance(content, str) and len(content) > MAX_MESSAGE_CHARS:
+                raise ValueError(f"a chat_history message exceeds {MAX_MESSAGE_CHARS} chars")
+        return history
+
+    @field_validator("context")
+    @classmethod
+    def _prune_context(cls, context: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Keep only the four keys build_messages reads, with light bounds.
+
+        Dropping unknown keys stops arbitrary client-supplied fields from riding
+        into the prompt; the kept values are size-bounded so a huge GP name or
+        driver list cannot bloat the system prompt.
+        """
+        if context is None:
+            return None
+        pruned: Dict[str, Any] = {}
+        if isinstance(context.get("year"), int) and 2018 <= context["year"] <= 2030:
+            pruned["year"] = context["year"]
+        for key in ("grand_prix", "session"):
+            value = context.get(key)
+            if isinstance(value, str) and value:
+                pruned[key] = value[:64]
+        drivers = context.get("drivers")
+        if isinstance(drivers, list):
+            pruned["drivers"] = [str(d)[:16] for d in drivers[:30]]
+        return pruned or None
 
 
 class ChatResponse(BaseModel):

--- a/backend/models/voice_models.py
+++ b/backend/models/voice_models.py
@@ -29,7 +29,7 @@ class TranscriptionResponse(BaseModel):
 class TTSRequest(BaseModel):
     """Request model for text-to-speech synthesis."""
 
-    text: str = Field(..., description="Text to synthesize", min_length=1)
+    text: str = Field(..., description="Text to synthesize", min_length=1, max_length=2_000)
     rate: Optional[int] = Field(
         175,
         description="Speech rate in words per minute",

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,67 @@
+"""Hermetic tests for the Security Phase C hardening (#226).
+
+Covers the token-bucket rate limiter and the chat/voice request-validation
+bounds. No provider, no models - all pure Pydantic + stdlib, so these run in
+the deps-lite CI job.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.rate_limit import TokenBucket
+from backend.models.chat_models import (
+    MAX_HISTORY_MESSAGES,
+    MAX_TEXT_CHARS,
+    ChatRequest,
+)
+from backend.models.voice_models import TTSRequest
+
+
+def test_token_bucket_allows_burst_then_blocks():
+    """A bucket of capacity N admits N immediate requests, then denies the next."""
+    bucket = TokenBucket(capacity=2, refill_per_minute=60)
+    assert bucket.try_acquire("ip-a")[0] is True
+    assert bucket.try_acquire("ip-a")[0] is True
+    allowed, retry_after = bucket.try_acquire("ip-a")
+    assert allowed is False
+    assert retry_after > 0  # a positive Retry-After is reported
+
+
+def test_token_bucket_is_keyed_per_client():
+    """One client's exhaustion does not affect another key."""
+    bucket = TokenBucket(capacity=1, refill_per_minute=1)
+    assert bucket.try_acquire("ip-a")[0] is True
+    assert bucket.try_acquire("ip-a")[0] is False
+    assert bucket.try_acquire("ip-b")[0] is True  # independent bucket state
+
+
+def test_chat_history_is_capped():
+    """chat_history over the cap is rejected before it can reach the prompt."""
+    with pytest.raises(ValueError):
+        ChatRequest(
+            text="hi",
+            chat_history=[{"role": "user", "content": "x"}] * (MAX_HISTORY_MESSAGES + 1),
+        )
+
+
+def test_chat_context_is_pruned_to_allowed_keys():
+    """Unknown context keys are dropped; only the four build_messages reads survive."""
+    request = ChatRequest(
+        text="hi",
+        context={"year": 2025, "grand_prix": "Monza", "injected": "evil", "drivers": ["NOR"]},
+    )
+    assert set(request.context) == {"year", "grand_prix", "drivers"}
+    assert "injected" not in request.context
+
+
+def test_chat_text_length_is_bounded():
+    """An oversized prompt text is rejected."""
+    with pytest.raises(ValueError):
+        ChatRequest(text="x" * (MAX_TEXT_CHARS + 1))
+
+
+def test_tts_text_is_bounded():
+    """TTS synth text is capped so a huge body cannot pin the TTS worker."""
+    with pytest.raises(ValueError):
+        TTSRequest(text="x" * 2_001)


### PR DESCRIPTION
Closes #226 (parent-repo epic #223, Security Phase C). Part of Sprint 2 hardening. Designed via a Fable design-before gate (zero new dependencies).

## What
Constrains the unauthenticated backend surface so no single client/request can exhaust the workers, and so client-supplied prompt inputs are bounded.

## How
- **Rate limiting (C2/S-7)** `backend/core/rate_limit.py`: a stdlib per-client-IP **token bucket** as a FastAPI dependency - no `slowapi`/`limits` dep for ~90 lines. Applied per-route: `/simulate` 3/min, `/recommend`/`/rag`/`/pace-range` 10/min, ML singles 60/min, chat 20/min, voice 12/min. GET selector helpers stay unmetered; an SSE stream consumes one token at admission then runs unmetered. Escape hatch `F1_RATE_LIMIT_OFF=1`.
- **CORS (C3/S-8)**: drop `allow_credentials` (verified: no client authenticates by cookie; the Streamlit frontend calls the backend server-side) and enumerate `allow_methods`/`allow_headers` instead of `*`.
- **Prompt-input validation (C3/S-8)**: bound `text`/`image` size, cap `chat_history` to 40 messages with role + per-message-size checks, and **prune `context` to the four keys `build_messages` reads** so injected keys never enter the prompt. Cap TTS text (2000) + audio upload (10 MB -> 413).

## Note
The provider **timeout (C1/S-5)** was already in `llm_service.py` (`F1_LLM_TIMEOUT`) - this PR does not touch it.

## Checks
- New hermetic `tests/test_security_hardening.py` (token bucket + validation bounds) - deps-lite, runs in CI.
- Full hermetic suite green locally (22 passed / 1 xfailed); all edited endpoint modules `py_compile` clean.