### PR TITLE
Promote #32 (brand theme + fonts + ECharts theme) to main

### DIFF
--- a/webapp/bun.lock
+++ b/webapp/bun.lock
@@ -4,12 +4,19 @@
     "": {
       "name": "f1-webapp",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/space-grotesk": "^5.2.10",
+        "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
+        "clsx": "^2.1.1",
         "eventsource-parser": "^3.1.0",
         "openapi-fetch": "^0.17.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "tailwind-merge": "^3.6.0",
+        "tailwindcss": "^4.3.2",
         "zustand": "^5.0.14",
       },
       "devDependencies": {
@@ -69,7 +76,21 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource-variable/space-grotesk": ["@fontsource-variable/space-grotesk@5.2.10", "", {}, "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -153,6 +174,36 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.2", "@tailwindcss/oxide-darwin-arm64": "4.3.2", "@tailwindcss/oxide-darwin-x64": "4.3.2", "@tailwindcss/oxide-freebsd-x64": "4.3.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2", "@tailwindcss/oxide-linux-arm64-musl": "4.3.2", "@tailwindcss/oxide-linux-x64-gnu": "4.3.2", "@tailwindcss/oxide-linux-x64-musl": "4.3.2", "@tailwindcss/oxide-wasm32-wasi": "4.3.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2", "@tailwindcss/oxide-win32-x64-msvc": "4.3.2" } }, "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.2", "", { "os": "android", "cpu": "arm64" }, "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.2", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
+
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
@@ -229,6 +280,8 @@
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -253,6 +306,8 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
@@ -269,6 +324,8 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -280,6 +337,8 @@
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "isbot": ["isbot@5.2.0", "", {}, "sha512-gbZiGCb4B5xaoxg9mS7koAyRdvJnArk10VLSHOgz6rtBG93/pi1xOFaVvXMKZ7JXgyZ8zAbNRK5uIBdIUTFSqw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
@@ -395,6 +454,12 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
+
+    "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -448,6 +513,18 @@
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,12 +17,19 @@
     "gen:api": "openapi-typescript http://localhost:8000/openapi.json -o src/lib/api/schema.ts"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
+    "clsx": "^2.1.1",
     "eventsource-parser": "^3.1.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^4.3.2",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/webapp/scripts/shot.mjs
+++ b/webapp/scripts/shot.mjs
@@ -1,0 +1,22 @@
+/**
+ * Dev-only screenshot tool for visual verification (not part of the app build).
+ * Usage: node scripts/shot.mjs [url] [out.png]
+ * Needs Playwright + a chromium build available (global install or ms-playwright
+ * cache). Run against `vite preview` (built dist) or the dev server.
+ */
+import { chromium } from 'playwright'
+
+const url = process.argv[2] ?? 'http://localhost:4173/'
+const out = process.argv[3] ?? 'shot.png'
+
+const browser = await chromium.launch()
+const ctx = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+  deviceScaleFactor: 2,
+})
+const page = await ctx.newPage()
+await page.goto(url, { waitUntil: 'load' })
+await page.waitForTimeout(1500) // let self-hosted fonts settle
+await page.screenshot({ path: out, fullPage: true })
+await browser.close()
+console.log('shot ->', out)

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,19 +1,68 @@
+import { cn } from '@/lib/cn'
+
 /**
- * App root: foundations scaffold (migration issue #30).
- *
- * Intentionally minimal: this is the strangler-pattern entry point for the
- * React SPA that replaces the Streamlit UI (epic #25). Routing, the design
- * system and the six feature screens land in later issues (#31-#43).
+ * Theme preview (issue #32). Temporary surface that exercises the ported design
+ * system (fonts, background ramp, tyre colors, purple accent, glow, tabular
+ * figures) so the theme can be screenshot-verified. Replaced by the real Home
+ * route + app shell in #33/#42.
  */
