### PR TITLE
feat(security): clamp chat max_tokens + pin 1-tool-per-turn (Phase A, A3)

### DIFF
--- a/backend/api/v1/endpoints/chat.py
+++ b/backend/api/v1/endpoints/chat.py
@@ -11,6 +11,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
+from backend.core.config import clamp_max_tokens
 from backend.core.rate_limit import rate_limit
 from fastapi.responses import StreamingResponse
 
@@ -94,12 +95,12 @@ async def send_chat_message(request: ChatRequest):
             context=request.context
         )
 
-        # Send to LM Studio
+        # Send to LM Studio (cost cap A3 #224: clamp the client budget server-side)
         response = lm_send_message(
             messages=messages,
             model=request.model,
             temperature=request.temperature,
-            max_tokens=request.max_tokens,
+            max_tokens=clamp_max_tokens(request.max_tokens),
             stream=False
         )
 
@@ -142,7 +143,7 @@ async def send_chat_message(request: ChatRequest):
                     messages=messages_text_only,
                     model=request.model,
                     temperature=request.temperature,
-                    max_tokens=request.max_tokens,
+                    max_tokens=clamp_max_tokens(request.max_tokens),
                     stream=False
                 )
 
@@ -195,7 +196,7 @@ async def stream_chat_message(request: ChatRequest):
                     messages=messages,
                     model=request.model,
                     temperature=request.temperature,
