### PR TITLE
feat(security): default-deny tool allowlist for the chat (Phase A, A2)

### DIFF
--- a/backend/models/tool_schemas.py
+++ b/backend/models/tool_schemas.py
@@ -71,6 +71,68 @@ TOOL_DISPLAY_MAP: dict[ToolName, DisplayType] = {
 
 
 # ---------------------------------------------------------------------------
+# Tool risk tiers + chat allowlist (Security A2, issue #224)
+# ---------------------------------------------------------------------------
+
+class ToolRisk(str, Enum):
+    """Risk tier for an MCP tool, driving the chat allowlist."""
+
+    READ_SAFE = "read_safe"            # cheap, read-only, no outbound cost
+    READ_EXPENSIVE = "read_expensive"  # read-only but heavy (MC sim, RAG, outbound FastF1)
+    MUTATING = "mutating"              # writes / exports / side effects — none exist today
+
+
+# Keyed by the REAL dispatched MCP tool names, NOT the ToolName enum values,
+# which drift: ``ToolName.LIST_GPS == "list_gps"`` but the tool is
+# ``list_available_gps``; the Phase 2 tools are OpenAPI-derived and never had a
+# ToolName entry at all. These strings match what
+# ``mcp_bridge.list_openai_tools()`` returns and the chat_engine system-prompt
+# cheat sheet.
+TOOL_RISK_MAP: dict[str, ToolRisk] = {
+    # Phase 1 — cheap, read-only
+    "predict_pace": ToolRisk.READ_SAFE,
+    "predict_tire": ToolRisk.READ_SAFE,
+    "predict_situation": ToolRisk.READ_SAFE,
+    "predict_pit": ToolRisk.READ_SAFE,
+    "analyze_radio": ToolRisk.READ_SAFE,
+    "list_available_gps": ToolRisk.READ_SAFE,
+    "list_available_drivers": ToolRisk.READ_SAFE,
+    "get_lap_range": ToolRisk.READ_SAFE,
+    # Read-only but heavy: 500-sample Monte Carlo, RAG, outbound FastF1
+    "query_regulations": ToolRisk.READ_EXPENSIVE,
+    "recommend_strategy": ToolRisk.READ_EXPENSIVE,
+    "compare_drivers": ToolRisk.READ_EXPENSIVE,
+    "get_lap_times": ToolRisk.READ_EXPENSIVE,
+    "get_telemetry": ToolRisk.READ_EXPENSIVE,
+    "get_race_data": ToolRisk.READ_EXPENSIVE,
+}
+
+
+# Default-deny allowlist: only READ tools the chat may see and dispatch. A tool
+# classified MUTATING, or any name absent from TOOL_RISK_MAP (a hallucinated or
+# newly added tool), is refused until it is deliberately classified here.
+#
+# HARD RULE (Security A2): no write / export / file / mutating tool may be added
+# to the MCP server until it is classified in TOOL_RISK_MAP — and a MUTATING tool
+# never joins this set. Containment must exist BEFORE the first such tool, not
+# after.
+CHAT_ALLOWED_TOOLS: frozenset[str] = frozenset(
+    name for name, risk in TOOL_RISK_MAP.items()
+    if risk in (ToolRisk.READ_SAFE, ToolRisk.READ_EXPENSIVE)
+)
+
+
+def is_tool_allowed(name: str) -> bool:
+    """True when *name* may be exposed to and dispatched by the chat.
+
+    Single source of truth for both A2 chokepoints (the ``mcp_bridge`` filter and
+    the ``chat_engine`` dispatch guard). Default-deny: unknown names (drift,
+    hallucination) and MUTATING tools return False.
+    """
+    return name in CHAT_ALLOWED_TOOLS
+
+
+# ---------------------------------------------------------------------------
 # Tool call extraction (backend internal)
 # ---------------------------------------------------------------------------
 

--- a/backend/services/chatbot/chat_engine.py
+++ b/backend/services/chatbot/chat_engine.py
@@ -38,7 +38,7 @@ import json
 import logging
 from typing import Any, AsyncGenerator
 
-from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName
+from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName, is_tool_allowed
 from backend.services.chatbot.llm_service import build_messages, send_message
 from backend.services.chatbot.mcp_bridge import (
     call_mcp_tool,
@@ -250,6 +250,23 @@ async def _stream_plain_response(
     yield ("done", _done_metadata(raw_response))
 
 
+async def _stream_refused_tool(
+    tool_name: str,
+    request_id: str,
+) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
+    """Emit a refusal for a non-allowlisted tool — no dispatch, no LLM call.
+
+    Security A2 (#224): keeps the SSE contract (stage → token → done) intact so
+    the frontend renders the refusal like any plain reply, while guaranteeing the
+    MCP client is never touched for a disallowed name.
+    """
+    message = f"_The `{tool_name}` tool is not available in this chat._"
+    set_stage(request_id, "composing_response")
+    yield ("stage", {"stage": "composing_response"})
+    yield ("token", {"token": message})
+    yield ("done", {})
+
+
 async def _stream_tool_response(
     tool_call: dict[str, Any],
     assistant_msg: dict[str, Any],
@@ -262,6 +279,15 @@ async def _stream_tool_response(
     """Dispatch the model's tool_call, stream the tool_result + summary."""
     tool_name = tool_call["function"]["name"]
     tool_args = coerce_tool_arguments(tool_call["function"].get("arguments"))
+
+    # Security A2 (#224): default-deny. The mcp_bridge filter already hides
+    # non-allowed tools from the model, but a hallucinated or leaked name must
+    # never reach dispatch — refuse here without calling the MCP client.
+    if not is_tool_allowed(tool_name):
+        logger.warning("Refused disallowed tool call from the model: %s", tool_name)
+        async for event in _stream_refused_tool(tool_name, request_id):
+            yield event
+        return
 
     set_stage(request_id, f"calling_{tool_name}")
     yield ("stage", {"stage": f"calling_{tool_name}"})

--- a/backend/services/chatbot/mcp_bridge.py
+++ b/backend/services/chatbot/mcp_bridge.py
@@ -26,6 +26,8 @@ import json
 import logging
 from typing import Any
 
+from backend.models.tool_schemas import is_tool_allowed
+
 logger = logging.getLogger(__name__)
 
 
@@ -93,9 +95,18 @@ async def list_openai_tools() -> list[dict[str, Any]]:
     Includes both the manually decorated ``@mcp.tool`` Phase 1 strategy
     tools and the Phase 2 telemetry tools auto-generated from the
     FastAPI OpenAPI spec via ``FastMCP.from_openapi``.
+
+    Security A2 (#224): tools not on ``CHAT_ALLOWED_TOOLS`` are filtered out here
+    so the model never sees — and therefore cannot pick — a non-allowed tool.
+    This is the first of two chokepoints; the dispatch guard in ``chat_engine``
+    is the second (a hallucinated name never reaches the MCP client).
     """
     tools = await _fetch_tools()
-    return [to_openai_tool(t.name, t.description, t.inputSchema) for t in tools]
+    return [
+        to_openai_tool(t.name, t.description, t.inputSchema)
+        for t in tools
+        if is_tool_allowed(t.name)
+    ]
 
 
 async def call_mcp_tool(name: str, arguments: dict[str, Any]) -> Any:

--- a/tests/test_security_tool_allowlist.py
+++ b/tests/test_security_tool_allowlist.py
@@ -1,0 +1,133 @@
+"""A2 — default-deny tool allowlist (issue #224).
+
+Hermetic: no FakeOpenAI socket. The two chokepoints are exercised directly —
+the ``mcp_bridge`` filter (with a stubbed tool fetch) and the ``chat_engine``
+dispatch guard (with a spy over the MCP call).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.models.tool_schemas import (
+    CHAT_ALLOWED_TOOLS,
+    TOOL_RISK_MAP,
+    ToolRisk,
+    is_tool_allowed,
+)
+from backend.services.chatbot import chat_engine, mcp_bridge
+
+# The real dispatched MCP names (must match the system-prompt cheat sheet).
+_REAL_TOOL_NAMES = {
+    "predict_pace", "predict_tire", "predict_situation", "predict_pit",
+    "analyze_radio", "list_available_gps", "list_available_drivers",
+    "get_lap_range", "query_regulations", "recommend_strategy",
+    "compare_drivers", "get_lap_times", "get_telemetry", "get_race_data",
+}
+
+
+# ---------------------------------------------------------------------------
+# The allowlist itself
+# ---------------------------------------------------------------------------
+
+def test_all_real_tools_are_allowed():
+    for name in _REAL_TOOL_NAMES:
+        assert is_tool_allowed(name), name
+
+
+def test_allowlist_is_exactly_the_read_tools():
+    assert CHAT_ALLOWED_TOOLS == frozenset(_REAL_TOOL_NAMES)
+    assert not any(risk is ToolRisk.MUTATING for risk in TOOL_RISK_MAP.values())
+
+
+def test_drift_and_hallucinated_names_are_denied():
+    # The ToolName enum's "list_gps" drifts from the real "list_available_gps";
+    # keying by real names is what makes the drift name correctly denied.
+    for name in ("list_gps", "list_drivers", "delete_everything", "export_report", ""):
+        assert not is_tool_allowed(name), name
+
+
+def test_a_mutating_tool_would_not_be_allowed(monkeypatch):
+    monkeypatch.setitem(TOOL_RISK_MAP, "wipe_cache", ToolRisk.MUTATING)
+    # CHAT_ALLOWED_TOOLS is frozen at import, so a live MUTATING classification is
+    # denied by is_tool_allowed regardless — the hard rule holds by construction.
+    assert not is_tool_allowed("wipe_cache")
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 1 — mcp_bridge filter (model never sees a non-allowed tool)
+# ---------------------------------------------------------------------------
+
+async def test_list_openai_tools_filters_disallowed(monkeypatch):
+    fake_tools = [
+        SimpleNamespace(name="predict_pace", description="d", inputSchema={"type": "object"}),
+        SimpleNamespace(name="delete_everything", description="d", inputSchema={"type": "object"}),
+    ]
+
+    async def fake_fetch():
+        return fake_tools
+
+    monkeypatch.setattr(mcp_bridge, "_fetch_tools", fake_fetch)
+    tools = await mcp_bridge.list_openai_tools()
+    names = {t["function"]["name"] for t in tools}
+    assert "predict_pace" in names
+    assert "delete_everything" not in names
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 2 — chat_engine dispatch guard (hallucination never dispatched)
+# ---------------------------------------------------------------------------
+
+async def test_dispatch_guard_refuses_disallowed_tool(monkeypatch):
+    called: list[str] = []
+
+    async def spy(name, args):
+        called.append(name)
+        return {"x": 1}, None
+
+    monkeypatch.setattr(chat_engine, "_safe_call_tool", spy)
+    tool_call = {"id": "c1", "function": {"name": "delete_everything", "arguments": "{}"}}
+    events = [
+        ev
+        async for ev in chat_engine._stream_tool_response(
+            tool_call=tool_call,
+            assistant_msg={"tool_calls": [tool_call]},
+            request_id="r1",
+            base_messages=[],
+            model=None,
+            temperature=0.3,
+            max_tokens=100,
+        )
+    ]
+    assert called == []  # never dispatched
+    assert "tool_result" not in [name for name, _ in events]
+    assert "done" in [name for name, _ in events]
+
+
+async def test_dispatch_allows_allowlisted_tool(monkeypatch):
+    called: list[str] = []
+
+    async def spy_call(name, args):
+        called.append(name)
+        return {"ok": True}, None
+
+    async def spy_send(messages, **kwargs):
+        return {"choices": [{"message": {"content": "summary"}}], "model": "fake"}
+
+    monkeypatch.setattr(chat_engine, "_safe_call_tool", spy_call)
+    monkeypatch.setattr(chat_engine, "_safe_send", spy_send)
+    tool_call = {"id": "c1", "function": {"name": "predict_pace", "arguments": "{}"}}
+    events = [
+        ev
+        async for ev in chat_engine._stream_tool_response(
+            tool_call=tool_call,
+            assistant_msg={"tool_calls": [tool_call]},
+            request_id="r1",
+            base_messages=[],
+            model=None,
+            temperature=0.3,
+            max_tokens=100,
+        )
+    ]
+    assert called == ["predict_pace"]
+    assert "tool_result" in [name for name, _ in events]


### PR DESCRIPTION
Third of the Security Phase A PRs (VforVitorio/F1_Strat_Manager#224). Builds on A1a/A1b. Containment for prompt-injection → tool execution, in place **before** the first write/export tool ever exists.

## What
- **`tool_schemas.py`** — `ToolRisk` tiers (`READ_SAFE` / `READ_EXPENSIVE` / `MUTATING`), `TOOL_RISK_MAP` keyed by the **real dispatched MCP names**, `CHAT_ALLOWED_TOOLS` (READ tiers only), and `is_tool_allowed()` as the single source of truth.
- **`mcp_bridge.list_openai_tools()`** — filters non-allowed tools so the model never *sees* one.
- **`chat_engine._stream_tool_response`** — refuses a disallowed name **before** dispatch (never calls the MCP client), streaming a clean refusal that keeps the SSE contract.

## Why
`chat_engine` handed the model *every* tool and dispatched its pick blind; the only limiter was the happy accident that all 14 tools are read-only. Two chokepoints (hide + refuse) make that a deliberate, default-deny policy.

## Keyed by real names, on purpose
The `ToolName` enum drifts — `ToolName.LIST_GPS == "list_gps"` but the dispatched tool is `list_available_gps`, and the Phase 2 tools (`compare_drivers`, `get_lap_times`, `get_telemetry`, `get_race_data`) never had an enum entry. The map uses the strings `list_openai_tools()` actually returns and the system-prompt cheat sheet references.

## Hard rule
No write / export / file / mutating tool may be added to the MCP server until it is classified in `TOOL_RISK_MAP` — and a `MUTATING` tool never joins `CHAT_ALLOWED_TOOLS`.

## Checks (`tests/test_security_tool_allowlist.py`, hermetic — no FakeOpenAI)
- All 14 real tools allowed; `list_gps`/`list_drivers` drift, hallucinations, and mutating names denied.
- Filter drops a disallowed tool from `list_openai_tools()`.
- Dispatch guard refuses a disallowed name **without** calling the tool; a READ tool still dispatches.

## Out of scope
- Cost cap (max_tokens clamp + 1-tool-per-turn invariant) → A3.