### PR TITLE
feat(security): loopback bind + /mcp kill-switch (Phase A, A1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
       # free so the integration tests run. Locally, a dev's live LM Studio on
       # :1234 makes them skip (never fail) — the documented MVP (Testing T-3,
       # AUDIT_TESTING_QA §11); an env-configurable port is a separate enabler.
+      # python-dotenv is featherweight (pure-python) and is a module-level import
+      # of backend.core.config, which the security tests import; it does not pull
+      # the heavy ML stack, so it stays in the deps-lite set.
       - name: Install test deps
-        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx
+        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx python-dotenv
       - name: Run unit tests
         run: pytest tests/ -v

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,4 +26,8 @@ COPY backend/ ./backend/
 
 EXPOSE 8000
 
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Security A1 (#224): bind to loopback by default. Expose the container
+# explicitly with F1_HOST=0.0.0.0 — which also makes F1_API_KEY mandatory
+# (the startup guard in core/auth.py refuses to boot on a non-localhost bind
+# without a key). Shell form so ${F1_HOST}/${F1_PORT} expand at runtime.
+CMD uvicorn backend.main:app --host "${F1_HOST:-127.0.0.1}" --port "${F1_PORT:-8000}" --reload

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -11,3 +11,23 @@ load_dotenv(get_repo_root() / ".env")
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env", override=True)
 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:8501")
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    """Read a boolean env var, accepting ``1/true/yes/on`` (case-insensitive)."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mcp_enabled() -> bool:
+    """Whether the external ``/mcp`` Streamable-HTTP endpoint is mounted.
+
+    Security A1 (issue #224): the FastMCP server is a fully open tool surface,
+    so it is OFF by default and only mounted when an operator opts in with
+    ``F1_MCP_ENABLED=true``. The chat pipeline calls the same tools in-process
+    regardless of this flag, so turning it off removes exposure, not features.
+    Read fresh (not cached) so a test can toggle it per case.
+    """
+    return _env_flag("F1_MCP_ENABLED", default=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,13 @@
+import logging
 from contextlib import asynccontextmanager
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
-from backend.core.config import FRONTEND_URL
+from backend.core.config import FRONTEND_URL, mcp_enabled
 from backend.mcp_tools import mcp as mcp_server, _mount_openapi_tools
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
 
 # Build the MCP ASGI sub-app (Streamable HTTP, FastMCP 3.x)
 mcp_app = mcp_server.http_app(path="/mcp")
@@ -67,8 +70,14 @@ app.include_router(voice.router, prefix="/api/v1/voice", tags=["voice"])
 app.include_router(strategy.router, prefix="/api/v1")
 
 
-# Mount FastMCP server — MCP clients connect via Streamable HTTP at /mcp
-app.mount("/mcp", mcp_app)
+# Mount FastMCP server — MCP clients connect via Streamable HTTP at /mcp.
+# Security A1 (#224): OFF by default. This is an open tool surface, so it is
+# only exposed when an operator sets F1_MCP_ENABLED=true. The chat pipeline
+# still reaches the same tools in-process, so a disabled /mcp costs no feature.
+if mcp_enabled():
+    app.mount("/mcp", mcp_app)
+else:
+    logger.info("F1_MCP_ENABLED is off — external /mcp endpoint not mounted (chat tools still work in-process).")
 
 
 @app.get("/")

--- a/tests/test_security_bind_mcp.py
+++ b/tests/test_security_bind_mcp.py
@@ -1,0 +1,28 @@
+"""A1a — /mcp kill-switch flag parsing (issue #224).
+
+The mount decision in ``main.py`` hinges on ``config.mcp_enabled()`` reading the
+``F1_MCP_ENABLED`` env var. Default-off is the security-relevant invariant: an
+operator must opt IN to expose the external tool surface, so a missing or
+unparseable value must never enable it.
+"""
+
+from __future__ import annotations
+
+from backend.core.config import mcp_enabled
+
+
+def test_mcp_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("F1_MCP_ENABLED", raising=False)
+    assert mcp_enabled() is False
+
+
+def test_mcp_enabled_accepts_truthy_spellings(monkeypatch):
+    for value in ("true", "TRUE", "1", "yes", "on", " On "):
+        monkeypatch.setenv("F1_MCP_ENABLED", value)
+        assert mcp_enabled() is True, value
+
+
+def test_mcp_stays_off_for_falsey_or_garbage(monkeypatch):
+    for value in ("false", "0", "no", "off", "", "maybe"):
+        monkeypatch.setenv("F1_MCP_ENABLED", value)
+        assert mcp_enabled() is False, value


### PR DESCRIPTION
Part of the Security Phase A hardening (VforVitorio/F1_Strat_Manager#224, epic #223). First of four small PRs (A1a → A1b → A2 → A3). This one is shippable on its own — it removes the worst exposure (world-open → localhost-open) before any auth lands.

## What
- **Loopback bind by default.** `Dockerfile` `CMD` binds uvicorn to `${F1_HOST:-127.0.0.1}` (shell form) instead of a hardcoded `0.0.0.0`. Exposing the container is now an explicit opt-in (`F1_HOST=0.0.0.0`), and `F1_HOST` is the same var A1b's startup guard reads.
- **`/mcp` kill-switch.** New `config.mcp_enabled()` reads `F1_MCP_ENABLED` (default **OFF**); `app.mount("/mcp", mcp_app)` in `main.py` is wrapped in `if mcp_enabled()`.

## Why
`main.py` mounted the full FastMCP tool catalogue at `/mcp` with no guard, and the image bound `0.0.0.0`. On any non-localhost exposure that is an anonymous, open tool surface. The FastMCP server is only needed for *external* MCP clients (Claude Desktop, Cursor); the chat pipeline calls the same tools **in-process** via `Client(mcp)`, so gating the HTTP mount removes exposure without removing any feature.

## How
- `mcp_enabled()` is read fresh from the env (mirrors `rate_limit`'s toggle pattern) so tests can flip it per case.
- Only the `.mount()` line is gated — the `mcp_app.lifespan(...)` wrapper stays so `_mount_openapi_tools` (which the in-process chat client depends on) still initialises.

## Checks
- `tests/test_security_bind_mcp.py`: default-off, truthy spellings, garbage-stays-off.
- `py_compile` on `main.py` / `config.py`.

## Out of scope
- Auth middleware + startup guard → A1b. Tool allowlist → A2. Cost cap → A3.