-                    max_tokens=request.max_tokens
+                    max_tokens=clamp_max_tokens(request.max_tokens)
                 ):
                     yield chunk
             except LLMServiceError as e:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -55,3 +55,27 @@ def mcp_enabled() -> bool:
     Read fresh (not cached) so a test can toggle it per case.
     """
     return _env_flag("F1_MCP_ENABLED", default=False)
+
+
+_DEFAULT_CHAT_MAX_TOKENS = 2048
+
+
+def chat_max_tokens() -> int:
+    """Server-side cap on completion tokens per chat turn (cost cap A3, #224).
+
+    A client's requested ``max_tokens`` is clamped down to this at every chat
+    boundary, so injected text cannot steer a huge completion. Defaults to 2048 —
+    above the internal 800/1000 defaults, so normal use is unaffected and only an
+    over-large request is capped. Read fresh so an operator can retune without a
+    restart; garbage falls back to the default.
+    """
+    try:
+        value = int(os.getenv("F1_CHAT_MAX_TOKENS", str(_DEFAULT_CHAT_MAX_TOKENS)))
+    except ValueError:
+        return _DEFAULT_CHAT_MAX_TOKENS
+    return max(1, value)
+
+
+def clamp_max_tokens(requested: int) -> int:
+    """Clamp a client-requested ``max_tokens`` down to :func:`chat_max_tokens`."""
+    return min(int(requested), chat_max_tokens())

--- a/backend/services/chatbot/chat_engine.py
+++ b/backend/services/chatbot/chat_engine.py
@@ -38,6 +38,7 @@ import json
 import logging
 from typing import Any, AsyncGenerator
 
+from backend.core.config import clamp_max_tokens
 from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName, is_tool_allowed
 from backend.services.chatbot.llm_service import build_messages, send_message
 from backend.services.chatbot.mcp_bridge import (
@@ -48,6 +49,13 @@ from backend.services.chatbot.mcp_bridge import (
 from backend.services.chatbot.stage_tracker import set_stage
 
 logger = logging.getLogger(__name__)
+
+
+# Cost cap A3 (#224): exactly one tool is dispatched per turn. This bounds the
+# per-message tool reach so injected text cannot chain N expensive tools from a
+# single message. ``_first_tool_call`` enforces it by construction — do not widen
+# it to return a list without re-checking this invariant.
+_MAX_TOOLS_PER_TURN = 1
 
 
 # Pirelli-style brevity for the chat: short, expert, bilingual.  The model
@@ -141,6 +149,11 @@ async def stream_response(
         ("token", {"token": <chunk>})          — LLM text chunk
         ("done", {...})                         — final marker + metadata
     """
+    # Cost cap A3 (#224): clamp the client-controlled budget down to the server
+    # cap before any provider call. Covers both /tool-message and
+    # /tool-message-stream (get_response funnels through here), and both LLM
+    # round-trips below reuse this clamped value.
+    max_tokens = clamp_max_tokens(max_tokens)
     set_stage(request_id, "preparing_tools")
     yield ("stage", {"stage": "preparing_tools"})
     tools = await _safe_list_tools()
@@ -418,7 +431,12 @@ def _strip_leaked_tool_call(text: str) -> str:
 
 
 def _first_tool_call(message: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the first OpenAI-style tool_call from an assistant message."""
+    """Return the first OpenAI-style tool_call from an assistant message.
+
+    Cost cap A3 (#224): this is where the ``_MAX_TOOLS_PER_TURN == 1`` invariant
+    lives — only the first proposed tool is ever dispatched, so one message can
+    reach at most one tool. Widening this to return several would defeat the cap.
+    """
     tool_calls = message.get("tool_calls") or []
     if not tool_calls:
         return None

--- a/tests/test_security_cost_cap.py
+++ b/tests/test_security_cost_cap.py
@@ -1,0 +1,72 @@
+"""A3 — server-side max_tokens clamp + 1-tool-per-turn invariant (issue #224).
+
+Hermetic: the provider call is spied, so the clamped budget is asserted on what
+the engine would send, with no real LLM and no FakeOpenAI socket.
+"""
+
+from __future__ import annotations
+
+from backend.core.config import chat_max_tokens, clamp_max_tokens
+from backend.services.chatbot import chat_engine
+
+
+# ---------------------------------------------------------------------------
+# The cap + clamp helpers
+# ---------------------------------------------------------------------------
+
+def test_chat_max_tokens_default_and_override(monkeypatch):
+    monkeypatch.delenv("F1_CHAT_MAX_TOKENS", raising=False)
+    assert chat_max_tokens() == 2048
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    assert chat_max_tokens() == 256
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "not-a-number")
+    assert chat_max_tokens() == 2048  # garbage falls back to the default
+
+
+def test_clamp_reduces_only_above_the_cap(monkeypatch):
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    assert clamp_max_tokens(1_000_000) == 256
+    assert clamp_max_tokens(8192) == 256
+    assert clamp_max_tokens(100) == 100  # already under the cap, untouched
+
+
+# ---------------------------------------------------------------------------
+# The clamp is applied at the engine boundary (what the provider receives)
+# ---------------------------------------------------------------------------
+
+async def test_stream_response_clamps_provider_budget(monkeypatch):
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    captured: dict[str, int] = {}
+
+    async def _no_tools():
+        return []
+
+    async def spy_send(messages, *, model, temperature, max_tokens, tools=None):
+        captured["max_tokens"] = max_tokens
+        return {"choices": [{"message": {"content": "hi"}}], "model": "fake"}
+
+    monkeypatch.setattr(chat_engine, "_safe_list_tools", _no_tools)
+    monkeypatch.setattr(chat_engine, "_safe_send", spy_send)
+
+    _ = [
+        ev
+        async for ev in chat_engine.stream_response(
+            text="hola", request_id="r1", max_tokens=8192
+        )
+    ]
+    assert captured["max_tokens"] == 256  # 8192 clamped to the cap
+
+
+# ---------------------------------------------------------------------------
+# 1-tool-per-turn invariant
+# ---------------------------------------------------------------------------
+
+def test_only_the_first_tool_call_is_taken():
+    assert chat_engine._MAX_TOOLS_PER_TURN == 1
+    message = {
+        "tool_calls": [
+            {"id": "a", "function": {"name": "predict_pace"}},
+            {"id": "b", "function": {"name": "predict_tire"}},
+        ]
+    }
+    assert chat_engine._first_tool_call(message)["id"] == "a"


### PR DESCRIPTION
Fourth and last Security Phase A implementation PR (VforVitorio/F1_Strat_Manager#224). Builds on A1a/A1b/A2. Bounds per-request cost; the frequency limiter and provider timeout already exist.

## What
- **`config.chat_max_tokens()`** reads `F1_CHAT_MAX_TOKENS` (default **2048**, above the internal 800/1000 defaults so normal use is unaffected); **`clamp_max_tokens()`** applies `min()`.
- **Clamp server-side** in `chat_engine.stream_response` (covers `/tool-message` + `/tool-message-stream` and both LLM round-trips) and in `chat.py` `/message` (incl. the image retry) and `/stream`.
- **Pin the 1-tool-per-turn invariant** with `_MAX_TOOLS_PER_TURN = 1` + a note on `_first_tool_call`, so a refactor cannot silently allow N-tool chaining from one injected message.

## Why
`chat.py` passed client-controlled `max_tokens` straight into the loop. Pydantic already caps it at 8192, but the operator wants a tunable, lower ceiling enforced uniformly. Combined with `core/rate_limit.py` (frequency) and the finite provider timeout (already shipped), injected text cannot pump `recommend_strategy`/`get_telemetry` beyond `rate-limit x 1 tool x clamped tokens`.

## Checks (`tests/test_security_cost_cap.py`, hermetic — provider spied)
- `chat_max_tokens()` default 2048, env override, garbage → default.
- `clamp_max_tokens()`: 1e6 / 8192 → cap; a value under the cap is untouched.
- `stream_response` sends the **clamped** budget to the (spied) provider.
- `_first_tool_call` takes only the first of several proposed calls; `_MAX_TOOLS_PER_TURN == 1`.

## Closes Phase A
After this: A1 (auth + `/mcp` + bind), A2 (allowlist), A3 (cost cap) are all in. Next: promotion to `main` + a Fable VERIFY-AFTER pass.