### PR TITLE
Security Phase A (#224): auth + /mcp kill-switch + tool allowlist + cost cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,9 @@
 # --- Security (issue #224, Phase A) ---
 
 # Shared API key. When SET, every request needs `X-API-Key: <key>` except
-# OPTIONS, `/`, and `/health`. When UNSET the API is unauthenticated — allowed
-# only on a loopback bind (the startup guard refuses a non-loopback bind with no
-# key). Single shared secret; there are no per-user accounts.
+# OPTIONS, `/`, and `/health`. When UNSET (or empty) the API is unauthenticated —
+# allowed only on a loopback bind (the startup guard refuses a non-loopback bind
+# with no key). Single shared secret; there are no per-user accounts.
 # F1_API_KEY=change-me
 
 # Host uvicorn binds to. Defaults to 127.0.0.1 (loopback-only). Set to 0.0.0.0

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# ──────────────────────────────────────────────
+# F1 Telemetry Manager (backend) — Environment Variables
+# ──────────────────────────────────────────────
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+#
+# core/config.py loads the repo-root .env first, then THIS file's .env as an
+# override, so anything set here wins over the parent for the backend.
+# NEVER commit .env — it is in .gitignore.
+# ──────────────────────────────────────────────
+
+# --- Security (issue #224, Phase A) ---
+
+# Shared API key. When SET, every request needs `X-API-Key: <key>` except
+# OPTIONS, `/`, and `/health`. When UNSET the API is unauthenticated — allowed
+# only on a loopback bind (the startup guard refuses a non-loopback bind with no
+# key). Single shared secret; there are no per-user accounts.
+# F1_API_KEY=change-me
+
+# Host uvicorn binds to. Defaults to 127.0.0.1 (loopback-only). Set to 0.0.0.0
+# to expose the container — which makes F1_API_KEY mandatory (fail-closed).
+# F1_HOST=127.0.0.1
+
+# External /mcp Streamable-HTTP endpoint. OFF by default; the chat pipeline uses
+# the same tools in-process regardless. Set true only to let external MCP
+# clients (Claude Desktop, Cursor) connect — and then only behind F1_API_KEY.
+# F1_MCP_ENABLED=false
+
+# Server-side cap on completion tokens per chat turn (cost cap). A client request
+# above this is clamped down to it. Defaults to 2048.
+# F1_CHAT_MAX_TOKENS=2048
+
+# --- Frontend origin (CORS) ---
+# FRONTEND_URL=http://localhost:8501

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
       # free so the integration tests run. Locally, a dev's live LM Studio on
       # :1234 makes them skip (never fail) — the documented MVP (Testing T-3,
       # AUDIT_TESTING_QA §11); an env-configurable port is a separate enabler.
+      # python-dotenv is featherweight (pure-python) and is a module-level import
+      # of backend.core.config, which the security tests import; it does not pull
+      # the heavy ML stack, so it stays in the deps-lite set.
       - name: Install test deps
-        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx
+        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx python-dotenv
       - name: Run unit tests
         run: pytest tests/ -v

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,4 +26,8 @@ COPY backend/ ./backend/
 
 EXPOSE 8000
 
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Security A1 (#224): bind to loopback by default. Expose the container
+# explicitly with F1_HOST=0.0.0.0 — which also makes F1_API_KEY mandatory
+# (the startup guard in core/auth.py refuses to boot on a non-localhost bind
+# without a key). Shell form so ${F1_HOST}/${F1_PORT} expand at runtime.
+CMD uvicorn backend.main:app --host "${F1_HOST:-127.0.0.1}" --port "${F1_PORT:-8000}" --reload

--- a/backend/api/v1/endpoints/chat.py
+++ b/backend/api/v1/endpoints/chat.py
@@ -11,6 +11,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
+from backend.core.config import clamp_max_tokens
 from backend.core.rate_limit import rate_limit
 from fastapi.responses import StreamingResponse
 
@@ -94,12 +95,12 @@ async def send_chat_message(request: ChatRequest):
             context=request.context
         )
 
-        # Send to LM Studio
+        # Send to LM Studio (cost cap A3 #224: clamp the client budget server-side)
         response = lm_send_message(
             messages=messages,
             model=request.model,
             temperature=request.temperature,
-            max_tokens=request.max_tokens,
+            max_tokens=clamp_max_tokens(request.max_tokens),
             stream=False
         )
 
@@ -142,7 +143,7 @@ async def send_chat_message(request: ChatRequest):
                     messages=messages_text_only,
                     model=request.model,
                     temperature=request.temperature,
-                    max_tokens=request.max_tokens,
+                    max_tokens=clamp_max_tokens(request.max_tokens),
                     stream=False
                 )
 
@@ -195,7 +196,7 @@ async def stream_chat_message(request: ChatRequest):
                     messages=messages,
                     model=request.model,
                     temperature=request.temperature,
-                    max_tokens=request.max_tokens
+                    max_tokens=clamp_max_tokens(request.max_tokens)
                 ):
                     yield chunk
             except LLMServiceError as e:

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -87,10 +87,14 @@ class ApiKeyMiddleware:
         self.app = app
 
     async def __call__(self, scope, receive, send) -> None:
-        if scope["type"] != "http" or self._is_authorized(scope):
+        # Gate HTTP and WebSocket alike. There is no WS route today, but the
+        # architecture anticipates a live WS feed, and a passthrough here would
+        # hand a future WS endpoint an unauthenticated door. `lifespan` and other
+        # non-connection scopes are never gated.
+        if scope["type"] not in ("http", "websocket") or self._is_authorized(scope):
             await self.app(scope, receive, send)
             return