+const RAMP = ['bg-bg-0', 'bg-bg-1', 'bg-bg-2', 'bg-bg-3', 'bg-bg-4', 'bg-bg-5']
+const TYRES: [string, string][] = [
+  ['SOFT', 'bg-tire-soft'],
+  ['MEDIUM', 'bg-tire-medium'],
+  ['HARD', 'bg-tire-hard'],
+  ['INTER', 'bg-tire-inter'],
+  ['WET', 'bg-tire-wet'],
+]
+
 export default function App() {
   return (
-    <main className="app-shell">
-      <h1>F1 StratLab</h1>
-      <p>Telemetry SPA scaffold, built with React + Vite + TypeScript.</p>
-      <p className="muted">
-        Migration epic #25, replacing the Streamlit UI. This is the foundations scaffold (issue
-        #30); the feature screens arrive in later sprints.
-      </p>
+    <main className="mx-auto flex min-h-dvh max-w-5xl flex-col gap-10 p-8 md:p-16">
+      <header className="flex flex-col gap-2">
+        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+          Migration epic #25
+        </span>
+        <h1 className="font-display text-5xl font-bold tracking-tight text-balance md:text-6xl">
+          F1 StratLab
+        </h1>
+        <p className="max-w-prose text-fg-2 text-pretty">
+          Design system online: Space Grotesk display, Inter body, JetBrains Mono for data. Brand
+          tokens mapped 1:1 to Tailwind v4.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="font-display text-lg text-fg-2">Background ramp</h2>
+        <div className="flex gap-2">
+          {RAMP.map((c) => (
+            <div key={c} className={cn('size-12 rounded-lg border border-hairline', c)} />
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="font-display text-lg text-fg-2">Tyre compounds</h2>
+        <div className="flex flex-wrap gap-3">
+          {TYRES.map(([label, bg]) => (
+            <span
+              key={label}
+              className={cn('rounded-full px-3 py-1 font-mono text-xs font-semibold text-bg-0', bg)}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex max-w-sm flex-col gap-2 rounded-2xl border border-purple-600/40 bg-bg-3 p-6 shadow-[var(--shadow-glow)]">
+        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+          Recommendation
+        </span>
+        <span className="font-display text-3xl font-bold text-balance">PIT, undercut</span>
+        <span className="font-mono text-fg-2 tabular-nums">
+          confidence 0.87 · lap 24 · gap +1.482s
+        </span>
+      </section>
     </main>
   )
 }

--- a/webapp/src/charts/echartsTheme.ts
+++ b/webapp/src/charts/echartsTheme.ts
@@ -1,0 +1,53 @@
+// ECharts theme built from the F1 StratLab brand tokens. Registered once when
+// the first chart mounts (issue #34): `echarts.registerTheme(F1_THEME, echartsTheme)`.
+// Kept as a plain object so #32 does not pull the heavy echarts dep into the
+// bundle; #34 imports echarts and this together.
+//
+// Design: transparent background (charts sit on solid --bg cards), hairline
+// grid, blue data ramp + purple accent, JetBrains Mono axis labels, tabular
+// figures. Colors are the resolved token hex (a build-time JS module cannot read
+// CSS vars); keep them in sync with styles/tokens.css.
+
+export const F1_THEME = 'f1'
+
+const FG_2 = 'rgba(255,255,255,0.72)'
+const FG_3 = 'rgba(255,255,255,0.52)'
+const LINE = 'rgba(255,255,255,0.18)'
+const HAIRLINE = 'rgba(255,255,255,0.06)'
+const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
+const DISPLAY = "'Space Grotesk Variable', system-ui, sans-serif"
+
+const axis = {
+  axisLine: { lineStyle: { color: LINE } },
+  axisTick: { lineStyle: { color: LINE } },
+  axisLabel: { color: FG_3, fontFamily: MONO },
+  splitLine: { lineStyle: { color: HAIRLINE } },
+}
+
+export const echartsTheme = {
+  // Categorical palette: blue (data) first, then purple accent, then compound-ish greens/ambers.
+  color: ['#3385ff', '#6c5ce7', '#2dd47a', '#ffbd33', '#ff5733', '#60a5fa', '#a29bfe'],
+  backgroundColor: 'transparent',
+  textStyle: { fontFamily: MONO, color: FG_2 },
+  title: { textStyle: { color: '#ffffff', fontFamily: DISPLAY, fontWeight: 600 } },
+  legend: { textStyle: { color: FG_2, fontFamily: MONO } },
+  grid: { borderColor: HAIRLINE, containLabel: true },
+  categoryAxis: axis,
+  valueAxis: axis,
+  timeAxis: axis,
+  logAxis: axis,
+  tooltip: {
+    backgroundColor: '#17192b',
+    borderColor: 'rgba(255,255,255,0.10)',
+    textStyle: { color: '#ffffff', fontFamily: MONO },
+  },
+}
+
+// F1 tyre-compound colors for series that encode compound (from tokens).
+export const tireColors: Record<string, string> = {
+  SOFT: '#ff2d3a',
+  MEDIUM: '#ffcf2d',
+  HARD: '#e6e6e6',
+  INTERMEDIATE: '#2dd47a',
+  WET: '#2d8fff',
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,43 +1,84 @@
-/*
- * Base styles only. The real design system (tokens.css mapped 1:1 to Tailwind
- * v4, self-hosted fonts, ECharts theme) lands in issue #32; do not grow this
- * file into an ad-hoc token system.
- */
-:root {
-  color-scheme: dark;
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  --bg: #08080c;
-  --fg: #f5f5f5;
-  --muted: #94a3b8;
+@import 'tailwindcss';
+@import './styles/tokens.css';
+
+/* Map brand tokens into Tailwind so utilities exist (bg-bg-2, text-fg-2,
+   border-hairline, font-display, bg-tire-soft, text-purple-300, ...).
+   @theme inline keeps utilities referencing the CSS vars, so a future light
+   theme (E1) is a var swap, not a rebuild. Spacing + radii use Tailwind
+   defaults (the token 4px scale already matches). */
+@theme inline {
+  --color-bg-0: var(--bg-0);
+  --color-bg-1: var(--bg-1);
+  --color-bg-2: var(--bg-2);
+  --color-bg-3: var(--bg-3);
+  --color-bg-4: var(--bg-4);
+  --color-bg-5: var(--bg-5);
+
+  --color-fg-1: var(--fg-1);
+  --color-fg-2: var(--fg-2);
+  --color-fg-3: var(--fg-3);
+  --color-fg-4: var(--fg-4);
+  --color-fg-inv: var(--fg-inv);
+
+  --color-purple-50: var(--purple-50);
+  --color-purple-100: var(--purple-100);
+  --color-purple-200: var(--purple-200);
+  --color-purple-300: var(--purple-300);
+  --color-purple-400: var(--purple-400);
+  --color-purple-500: var(--purple-500);
+  --color-purple-600: var(--purple-600);
+  --color-purple-700: var(--purple-700);
+  --color-purple-800: var(--purple-800);
+  --color-purple-900: var(--purple-900);
+
+  --color-accent: var(--accent-primary);
+  --color-accent-2: var(--accent-secondary);
+  --color-accent-hover: var(--accent-hover);
+
+  --color-blue-300: var(--blue-300);
+  --color-blue-400: var(--blue-400);
+  --color-blue-500: var(--blue-500);
+  --color-blue-600: var(--blue-600);
+
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-danger: var(--danger);
+  --color-info: var(--info);
+
+  --color-tire-soft: var(--tire-soft);
+  --color-tire-medium: var(--tire-medium);
+  --color-tire-hard: var(--tire-hard);
+  --color-tire-inter: var(--tire-inter);
+  --color-tire-wet: var(--tire-wet);
+
+  --color-divider: var(--divider);
+  --color-hairline: var(--hairline);
+
+  --font-display: var(--font-display);
+  --font-body: var(--font-body);
+  --font-mono: var(--font-mono);
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--fg);
-}
-
-.app-shell {
-  min-height: 100dvh;
-  display: grid;
-  place-content: center;
-  gap: 0.5rem;
-  padding: 2rem;
-  text-align: center;
-}
-
-.app-shell h1 {
-  margin: 0;
-  font-size: clamp(2rem, 6vw, 3.5rem);
-}
-
-.muted {
-  color: var(--muted);
-  max-width: 48ch;
+@layer base {
+  html {
+    color-scheme: dark;
+  }
+  body {
+    background: var(--bg-0);
+    color: var(--fg-1);
+    font-family: var(--font-body);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: 'ss01', 'cv11';
+  }
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    text-wrap: balance;
+  }
+  ::selection {
+    background: var(--purple-600);
+    color: #fff;
+  }
 }

--- a/webapp/src/lib/cn.ts
+++ b/webapp/src/lib/cn.ts
@@ -1,0 +1,8 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/** Merge Tailwind classes with conditional logic (clsx) and conflict resolution
+ *  (tailwind-merge). The single class-composition helper for all components. */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,5 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import '@fontsource-variable/space-grotesk'
+import '@fontsource-variable/inter'
+import '@fontsource-variable/jetbrains-mono'
 import './index.css'
 import { Providers } from './app/providers'
 

--- a/webapp/src/styles/tokens.css
+++ b/webapp/src/styles/tokens.css
@@ -1,0 +1,109 @@
+/* =========================================================
+   F1 StratLab design tokens, ported 1:1 from the brand system
+   (parent docs/styles/tokens.css). Source of truth for the SPA.
+   Colors + fonts are mapped into Tailwind's @theme in index.css so
+   utilities (bg-bg-2, text-fg-2, font-display) exist; gradients,
+   shadows and tracking stay here and are used via component CSS.
+
+   Dark-only at parity (migration Q6): the ramp is dark and semantic
+   (--bg-*, --fg-*), so a designed light theme is a token swap (E1),
+   not a refactor. Do NOT hardcode hex in components; use these vars.
+   ========================================================= */
+:root {
+  /* ---------- BASE BACKGROUND RAMP ---------- */
+  --bg-0: #08080c; /* page black */
+  --bg-1: #0c0d14; /* deep surface (hero) */
+  --bg-2: #111827; /* sidebar / card dark */
+  --bg-3: #17192b; /* card resting */
+  --bg-4: #1e2139; /* card hovered / elevated */
+  --bg-5: #23234a; /* sidebar-hover / input bg */
+
+  /* ---------- FOREGROUND RAMP ---------- */
+  --fg-1: #ffffff; /* primary text */
+  --fg-2: rgba(255, 255, 255, 0.72); /* secondary text */
+  --fg-3: rgba(255, 255, 255, 0.52); /* tertiary / captions */
+  --fg-4: rgba(255, 255, 255, 0.32); /* disabled / hairline labels */
+  --fg-inv: #0c0d14; /* on-primary text */
+
+  /* ---------- BRAND / PURPLE (PRIMARY) ---------- */
+  --purple-50: #f2efff;
+  --purple-100: #e0d9ff;
+  --purple-200: #c2b4ff;
+  --purple-300: #a29bfe; /* hover */
+  --purple-400: #8b7cf6;
+  --purple-500: #7f6ff0; /* secondary */
+  --purple-600: #6c5ce7; /* PRIMARY */
+  --purple-700: #5a48d4;
+  --purple-800: #4434a6;
+  --purple-900: #2a1f6b;
+
+  --accent-primary: var(--purple-600);
+  --accent-secondary: var(--purple-500);
+  --accent-hover: var(--purple-300);
+
+  /* ---------- BLUE (TELEMETRY / DATA) ---------- */
+  --blue-300: #60a5fa;
+  --blue-400: #3385ff;
+  --blue-500: #2563eb;
+  --blue-600: #1d4ed8;
+
+  /* ---------- SEMANTIC / STATUS ---------- */
+  --success: #43ff64; /* green pill */
+  --warning: #ffbd33; /* amber */
+  --danger: #ff5733; /* pit/stop red */
+  --info: #3385ff; /* info blue */
+
+  /* ---------- F1 TIRE COMPOUND ACCENTS ---------- */
+  --tire-soft: #ff2d3a; /* red */
+  --tire-medium: #ffcf2d; /* yellow */
+  --tire-hard: #e6e6e6; /* white */
+  --tire-inter: #2dd47a; /* green */
+  --tire-wet: #2d8fff; /* blue */
+
+  /* ---------- DIVIDERS / SURFACES ---------- */
+  --divider: rgba(255, 255, 255, 0.1);
+  --divider-strong: rgba(255, 255, 255, 0.18);
+  --hairline: rgba(255, 255, 255, 0.06);
+
+  /* ---------- GRADIENTS (brand; chrome/hero only, never behind data) ---------- */
+  --grad-purple: linear-gradient(135deg, #6c5ce7 0%, #a29bfe 100%);
+  --grad-purple-soft: linear-gradient(
+    135deg,
+    rgba(108, 92, 231, 0.18) 0%,
+    rgba(162, 155, 254, 0.08) 100%
+  );
+  --grad-hero: radial-gradient(
+    ellipse 120% 80% at 50% 0%,
+    rgba(108, 92, 231, 0.28) 0%,
+    rgba(108, 92, 231, 0.08) 35%,
+    transparent 70%
+  );
+  --grad-halo: radial-gradient(circle at 50% 50%, rgba(162, 155, 254, 0.35) 0%, transparent 60%);
+
+  /* ---------- SHADOWS ---------- */
+  --shadow-card: 0 2px 10px rgba(0, 0, 0, 0.25);
+  --shadow-elev: 0 12px 40px rgba(0, 0, 0, 0.45);
+  --shadow-glow: 0 0 0 1px rgba(108, 92, 231, 0.35), 0 12px 40px rgba(108, 92, 231, 0.25);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+  /* ---------- RADII (aligned to Tailwind: md 12px = rounded-xl) ---------- */
+  --radius-xs: 4px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-pill: 999px;
+
+  /* ---------- TYPOGRAPHY (self-hosted via @fontsource-variable) ---------- */
+  --font-display: 'Space Grotesk Variable', 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono:
+    'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Tracking (used sparingly, e.g. eyebrows) */
+  --tracking-tightest: -0.04em;
+  --tracking-tighter: -0.02em;
+  --tracking-tight: -0.01em;
+  --tracking-wide: 0.04em;
+  --tracking-widest: 0.18em;
+}

--- a/webapp/src/vite-env.d.ts
+++ b/webapp/src/vite-env.d.ts
@@ -9,3 +9,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+// Self-hosted fonts (@fontsource-variable/*) are CSS side-effect imports with no
+// type declarations; this lets tsc accept `import '@fontsource-variable/inter'`.
+declare module '@fontsource-variable/*'

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,13 +1,14 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'node:url'
 
 // Dev-mode mirror of the nginx reverse proxy (see webapp/nginx.conf):
 // /api/* -> FastAPI backend on :8000. The client is always same-origin,
 // so there is zero CORS in dev and in prod alike.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
Promotes issue #32 (Tailwind v4 theme from brand tokens + self-hosted fonts + ECharts theme) from dev to main (epic #25). Screenshot-verified dark; all CI green on dev. Inert beside Streamlit until cutover (#43).
