### PR TITLE
fix(security): gate websocket scope in the auth middleware (Phase A hardening)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,9 @@
 # --- Security (issue #224, Phase A) ---
 
 # Shared API key. When SET, every request needs `X-API-Key: <key>` except
-# OPTIONS, `/`, and `/health`. When UNSET the API is unauthenticated — allowed
-# only on a loopback bind (the startup guard refuses a non-loopback bind with no
-# key). Single shared secret; there are no per-user accounts.
+# OPTIONS, `/`, and `/health`. When UNSET (or empty) the API is unauthenticated —
+# allowed only on a loopback bind (the startup guard refuses a non-loopback bind
+# with no key). Single shared secret; there are no per-user accounts.
 # F1_API_KEY=change-me
 
 # Host uvicorn binds to. Defaults to 127.0.0.1 (loopback-only). Set to 0.0.0.0

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -87,10 +87,14 @@ class ApiKeyMiddleware:
         self.app = app
 
     async def __call__(self, scope, receive, send) -> None:
-        if scope["type"] != "http" or self._is_authorized(scope):
+        # Gate HTTP and WebSocket alike. There is no WS route today, but the
+        # architecture anticipates a live WS feed, and a passthrough here would
+        # hand a future WS endpoint an unauthenticated door. `lifespan` and other
+        # non-connection scopes are never gated.
+        if scope["type"] not in ("http", "websocket") or self._is_authorized(scope):
             await self.app(scope, receive, send)
             return
-        await self._reject(send)
+        await self._reject(scope, send)
 
     def _is_authorized(self, scope) -> bool:
         """True when the request may proceed without or with a valid key."""
@@ -117,8 +121,15 @@ class ApiKeyMiddleware:
         return None
 
     @staticmethod
-    async def _reject(send) -> None:
-        """Emit a bare 401 JSON body without touching the downstream app."""
+    async def _reject(scope, send) -> None:
+        """Refuse an unauthenticated request without touching the downstream app.
+
+        HTTP → a bare 401 JSON body; WebSocket → a policy-violation close (1008)
+        before the handshake is accepted.
+        """
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
         body = b'{"detail":"Missing or invalid API key."}'
         await send({
             "type": "http.response.start",

--- a/tests/test_security_auth.py
+++ b/tests/test_security_auth.py
@@ -113,3 +113,51 @@ def test_options_is_never_blocked(monkeypatch):
     # No CORS on this bare app, so OPTIONS falls through to a 405 — the point is
     # the middleware did NOT turn it into a 401 (preflight must reach CORS).
     assert client.options(PROTECTED).status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# WebSocket scope — gated at the ASGI layer (no live route today, but the
+# roadmap has one). Driven directly, since Starlette's TestClient WS transport
+# is unavailable in the deps-lite tier.
+# ---------------------------------------------------------------------------
+
+def _ws_scope(headers=None) -> dict:
+    return {"type": "websocket", "path": "/ws", "headers": headers or []}
+
+
+async def _run_ws(scope) -> tuple[list, list]:
+    """Drive ``ApiKeyMiddleware`` over *scope*; return (delegated_types, sent)."""
+    delegated: list = []
+    sent: list = []
+
+    async def inner(inner_scope, receive, send):
+        delegated.append(inner_scope["type"])
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    await ApiKeyMiddleware(inner)(scope, receive, send)
+    return delegated, sent
+
+
+async def test_websocket_rejected_without_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    delegated, sent = await _run_ws(_ws_scope(headers=[]))
+    assert delegated == []  # never reached the app
+    assert sent == [{"type": "websocket.close", "code": 1008}]
+
+
+async def test_websocket_allowed_with_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    delegated, sent = await _run_ws(_ws_scope(headers=[(b"x-api-key", b"secret")]))
+    assert delegated == ["websocket"]  # delegated to the app
+    assert sent == []
+
+
+async def test_websocket_passes_when_no_key_configured(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    delegated, _ = await _run_ws(_ws_scope(headers=[]))
+    assert delegated == ["websocket"]


### PR DESCRIPTION
Follow-up to the Security Phase A PRs, from the Fable verify-after pass (VforVitorio/F1_Strat_Manager#224).

## What
- `ApiKeyMiddleware` now authorizes **both** `http` and `websocket` scopes. An unauthorized WS handshake is rejected with a policy-violation close (`1008`) before `accept`; other non-connection scopes (`lifespan`) are never gated.
- `.env.example`: note that an empty `F1_API_KEY` counts as unset.

## Why
Fable's adversarial pass found the middleware short-circuited every non-HTTP scope (`scope["type"] != "http"`), so a **future** websocket route would have been unauthenticated — the module claims to cover every request, and the architecture (CLAUDE.md §6, the `lap_state` contract) anticipates a live WS feed. No WS route exists today (no live exposure), but closing the gap now avoids a silent footgun for whoever adds one.

## Checks (`tests/test_security_auth.py`)
- WS unauthorized (key set, no header) → middleware sends `websocket.close 1008`, never delegates to the app.
- WS authorized (correct header) and WS with no key configured → delegated through.
- Driven directly at the ASGI layer because Starlette's `TestClient` WS transport is unavailable in the deps-lite test tier.

Verdict from the gate before this fix: **PHASE A: SOUND (0 P0, 0 P1)** — this closes the one latent P2.