-        await self._reject(send)
+        await self._reject(scope, send)
 
     def _is_authorized(self, scope) -> bool:
         """True when the request may proceed without or with a valid key."""
@@ -117,8 +121,15 @@ class ApiKeyMiddleware:
         return None
 
     @staticmethod
-    async def _reject(send) -> None:
-        """Emit a bare 401 JSON body without touching the downstream app."""
+    async def _reject(scope, send) -> None:
+        """Refuse an unauthenticated request without touching the downstream app.
+
+        HTTP → a bare 401 JSON body; WebSocket → a policy-violation close (1008)
+        before the handshake is accepted.
+        """
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
         body = b'{"detail":"Missing or invalid API key."}'
         await send({
             "type": "http.response.start",

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,0 +1,131 @@
+"""API-key authentication + fail-closed startup guard (Security A1, issue #224).
+
+A single shared secret is the whole identity model here: this is a single-user
+TFG deploy with no IdP or user store, so one static key (``F1_API_KEY``) enforced
+by one ASGI middleware is the minimal control that covers BOTH the routers and
+the ``/mcp`` sub-app from a single insertion point. A router-level ``Depends``
+cannot guard an ``app.mount()`` sub-app; middleware runs before mount dispatch,
+so it can.
+
+Safe-by-default:
+- When ``F1_API_KEY`` is unset the middleware passes every request, so local dev
+  is unchanged. The only dangerous combination — a non-loopback bind with no key
+  — is refused at startup by :func:`enforce_startup_security`, so "no key" only
+  ever means "localhost-only", never "open to the network".
+- ``OPTIONS`` (CORS preflight) and the unauthenticated paths ``/`` and
+  ``/health`` always pass.
+
+Pure ASGI on purpose (not ``BaseHTTPMiddleware``): the latter buffers the whole
+response body, which would break the SSE streams
+(``/chat/tool-message-stream``, ``/simulate``). A pass-through ASGI wrapper
+leaves streaming untouched.
+
+--- WHERE TO CHANGE IF THE AUTH CONTRACT CHANGES ---
+- Header name: ``_API_KEY_HEADER`` below.
+- Open (keyless) paths: ``OPEN_PATHS`` below.
+- The env vars (``F1_API_KEY``, ``F1_HOST``) are read via ``core.config``.
+- Registration order lives in ``main.py`` (added after CORS so auth is outermost).
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+
+from backend.core.config import api_key, bind_host
+
+logger = logging.getLogger(__name__)
+
+# ASGI lowercases HTTP header names in ``scope``; match in lowercase bytes.
+_API_KEY_HEADER = b"x-api-key"
+
+# Liveness/root paths that must answer without a key (uptime probes, a human
+# hitting ``/``). Everything else is gated once a key is configured.
+OPEN_PATHS = frozenset({"/", "/health"})
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _is_loopback(host: str) -> bool:
+    """True when *host* binds only the loopback interface.
+
+    ``0.0.0.0`` / ``::`` (all interfaces) and any concrete LAN/public address are
+    NOT loopback — those are exactly the binds that must carry a key.
+    """
+    normalized = (host or "").strip().lower()
+    return normalized in _LOOPBACK_HOSTS or normalized.startswith("127.")
+
+
+def enforce_startup_security() -> None:
+    """Fail closed when bound to a non-loopback host without an API key.
+
+    That pairing is the only one that silently exposes the whole surface to the
+    network, so we refuse to boot rather than come up open. Localhost with no key
+    stays allowed (local dev); any key with any bind is allowed.
+
+    Raises:
+        RuntimeError: on a non-loopback bind with ``F1_API_KEY`` unset.
+    """
+    if api_key():
+        return
+    host = bind_host()
+    if not _is_loopback(host):
+        raise RuntimeError(
+            f"Refusing to start: bound to non-loopback host {host!r} without "
+            f"F1_API_KEY set. Set F1_API_KEY, or bind F1_HOST to 127.0.0.1."
+        )
+    logger.warning(
+        "F1_API_KEY is not set — the API is UNAUTHENTICATED (localhost-only bind %r).",
+        host,
+    )
+
+
+class ApiKeyMiddleware:
+    """Pure-ASGI shared-secret gate. Policy lives in the module docstring."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http" or self._is_authorized(scope):
+            await self.app(scope, receive, send)
+            return
+        await self._reject(send)
+
+    def _is_authorized(self, scope) -> bool:
+        """True when the request may proceed without or with a valid key."""
+        if scope.get("method") == "OPTIONS":
+            return True
+        if scope.get("path") in OPEN_PATHS:
+            return True
+        expected = api_key()
+        if not expected:
+            # Safe-by-default: no key configured → local dev. The startup guard
+            # already refused the only unsafe bind for this state.
+            return True
+        provided = self._header(scope, _API_KEY_HEADER)
+        if provided is None:
+            return False
+        return hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))
+
+    @staticmethod
+    def _header(scope, name: bytes) -> str | None:
+        """Return the first value of header *name* (lowercased bytes) or None."""
+        for key, value in scope.get("headers") or []:
+            if key == name:
+                return value.decode("latin-1")
+        return None
+
+    @staticmethod
+    async def _reject(send) -> None:
+        """Emit a bare 401 JSON body without touching the downstream app."""
+        body = b'{"detail":"Missing or invalid API key."}'
+        await send({
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        })
+        await send({"type": "http.response.body", "body": body})

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -55,3 +55,27 @@ def mcp_enabled() -> bool:
     Read fresh (not cached) so a test can toggle it per case.
     """
     return _env_flag("F1_MCP_ENABLED", default=False)
+
+
+_DEFAULT_CHAT_MAX_TOKENS = 2048
+
+
+def chat_max_tokens() -> int:
+    """Server-side cap on completion tokens per chat turn (cost cap A3, #224).
+
+    A client's requested ``max_tokens`` is clamped down to this at every chat
+    boundary, so injected text cannot steer a huge completion. Defaults to 2048 —
+    above the internal 800/1000 defaults, so normal use is unaffected and only an
+    over-large request is capped. Read fresh so an operator can retune without a
+    restart; garbage falls back to the default.
+    """
+    try:
+        value = int(os.getenv("F1_CHAT_MAX_TOKENS", str(_DEFAULT_CHAT_MAX_TOKENS)))
+    except ValueError:
+        return _DEFAULT_CHAT_MAX_TOKENS
+    return max(1, value)
+
+
+def clamp_max_tokens(requested: int) -> int:
+    """Clamp a client-requested ``max_tokens`` down to :func:`chat_max_tokens`."""
+    return min(int(requested), chat_max_tokens())

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -21,6 +21,30 @@ def _env_flag(name: str, *, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def api_key() -> str | None:
+    """The shared API secret, or None when unset (auth then passes — see auth.py).
+
+    Read fresh so a test can set/clear it per case and so key rotation takes
+    effect without a process restart.
+    """
+    return os.getenv("F1_API_KEY") or None
+
+
+def bind_host() -> str:
+    """The host uvicorn binds to; the startup guard fails closed on non-loopback.
+
+    The Dockerfile passes ``--host $F1_HOST``, so this value mirrors the real
+    bind in the container. Defaults to loopback so a bare ``uvicorn`` run without
+    F1_HOST is treated as safe.
+
+    ponytail: this trusts F1_HOST to match the actual --host. A manual
+    ``uvicorn --host 0.0.0.0`` with F1_HOST unset would evade the guard — an
+    accepted ceiling for a single-user deploy; wire the real bound socket in if
+    a multi-host deploy ever needs it.
+    """
+    return os.getenv("F1_HOST", "127.0.0.1")
+
+
 def mcp_enabled() -> bool:
     """Whether the external ``/mcp`` Streamable-HTTP endpoint is mounted.
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -11,3 +11,23 @@ load_dotenv(get_repo_root() / ".env")
 load_dotenv(Path(__file__).resolve().parent.parent.parent / ".env", override=True)
 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:8501")
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    """Read a boolean env var, accepting ``1/true/yes/on`` (case-insensitive)."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mcp_enabled() -> bool:
+    """Whether the external ``/mcp`` Streamable-HTTP endpoint is mounted.
+
+    Security A1 (issue #224): the FastMCP server is a fully open tool surface,
+    so it is OFF by default and only mounted when an operator opts in with
+    ``F1_MCP_ENABLED=true``. The chat pipeline calls the same tools in-process
+    regardless of this flag, so turning it off removes exposure, not features.
+    Read fresh (not cached) so a test can toggle it per case.
+    """
+    return _env_flag("F1_MCP_ENABLED", default=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,13 @@
+import logging
 from contextlib import asynccontextmanager
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
-from backend.core.config import FRONTEND_URL
+from backend.core.config import FRONTEND_URL, mcp_enabled
 from backend.mcp_tools import mcp as mcp_server, _mount_openapi_tools
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
 
 # Build the MCP ASGI sub-app (Streamable HTTP, FastMCP 3.x)
 mcp_app = mcp_server.http_app(path="/mcp")
@@ -67,8 +70,14 @@ app.include_router(voice.router, prefix="/api/v1/voice", tags=["voice"])
 app.include_router(strategy.router, prefix="/api/v1")
 
 
-# Mount FastMCP server — MCP clients connect via Streamable HTTP at /mcp
-app.mount("/mcp", mcp_app)
+# Mount FastMCP server — MCP clients connect via Streamable HTTP at /mcp.
+# Security A1 (#224): OFF by default. This is an open tool surface, so it is
+# only exposed when an operator sets F1_MCP_ENABLED=true. The chat pipeline
+# still reaches the same tools in-process, so a disabled /mcp costs no feature.
+if mcp_enabled():
+    app.mount("/mcp", mcp_app)
+else:
+    logger.info("F1_MCP_ENABLED is off — external /mcp endpoint not mounted (chat tools still work in-process).")
 
 
 @app.get("/")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
 from backend.core.config import FRONTEND_URL, mcp_enabled
+from backend.core.auth import ApiKeyMiddleware, enforce_startup_security
 from backend.mcp_tools import mcp as mcp_server, _mount_openapi_tools
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import FastAPI
@@ -32,6 +33,9 @@ async def lifespan(app):
     The fix: run the wrapped MCP lifespan first (initialising the server),
     then mount the OpenAPI-derived tools, then yield control to uvicorn.
     """
+    # Security A1 (#224): fail closed on a non-loopback bind with no key before
+    # any heavy init runs.
+    enforce_startup_security()
     async with mcp_app.lifespan(app):
         _mount_openapi_tools(app)
         yield
@@ -50,6 +54,13 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type", "Accept", "X-Request-Id"],
 )
+
+# Security A1 (#224): the shared-secret gate. Added AFTER CORS so it wraps
+# OUTERMOST — an unauthenticated request is rejected before any other work, and
+# OPTIONS is passed through so CORS preflight still runs. One insertion point
+# covers both the routers and the /mcp mount (middleware runs before mount
+# dispatch; a router-level Depends could not reach the mounted sub-app).
+app.add_middleware(ApiKeyMiddleware)
 
 # Add telemetry router
 app.include_router(telemetry.router, prefix="/api/v1")
@@ -83,3 +94,9 @@ else:
 @app.get("/")
 def root():
     return {"message": "F1 Telemetry API is running"}
+
+
+@app.get("/health")
+def health():
+    """Unauthenticated liveness probe (open path — see core/auth.py OPEN_PATHS)."""
+    return {"status": "ok"}

--- a/backend/models/tool_schemas.py
+++ b/backend/models/tool_schemas.py
@@ -71,6 +71,68 @@ TOOL_DISPLAY_MAP: dict[ToolName, DisplayType] = {
 
 
 # ---------------------------------------------------------------------------
+# Tool risk tiers + chat allowlist (Security A2, issue #224)
+# ---------------------------------------------------------------------------
+
+class ToolRisk(str, Enum):
+    """Risk tier for an MCP tool, driving the chat allowlist."""
+
+    READ_SAFE = "read_safe"            # cheap, read-only, no outbound cost
+    READ_EXPENSIVE = "read_expensive"  # read-only but heavy (MC sim, RAG, outbound FastF1)
+    MUTATING = "mutating"              # writes / exports / side effects — none exist today
+
+
+# Keyed by the REAL dispatched MCP tool names, NOT the ToolName enum values,
+# which drift: ``ToolName.LIST_GPS == "list_gps"`` but the tool is
+# ``list_available_gps``; the Phase 2 tools are OpenAPI-derived and never had a
+# ToolName entry at all. These strings match what
+# ``mcp_bridge.list_openai_tools()`` returns and the chat_engine system-prompt
+# cheat sheet.
+TOOL_RISK_MAP: dict[str, ToolRisk] = {
+    # Phase 1 — cheap, read-only
+    "predict_pace": ToolRisk.READ_SAFE,
+    "predict_tire": ToolRisk.READ_SAFE,
+    "predict_situation": ToolRisk.READ_SAFE,
+    "predict_pit": ToolRisk.READ_SAFE,
+    "analyze_radio": ToolRisk.READ_SAFE,
+    "list_available_gps": ToolRisk.READ_SAFE,
+    "list_available_drivers": ToolRisk.READ_SAFE,
+    "get_lap_range": ToolRisk.READ_SAFE,
+    # Read-only but heavy: 500-sample Monte Carlo, RAG, outbound FastF1
+    "query_regulations": ToolRisk.READ_EXPENSIVE,
+    "recommend_strategy": ToolRisk.READ_EXPENSIVE,
+    "compare_drivers": ToolRisk.READ_EXPENSIVE,
+    "get_lap_times": ToolRisk.READ_EXPENSIVE,
+    "get_telemetry": ToolRisk.READ_EXPENSIVE,
+    "get_race_data": ToolRisk.READ_EXPENSIVE,
+}
+
+
+# Default-deny allowlist: only READ tools the chat may see and dispatch. A tool
+# classified MUTATING, or any name absent from TOOL_RISK_MAP (a hallucinated or
+# newly added tool), is refused until it is deliberately classified here.
+#
+# HARD RULE (Security A2): no write / export / file / mutating tool may be added
+# to the MCP server until it is classified in TOOL_RISK_MAP — and a MUTATING tool
+# never joins this set. Containment must exist BEFORE the first such tool, not
+# after.
+CHAT_ALLOWED_TOOLS: frozenset[str] = frozenset(
+    name for name, risk in TOOL_RISK_MAP.items()
+    if risk in (ToolRisk.READ_SAFE, ToolRisk.READ_EXPENSIVE)
+)
+
+
+def is_tool_allowed(name: str) -> bool:
+    """True when *name* may be exposed to and dispatched by the chat.
+
+    Single source of truth for both A2 chokepoints (the ``mcp_bridge`` filter and
+    the ``chat_engine`` dispatch guard). Default-deny: unknown names (drift,
+    hallucination) and MUTATING tools return False.
+    """
+    return name in CHAT_ALLOWED_TOOLS
+
+
+# ---------------------------------------------------------------------------
 # Tool call extraction (backend internal)
 # ---------------------------------------------------------------------------
 

--- a/backend/services/chatbot/chat_engine.py
+++ b/backend/services/chatbot/chat_engine.py
@@ -38,7 +38,7 @@ import json
 import logging
 from typing import Any, AsyncGenerator
 
-from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName
+from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName, is_tool_allowed
 from backend.services.chatbot.llm_service import build_messages, send_message
 from backend.services.chatbot.mcp_bridge import (
     call_mcp_tool,
@@ -250,6 +250,23 @@ async def _stream_plain_response(
     yield ("done", _done_metadata(raw_response))
 
 
+async def _stream_refused_tool(
+    tool_name: str,
+    request_id: str,
+) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
+    """Emit a refusal for a non-allowlisted tool — no dispatch, no LLM call.
+
+    Security A2 (#224): keeps the SSE contract (stage → token → done) intact so
+    the frontend renders the refusal like any plain reply, while guaranteeing the
+    MCP client is never touched for a disallowed name.
+    """
+    message = f"_The `{tool_name}` tool is not available in this chat._"
+    set_stage(request_id, "composing_response")
+    yield ("stage", {"stage": "composing_response"})
+    yield ("token", {"token": message})
+    yield ("done", {})
+
+
 async def _stream_tool_response(
     tool_call: dict[str, Any],
     assistant_msg: dict[str, Any],
@@ -262,6 +279,15 @@ async def _stream_tool_response(
     """Dispatch the model's tool_call, stream the tool_result + summary."""
     tool_name = tool_call["function"]["name"]
     tool_args = coerce_tool_arguments(tool_call["function"].get("arguments"))
+
+    # Security A2 (#224): default-deny. The mcp_bridge filter already hides
+    # non-allowed tools from the model, but a hallucinated or leaked name must
+    # never reach dispatch — refuse here without calling the MCP client.
+    if not is_tool_allowed(tool_name):
+        logger.warning("Refused disallowed tool call from the model: %s", tool_name)
+        async for event in _stream_refused_tool(tool_name, request_id):
+            yield event
+        return
 
     set_stage(request_id, f"calling_{tool_name}")
     yield ("stage", {"stage": f"calling_{tool_name}"})

--- a/backend/services/chatbot/chat_engine.py
+++ b/backend/services/chatbot/chat_engine.py
@@ -38,6 +38,7 @@ import json
 import logging
 from typing import Any, AsyncGenerator
 
+from backend.core.config import clamp_max_tokens
 from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName, is_tool_allowed
 from backend.services.chatbot.llm_service import build_messages, send_message
 from backend.services.chatbot.mcp_bridge import (
@@ -48,6 +49,13 @@ from backend.services.chatbot.mcp_bridge import (
 from backend.services.chatbot.stage_tracker import set_stage
 
 logger = logging.getLogger(__name__)
+
+
+# Cost cap A3 (#224): exactly one tool is dispatched per turn. This bounds the
+# per-message tool reach so injected text cannot chain N expensive tools from a
+# single message. ``_first_tool_call`` enforces it by construction — do not widen
+# it to return a list without re-checking this invariant.
+_MAX_TOOLS_PER_TURN = 1
 
 
 # Pirelli-style brevity for the chat: short, expert, bilingual.  The model
@@ -141,6 +149,11 @@ async def stream_response(
         ("token", {"token": <chunk>})          — LLM text chunk
         ("done", {...})                         — final marker + metadata
     """
+    # Cost cap A3 (#224): clamp the client-controlled budget down to the server
+    # cap before any provider call. Covers both /tool-message and
+    # /tool-message-stream (get_response funnels through here), and both LLM
+    # round-trips below reuse this clamped value.
+    max_tokens = clamp_max_tokens(max_tokens)
     set_stage(request_id, "preparing_tools")
     yield ("stage", {"stage": "preparing_tools"})
     tools = await _safe_list_tools()
@@ -418,7 +431,12 @@ def _strip_leaked_tool_call(text: str) -> str:
 
 
 def _first_tool_call(message: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the first OpenAI-style tool_call from an assistant message."""
+    """Return the first OpenAI-style tool_call from an assistant message.
+
+    Cost cap A3 (#224): this is where the ``_MAX_TOOLS_PER_TURN == 1`` invariant
+    lives — only the first proposed tool is ever dispatched, so one message can
+    reach at most one tool. Widening this to return several would defeat the cap.
+    """
     tool_calls = message.get("tool_calls") or []
     if not tool_calls:
         return None

--- a/backend/services/chatbot/mcp_bridge.py
+++ b/backend/services/chatbot/mcp_bridge.py
@@ -26,6 +26,8 @@ import json
 import logging
 from typing import Any
 
+from backend.models.tool_schemas import is_tool_allowed
+
 logger = logging.getLogger(__name__)
 
 
@@ -93,9 +95,18 @@ async def list_openai_tools() -> list[dict[str, Any]]:
     Includes both the manually decorated ``@mcp.tool`` Phase 1 strategy
     tools and the Phase 2 telemetry tools auto-generated from the
     FastAPI OpenAPI spec via ``FastMCP.from_openapi``.
+
+    Security A2 (#224): tools not on ``CHAT_ALLOWED_TOOLS`` are filtered out here
+    so the model never sees — and therefore cannot pick — a non-allowed tool.
+    This is the first of two chokepoints; the dispatch guard in ``chat_engine``
+    is the second (a hallucinated name never reaches the MCP client).
     """
     tools = await _fetch_tools()
-    return [to_openai_tool(t.name, t.description, t.inputSchema) for t in tools]
+    return [
+        to_openai_tool(t.name, t.description, t.inputSchema)
+        for t in tools
+        if is_tool_allowed(t.name)
+    ]
 
 
 async def call_mcp_tool(name: str, arguments: dict[str, Any]) -> Any:

--- a/tests/test_security_auth.py
+++ b/tests/test_security_auth.py
@@ -1,0 +1,115 @@
+"""A1b — API-key middleware + fail-closed startup guard (issue #224).
+
+Two hermetic layers, no real provider, no heavy imports:
+- pure functions ``_is_loopback`` / ``enforce_startup_security`` (unit);
+- the ``ApiKeyMiddleware`` driven over a bare FastAPI app via ``TestClient``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.core.auth import (
+    ApiKeyMiddleware,
+    _is_loopback,
+    enforce_startup_security,
+)
+
+PROTECTED = "/api/v1/strategy/ping"
+
+
+def _build_app() -> FastAPI:
+    """A minimal app carrying only the auth middleware + open/protected routes."""
+    app = FastAPI()
+    app.add_middleware(ApiKeyMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"ok": True}
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get(PROTECTED)
+    def protected():
+        return {"pong": True}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Startup guard — the fail-closed unit
+# ---------------------------------------------------------------------------
+
+def test_is_loopback_classifies_binds():
+    for host in ("127.0.0.1", "localhost", "::1", "127.0.1.1", " 127.0.0.1 "):
+        assert _is_loopback(host), host
+    for host in ("0.0.0.0", "192.168.1.5", "::", "", "10.0.0.2"):
+        assert not _is_loopback(host), host
+
+
+def test_guard_raises_on_public_bind_without_key(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    monkeypatch.setenv("F1_HOST", "0.0.0.0")
+    with pytest.raises(RuntimeError):
+        enforce_startup_security()
+
+
+def test_guard_allows_loopback_without_key(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    monkeypatch.setenv("F1_HOST", "127.0.0.1")
+    enforce_startup_security()  # must not raise
+
+
+def test_guard_allows_public_bind_with_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    monkeypatch.setenv("F1_HOST", "0.0.0.0")
+    enforce_startup_security()  # a key covers any bind
+
+
+# ---------------------------------------------------------------------------
+# Middleware — safe-by-default + gate when a key is set
+# ---------------------------------------------------------------------------
+
+def test_no_key_configured_passes_everything(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED).status_code == 200
+
+
+def test_key_set_blocks_protected_without_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED).status_code == 401
+
+
+def test_key_set_allows_correct_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    resp = client.get(PROTECTED, headers={"X-API-Key": "secret"})
+    assert resp.status_code == 200
+    assert resp.json() == {"pong": True}
+
+
+def test_key_set_rejects_wrong_header(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get(PROTECTED, headers={"X-API-Key": "nope"}).status_code == 401
+
+
+def test_open_paths_pass_without_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    assert client.get("/").status_code == 200
+    assert client.get("/health").status_code == 200
+
+
+def test_options_is_never_blocked(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    client = TestClient(_build_app())
+    # No CORS on this bare app, so OPTIONS falls through to a 405 — the point is
+    # the middleware did NOT turn it into a 401 (preflight must reach CORS).
+    assert client.options(PROTECTED).status_code != 401

--- a/tests/test_security_auth.py
+++ b/tests/test_security_auth.py
@@ -113,3 +113,51 @@ def test_options_is_never_blocked(monkeypatch):
     # No CORS on this bare app, so OPTIONS falls through to a 405 — the point is
     # the middleware did NOT turn it into a 401 (preflight must reach CORS).
     assert client.options(PROTECTED).status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# WebSocket scope — gated at the ASGI layer (no live route today, but the
+# roadmap has one). Driven directly, since Starlette's TestClient WS transport
+# is unavailable in the deps-lite tier.
+# ---------------------------------------------------------------------------
+
+def _ws_scope(headers=None) -> dict:
+    return {"type": "websocket", "path": "/ws", "headers": headers or []}
+
+
+async def _run_ws(scope) -> tuple[list, list]:
+    """Drive ``ApiKeyMiddleware`` over *scope*; return (delegated_types, sent)."""
+    delegated: list = []
+    sent: list = []
+
+    async def inner(inner_scope, receive, send):
+        delegated.append(inner_scope["type"])
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    await ApiKeyMiddleware(inner)(scope, receive, send)
+    return delegated, sent
+
+
+async def test_websocket_rejected_without_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    delegated, sent = await _run_ws(_ws_scope(headers=[]))
+    assert delegated == []  # never reached the app
+    assert sent == [{"type": "websocket.close", "code": 1008}]
+
+
+async def test_websocket_allowed_with_key(monkeypatch):
+    monkeypatch.setenv("F1_API_KEY", "secret")
+    delegated, sent = await _run_ws(_ws_scope(headers=[(b"x-api-key", b"secret")]))
+    assert delegated == ["websocket"]  # delegated to the app
+    assert sent == []
+
+
+async def test_websocket_passes_when_no_key_configured(monkeypatch):
+    monkeypatch.delenv("F1_API_KEY", raising=False)
+    delegated, _ = await _run_ws(_ws_scope(headers=[]))
+    assert delegated == ["websocket"]

--- a/tests/test_security_bind_mcp.py
+++ b/tests/test_security_bind_mcp.py
@@ -1,0 +1,28 @@
+"""A1a — /mcp kill-switch flag parsing (issue #224).
+
+The mount decision in ``main.py`` hinges on ``config.mcp_enabled()`` reading the
+``F1_MCP_ENABLED`` env var. Default-off is the security-relevant invariant: an
+operator must opt IN to expose the external tool surface, so a missing or
+unparseable value must never enable it.
+"""
+
+from __future__ import annotations
+
+from backend.core.config import mcp_enabled
+
+
+def test_mcp_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("F1_MCP_ENABLED", raising=False)
+    assert mcp_enabled() is False
+
+
+def test_mcp_enabled_accepts_truthy_spellings(monkeypatch):
+    for value in ("true", "TRUE", "1", "yes", "on", " On "):
+        monkeypatch.setenv("F1_MCP_ENABLED", value)
+        assert mcp_enabled() is True, value
+
+
+def test_mcp_stays_off_for_falsey_or_garbage(monkeypatch):
+    for value in ("false", "0", "no", "off", "", "maybe"):
+        monkeypatch.setenv("F1_MCP_ENABLED", value)
+        assert mcp_enabled() is False, value

--- a/tests/test_security_cost_cap.py
+++ b/tests/test_security_cost_cap.py
@@ -1,0 +1,72 @@
+"""A3 — server-side max_tokens clamp + 1-tool-per-turn invariant (issue #224).
+
+Hermetic: the provider call is spied, so the clamped budget is asserted on what
+the engine would send, with no real LLM and no FakeOpenAI socket.
+"""
+
+from __future__ import annotations
+
+from backend.core.config import chat_max_tokens, clamp_max_tokens
+from backend.services.chatbot import chat_engine
+
+
+# ---------------------------------------------------------------------------
+# The cap + clamp helpers
+# ---------------------------------------------------------------------------
+
+def test_chat_max_tokens_default_and_override(monkeypatch):
+    monkeypatch.delenv("F1_CHAT_MAX_TOKENS", raising=False)
+    assert chat_max_tokens() == 2048
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    assert chat_max_tokens() == 256
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "not-a-number")
+    assert chat_max_tokens() == 2048  # garbage falls back to the default
+
+
+def test_clamp_reduces_only_above_the_cap(monkeypatch):
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    assert clamp_max_tokens(1_000_000) == 256
+    assert clamp_max_tokens(8192) == 256
+    assert clamp_max_tokens(100) == 100  # already under the cap, untouched
+
+
+# ---------------------------------------------------------------------------
+# The clamp is applied at the engine boundary (what the provider receives)
+# ---------------------------------------------------------------------------
+
+async def test_stream_response_clamps_provider_budget(monkeypatch):
+    monkeypatch.setenv("F1_CHAT_MAX_TOKENS", "256")
+    captured: dict[str, int] = {}
+
+    async def _no_tools():
+        return []
+
+    async def spy_send(messages, *, model, temperature, max_tokens, tools=None):
+        captured["max_tokens"] = max_tokens
+        return {"choices": [{"message": {"content": "hi"}}], "model": "fake"}
+
+    monkeypatch.setattr(chat_engine, "_safe_list_tools", _no_tools)
+    monkeypatch.setattr(chat_engine, "_safe_send", spy_send)
+
+    _ = [
+        ev
+        async for ev in chat_engine.stream_response(
+            text="hola", request_id="r1", max_tokens=8192
+        )
+    ]
+    assert captured["max_tokens"] == 256  # 8192 clamped to the cap
+
+
+# ---------------------------------------------------------------------------
+# 1-tool-per-turn invariant
+# ---------------------------------------------------------------------------
+
+def test_only_the_first_tool_call_is_taken():
+    assert chat_engine._MAX_TOOLS_PER_TURN == 1
+    message = {
+        "tool_calls": [
+            {"id": "a", "function": {"name": "predict_pace"}},
+            {"id": "b", "function": {"name": "predict_tire"}},
+        ]
+    }
+    assert chat_engine._first_tool_call(message)["id"] == "a"

--- a/tests/test_security_tool_allowlist.py
+++ b/tests/test_security_tool_allowlist.py
@@ -1,0 +1,133 @@
+"""A2 — default-deny tool allowlist (issue #224).
+
+Hermetic: no FakeOpenAI socket. The two chokepoints are exercised directly —
+the ``mcp_bridge`` filter (with a stubbed tool fetch) and the ``chat_engine``
+dispatch guard (with a spy over the MCP call).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.models.tool_schemas import (
+    CHAT_ALLOWED_TOOLS,
+    TOOL_RISK_MAP,
+    ToolRisk,
+    is_tool_allowed,
+)
+from backend.services.chatbot import chat_engine, mcp_bridge
+
+# The real dispatched MCP names (must match the system-prompt cheat sheet).
+_REAL_TOOL_NAMES = {
+    "predict_pace", "predict_tire", "predict_situation", "predict_pit",
+    "analyze_radio", "list_available_gps", "list_available_drivers",
+    "get_lap_range", "query_regulations", "recommend_strategy",
+    "compare_drivers", "get_lap_times", "get_telemetry", "get_race_data",
+}
+
+
+# ---------------------------------------------------------------------------
+# The allowlist itself
+# ---------------------------------------------------------------------------
+
+def test_all_real_tools_are_allowed():
+    for name in _REAL_TOOL_NAMES:
+        assert is_tool_allowed(name), name
+
+
+def test_allowlist_is_exactly_the_read_tools():
+    assert CHAT_ALLOWED_TOOLS == frozenset(_REAL_TOOL_NAMES)
+    assert not any(risk is ToolRisk.MUTATING for risk in TOOL_RISK_MAP.values())
+
+
+def test_drift_and_hallucinated_names_are_denied():
+    # The ToolName enum's "list_gps" drifts from the real "list_available_gps";
+    # keying by real names is what makes the drift name correctly denied.
+    for name in ("list_gps", "list_drivers", "delete_everything", "export_report", ""):
+        assert not is_tool_allowed(name), name
+
+
+def test_a_mutating_tool_would_not_be_allowed(monkeypatch):
+    monkeypatch.setitem(TOOL_RISK_MAP, "wipe_cache", ToolRisk.MUTATING)
+    # CHAT_ALLOWED_TOOLS is frozen at import, so a live MUTATING classification is
+    # denied by is_tool_allowed regardless — the hard rule holds by construction.
+    assert not is_tool_allowed("wipe_cache")
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 1 — mcp_bridge filter (model never sees a non-allowed tool)
+# ---------------------------------------------------------------------------
+
+async def test_list_openai_tools_filters_disallowed(monkeypatch):
+    fake_tools = [
+        SimpleNamespace(name="predict_pace", description="d", inputSchema={"type": "object"}),
+        SimpleNamespace(name="delete_everything", description="d", inputSchema={"type": "object"}),
+    ]
+
+    async def fake_fetch():
+        return fake_tools
+
+    monkeypatch.setattr(mcp_bridge, "_fetch_tools", fake_fetch)
+    tools = await mcp_bridge.list_openai_tools()
+    names = {t["function"]["name"] for t in tools}
+    assert "predict_pace" in names
+    assert "delete_everything" not in names
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint 2 — chat_engine dispatch guard (hallucination never dispatched)
+# ---------------------------------------------------------------------------
+
+async def test_dispatch_guard_refuses_disallowed_tool(monkeypatch):
+    called: list[str] = []
+
+    async def spy(name, args):
+        called.append(name)
+        return {"x": 1}, None
+
+    monkeypatch.setattr(chat_engine, "_safe_call_tool", spy)
+    tool_call = {"id": "c1", "function": {"name": "delete_everything", "arguments": "{}"}}
+    events = [
+        ev
+        async for ev in chat_engine._stream_tool_response(
+            tool_call=tool_call,
+            assistant_msg={"tool_calls": [tool_call]},
+            request_id="r1",
+            base_messages=[],
+            model=None,
+            temperature=0.3,
+            max_tokens=100,
+        )
+    ]
+    assert called == []  # never dispatched
+    assert "tool_result" not in [name for name, _ in events]
+    assert "done" in [name for name, _ in events]
+
+
+async def test_dispatch_allows_allowlisted_tool(monkeypatch):
+    called: list[str] = []
+
+    async def spy_call(name, args):
+        called.append(name)
+        return {"ok": True}, None
+
+    async def spy_send(messages, **kwargs):
+        return {"choices": [{"message": {"content": "summary"}}], "model": "fake"}
+
+    monkeypatch.setattr(chat_engine, "_safe_call_tool", spy_call)
+    monkeypatch.setattr(chat_engine, "_safe_send", spy_send)
+    tool_call = {"id": "c1", "function": {"name": "predict_pace", "arguments": "{}"}}
+    events = [
+        ev
+        async for ev in chat_engine._stream_tool_response(
+            tool_call=tool_call,
+            assistant_msg={"tool_calls": [tool_call]},
+            request_id="r1",
+            base_messages=[],
+            model=None,
+            temperature=0.3,
+            max_tokens=100,
+        )
+    ]
+    assert called == ["predict_pace"]
+    assert "tool_result" in [name for name, _ in events]


### PR DESCRIPTION
Promotion of Security Phase A (VforVitorio/F1_Strat_Manager#224, epic #223) from `dev` to `main`. Bundles five reviewed PRs (#70, #71, #72, #73, #74), all CI-green, plus a Fable verify-after pass (verdict **PHASE A: SOUND**, 0 P0 / 0 P1; the one latent P2 closed in #74).

## What lands
- **A1a (#70)** — loopback bind by default (`Dockerfile` `${F1_HOST:-127.0.0.1}`) + `/mcp` kill-switch (`F1_MCP_ENABLED`, default OFF).
- **A1b/A1c (#71)** — pure-ASGI `ApiKeyMiddleware` (shared `X-API-Key`, constant-time, safe-by-default) + fail-closed startup guard on non-loopback bind without a key + `/health` + submodule `.env.example`.
- **A2 (#72)** — default-deny tool allowlist keyed by the real MCP names, enforced at two chokepoints (bridge filter + dispatch guard).
- **A3 (#73)** — server-side `max_tokens` clamp (`F1_CHAT_MAX_TOKENS`) at every chat boundary + pinned 1-tool-per-turn invariant.
- **Hardening (#74)** — gate websocket scope in the middleware (from the Fable pass).

## Design decisions (Víctor's §8 answers, now resolved)
Single shared key (no per-user/OAuth) · safe-by-default enforcement + fail-closed on public bind · `/mcp` OFF by default · `X-API-Key` header.

## Verification
All hermetic security tests green in CI; Fable drove the full app end-to-end (auth 401/200, `/mcp` 404 when off, allowlist refuse-without-dispatch, clamp at all five boundaries, finite provider timeout). Never a real provider.

New env vars: `F1_API_KEY`, `F1_HOST`, `F1_MCP_ENABLED`, `F1_CHAT_MAX_TOKENS` — all documented in the submodule `.env.example`. Backwards-compatible: no key + loopback bind = today's behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable API-key protection for HTTP and WebSocket connections.
  * Added a health-check endpoint and optional MCP endpoint.
  * Added environment-based configuration for server binding, CORS, MCP access, and chat token limits.
  * Restricted chat tool access to approved read-only operations.

* **Bug Fixes**
  * Enforced chat token limits and prevented multiple tool calls in a single turn.
  * Improved default server security by binding locally unless explicitly configured otherwise.

* **Tests**
  * Added coverage for authentication, endpoint exposure, token limits, and tool-access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->