### PR TITLE
feat(security): API-key auth + fail-closed startup guard (Phase A, A1b/A1c)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# ──────────────────────────────────────────────
+# F1 Telemetry Manager (backend) — Environment Variables
+# ──────────────────────────────────────────────
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+#
+# core/config.py loads the repo-root .env first, then THIS file's .env as an
+# override, so anything set here wins over the parent for the backend.
+# NEVER commit .env — it is in .gitignore.
+# ──────────────────────────────────────────────
+
+# --- Security (issue #224, Phase A) ---
+
+# Shared API key. When SET, every request needs `X-API-Key: <key>` except
+# OPTIONS, `/`, and `/health`. When UNSET the API is unauthenticated — allowed
+# only on a loopback bind (the startup guard refuses a non-loopback bind with no
+# key). Single shared secret; there are no per-user accounts.
+# F1_API_KEY=change-me
+
+# Host uvicorn binds to. Defaults to 127.0.0.1 (loopback-only). Set to 0.0.0.0
+# to expose the container — which makes F1_API_KEY mandatory (fail-closed).
+# F1_HOST=127.0.0.1
+
+# External /mcp Streamable-HTTP endpoint. OFF by default; the chat pipeline uses
+# the same tools in-process regardless. Set true only to let external MCP
+# clients (Claude Desktop, Cursor) connect — and then only behind F1_API_KEY.
+# F1_MCP_ENABLED=false
+
+# Server-side cap on completion tokens per chat turn (cost cap). A client request
+# above this is clamped down to it. Defaults to 2048.
+# F1_CHAT_MAX_TOKENS=2048
+
+# --- Frontend origin (CORS) ---
+# FRONTEND_URL=http://localhost:8501

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,0 +1,131 @@
+"""API-key authentication + fail-closed startup guard (Security A1, issue #224).
+
+A single shared secret is the whole identity model here: this is a single-user
+TFG deploy with no IdP or user store, so one static key (``F1_API_KEY``) enforced
+by one ASGI middleware is the minimal control that covers BOTH the routers and
+the ``/mcp`` sub-app from a single insertion point. A router-level ``Depends``
+cannot guard an ``app.mount()`` sub-app; middleware runs before mount dispatch,
+so it can.
+
+Safe-by-default:
+- When ``F1_API_KEY`` is unset the middleware passes every request, so local dev
+  is unchanged. The only dangerous combination — a non-loopback bind with no key
+  — is refused at startup by :func:`enforce_startup_security`, so "no key" only
+  ever means "localhost-only", never "open to the network".
+- ``OPTIONS`` (CORS preflight) and the unauthenticated paths ``/`` and
+  ``/health`` always pass.
+
+Pure ASGI on purpose (not ``BaseHTTPMiddleware``): the latter buffers the whole
+response body, which would break the SSE streams
+(``/chat/tool-message-stream``, ``/simulate``). A pass-through ASGI wrapper
+leaves streaming untouched.
+
+--- WHERE TO CHANGE IF THE AUTH CONTRACT CHANGES ---
+- Header name: ``_API_KEY_HEADER`` below.
+- Open (keyless) paths: ``OPEN_PATHS`` below.
+- The env vars (``F1_API_KEY``, ``F1_HOST``) are read via ``core.config``.
+- Registration order lives in ``main.py`` (added after CORS so auth is outermost).
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+
+from backend.core.config import api_key, bind_host
+
+logger = logging.getLogger(__name__)
+
+# ASGI lowercases HTTP header names in ``scope``; match in lowercase bytes.
+_API_KEY_HEADER = b"x-api-key"
+
+# Liveness/root paths that must answer without a key (uptime probes, a human
+# hitting ``/``). Everything else is gated once a key is configured.
+OPEN_PATHS = frozenset({"/", "/health"})
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _is_loopback(host: str) -> bool:
+    """True when *host* binds only the loopback interface.
+
+    ``0.0.0.0`` / ``::`` (all interfaces) and any concrete LAN/public address are
+    NOT loopback — those are exactly the binds that must carry a key.
+    """
+    normalized = (host or "").strip().lower()
+    return normalized in _LOOPBACK_HOSTS or normalized.startswith("127.")
+
+
+def enforce_startup_security() -> None:
+    """Fail closed when bound to a non-loopback host without an API key.
+
+    That pairing is the only one that silently exposes the whole surface to the
+    network, so we refuse to boot rather than come up open. Localhost with no key
+    stays allowed (local dev); any key with any bind is allowed.
+
+    Raises:
+        RuntimeError: on a non-loopback bind with ``F1_API_KEY`` unset.
+    """
+    if api_key():
+        return
+    host = bind_host()
+    if not _is_loopback(host):
+        raise RuntimeError(
+            f"Refusing to start: bound to non-loopback host {host!r} without "
+            f"F1_API_KEY set. Set F1_API_KEY, or bind F1_HOST to 127.0.0.1."
+        )
+    logger.warning(
+        "F1_API_KEY is not set — the API is UNAUTHENTICATED (localhost-only bind %r).",
+        host,
+    )
+
+
+class ApiKeyMiddleware:
+    """Pure-ASGI shared-secret gate. Policy lives in the module docstring."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http" or self._is_authorized(scope):
+            await self.app(scope, receive, send)
+            return
+        await self._reject(send)
+
+    def _is_authorized(self, scope) -> bool:
+        """True when the request may proceed without or with a valid key."""
+        if scope.get("method") == "OPTIONS":
+            return True
+        if scope.get("path") in OPEN_PATHS:
+            return True
+        expected = api_key()
+        if not expected:
+            # Safe-by-default: no key configured → local dev. The startup guard
+            # already refused the only unsafe bind for this state.
+            return True
+        provided = self._header(scope, _API_KEY_HEADER)
+        if provided is None:
+            return False
+        return hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+
+    @staticmethod
+    def _header(scope, name: bytes) -> str | None:
+        """Return the first value of header *name* (lowercased bytes) or None."""
+        for key, value in scope.get("headers") or []:
+            if key == name:
+                return value.decode("latin-1")
+        return None
+
+    @staticmethod
+    async def _reject(send) -> None:
+        """Emit a bare 401 JSON body without touching the downstream app."""
+        body = b'{"detail":"Missing or invalid API key."}'
+        await send({
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -21,6 +21,30 @@ def _env_flag(name: str, *, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def api_key() -> str | None:
+    """The shared API secret, or None when unset (auth then passes — see auth.py).
+
+    Read fresh so a test can set/clear it per case and so key rotation takes
+    effect without a process restart.
+    """
+    return os.getenv("F1_API_KEY") or None
+
+
+def bind_host() -> str:
+    """The host uvicorn binds to; the startup guard fails closed on non-loopback.
+
+    The Dockerfile passes ``--host $F1_HOST``, so this value mirrors the real
+    bind in the container. Defaults to loopback so a bare ``uvicorn`` run without
+    F1_HOST is treated as safe.
+
+    ponytail: this trusts F1_HOST to match the actual --host. A manual
+    ``uvicorn --host 0.0.0.0`` with F1_HOST unset would evade the guard — an
+    accepted ceiling for a single-user deploy; wire the real bound socket in if
+    a multi-host deploy ever needs it.
+    """
+    return os.getenv("F1_HOST", "127.0.0.1")
+
+
 def mcp_enabled() -> bool:
     """Whether the external ``/mcp`` Streamable-HTTP endpoint is mounted.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
 from backend.core.config import FRONTEND_URL, mcp_enabled
+from backend.core.auth import ApiKeyMiddleware, enforce_startup_security
 from backend.mcp_tools import mcp as mcp_server, _mount_openapi_tools
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
@@ -32,6 +33,9 @@ async def lifespan(app):
     The fix: run the wrapped MCP lifespan first (initialising the server),
     then mount the OpenAPI-derived tools, then yield control to uvicorn.
     """
+    # Security A1 (#224): fail closed on a non-loopback bind with no key before
+    # any heavy init runs.
+    enforce_startup_security()
     async with mcp_app.lifespan(app):
         _mount_openapi_tools(app)
         yield
@@ -50,6 +54,13 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type", "Accept", "X-Request-Id"],
 )
+
+# Security A1 (#224): the shared-secret gate. Added AFTER CORS so it wraps
+# OUTERMOST — an unauthenticated request is rejected before any other work, and
+# OPTIONS is passed through so CORS preflight still runs. One insertion point
+# covers both the routers and the /mcp mount (middleware runs before mount
+# dispatch; a router-level Depends could not reach the mounted sub-app).
+app.add_middleware(ApiKeyMiddleware)
 
 # Add telemetry router
 app.include_router(telemetry.router, prefix="/api/v1")
@@ -83,3 +94,9 @@ else:
 @app.get("/")
 def root():
     return {"message": "F1 Telemetry API is running"}
+
+
+@app.get("/health")
+def health():
+    """Unauthenticated liveness probe (open path — see core/auth.py OPEN_PATHS)."""
+    return {"status": "ok"}

--- a/tests/test_security_auth.py
+++ b/tests/test_security_auth.py
@@ -1,0 +1,115 @@
+"""A1b — API-key middleware + fail-closed startup guard (issue #224).
+
+Two hermetic layers, no real provider, no heavy imports:
+- pure functions ``_is_loopback`` / ``enforce_startup_security`` (unit);
+- the ``ApiKeyMiddleware`` driven over a bare FastAPI app via ``TestClient``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.core.auth import (
+    ApiKeyMiddleware,
+    _is_loopback,
+    enforce_startup_security,
+)
+
+PROTECTED = "/api/v1/strategy/ping"
+
+
+def _build_app() -> FastAPI:
+    """A minimal app carrying only the auth middleware + open/protected routes."""
+    app = FastAPI()
+    app.add_middleware(ApiKeyMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"ok": True}
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get(PROTECTED)
+    def protected():
+        return {"pong": True}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Startup guard — the fail-closed unit
+# ---------------------------------------------------------------------------
+
+def test_is_loopback_classifies_binds():
+    for host in ("127.0.0.1", "localhost", "::1", "127.0.1.1", " 127.0.0.1 "):
+        assert _is_loopback(host), host
+    for host in ("0.0.0.0", "192.168.1.5", "::", "", "10.0.0.2"):
+        assert not _is_loopback(host), host
+
+
+def test_guard_raises_on_public_bind_without_key(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    monkeypatch.setenv("F1_HOST", "0.0.0.0")
+    with pytest.raises(RuntimeError):
+        enforce_startup_security()
+
+
+def test_guard_allows_loopback_without_key(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    monkeypatch.setenv("F1_HOST", "127.0.0.1")
+    enforce_startup_security()  # must not raise
+
+
+def test_guard_allows_public_bind_with_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    monkeypatch.setenv("F1_HOST", "0.0.0.0")
+    enforce_startup_security()  # a key covers any bind
+
+
+# ---------------------------------------------------------------------------
+# Middleware — safe-by-default + gate when a key is set
+# ---------------------------------------------------------------------------
+
+def test_no_key_configured_passes_everything(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED).status_code == 200
+
+
+def test_key_set_blocks_protected_without_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED).status_code == 401
+
+
+def test_key_set_allows_correct_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    resp = client.get(PROTECTED, headers={"X-API-Key": "secret"})
+    assert resp.status_code == 200
+    assert resp.json() == {"pong": True}
+
+
+def test_key_set_rejects_wrong_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED, headers={"X-API-Key": "nope"}).status_code == 401
+
+
+def test_open_paths_pass_without_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get("/").status_code == 200
+    assert client.get("/health").status_code == 200
+
+
+def test_options_is_never_blocked(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    # No CORS on this bare app, so OPTIONS falls through to a 405 — the point is
+    # the middleware did NOT turn it into a 401 (preflight must reach CORS).
+    assert client.options(PROTECTED).status_code != 401


### PR DESCRIPTION
Second of the Security Phase A PRs (VforVitorio/F1_Strat_Manager#224). Builds on A1a (#70). Adds the identity boundary the backend never had.

## What
- **`core/auth.py` (new)** — a pure-ASGI `ApiKeyMiddleware` enforcing one shared secret. Per request: `OPTIONS` passes (CORS preflight); `/` and `/health` pass; if `F1_API_KEY` is unset it passes (local dev); otherwise `X-API-Key` is compared constant-time (`hmac.compare_digest`) against `F1_API_KEY`, else **401**.
- **`enforce_startup_security()`** — refuses to boot on a non-loopback bind (`F1_HOST`) with no key. Called in `main.py`'s lifespan before any heavy init.
- **`main.py`** — registers the middleware **after** CORS so auth wraps outermost (rejects before other work, passes `OPTIONS`); one insertion point covers the routers **and** the `/mcp` mount. Adds an unauthenticated `/health` route.
- **`config.api_key()` / `bind_host()`** — fresh env readers.
- **`.env.example` (A1c, submodule)** — documents `F1_API_KEY`, `F1_HOST`, `F1_MCP_ENABLED`, `F1_CHAT_MAX_TOKENS`.

## Why
`main.py` had zero identity boundary and the `/mcp` sub-app cannot be guarded by a router `Depends`. A single ASGI middleware is the minimal control covering both. Safe-by-default keeps local dev frictionless; the startup guard closes the one dangerous state (open to the network, no key) by failing closed instead of coming up open.

## Design decisions (Víctor's §8 answers)
- **Single shared key**, no per-user/OAuth (single-user localhost deploy).
- **Safe-by-default**: enforce only when the key is set, but refuse a non-localhost boot without one.
- **Header**: `X-API-Key`, constant-time compare.

## Checks (`tests/test_security_auth.py`)
- Guard: raises on public-bind + no key; allows loopback-no-key and any-bind-with-key.
- `_is_loopback` classification (127.x / localhost / ::1 vs 0.0.0.0 / LAN / ::).
- Middleware: no-key passes all; key set blocks protected without/with-wrong header (401), allows correct header (200); `/` + `/health` open; `OPTIONS` never 401.

## Out of scope
- Tool allowlist → A2. Cost cap → A3.