### PR TITLE
feat(webapp): dashboard telemetry screen (#34)

### DIFF
--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -2,6 +2,8 @@ import { createRootRoute, createRoute, createRouter } from '@tanstack/react-rout
 import App from '@/App'
 import { Header } from './Header'
 import { Shell } from './Shell'
+import { DashboardPage } from '@/features/dashboard/DashboardPage'
+import { validateDashboardSearch } from '@/features/dashboard/search'
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
 // content plane, see Shell.tsx); the shell's <Outlet/> renders whichever leaf
@@ -34,7 +36,8 @@ function ComingSoon({ title }: { title: string }) {
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/dashboard',
-  component: () => <ComingSoon title="Dashboard" />,
+  validateSearch: validateDashboardSearch,
+  component: DashboardPage,
 })
 
 const strategyRoute = createRoute({
@@ -55,9 +58,12 @@ const labRoute = createRoute({
   component: () => <ComingSoon title="Lab" />,
 })
 
+// Comparison shares the Dashboard's selection shape so the "Go to comparison"
+// cross-link can carry year/gp/session/drivers forward (wired up in #36).
 const comparisonRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/comparison',
+  validateSearch: validateDashboardSearch,
   component: () => <ComingSoon title="Comparison" />,
 })
 

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -114,11 +114,13 @@ export interface ComboboxProps {
   placeholder?: string
   disabled?: boolean
   className?: string
+  /** Accessible name for the trigger when the visible label lives elsewhere. */
+  ariaLabel?: string
 }
 
 /** Single-select typeahead combobox (e.g. "pick a circuit"). */
 export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, className },
+  { options, value, onChange, placeholder = 'Select...', disabled, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -136,6 +138,7 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Co
           ref={ref}
           type="button"
           disabled={disabled}
+          aria-label={ariaLabel}
           className={cn(
             'flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-hairline bg-bg-3 px-3 text-sm text-fg-1 transition-colors',
             'hover:bg-bg-4',
@@ -176,13 +179,15 @@ export interface MultiComboboxProps {
   /** Caps how many options can be selected at once (e.g. a 3-driver comparison). */
   max?: number
   className?: string
+  /** Accessible name for the trigger when the visible label lives elsewhere. */
+  ariaLabel?: string
 }
 
 /** Multi-select combobox. Selections render as removable chips in the
  *  trigger; once `max` is reached, remaining options render disabled in the
  *  list instead of silently doing nothing on select. */
 export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(function MultiCombobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, max, className },
+  { options, value, onChange, placeholder = 'Select...', disabled, max, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -220,6 +225,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
         <div
           ref={ref}
           role="combobox"
+          aria-label={ariaLabel}
           aria-expanded={!disabled && open}
           aria-haspopup="listbox"
           aria-disabled={disabled}

--- a/webapp/src/features/dashboard/DashboardPage.tsx
+++ b/webapp/src/features/dashboard/DashboardPage.tsx
@@ -1,0 +1,85 @@
+// Dashboard page (issue #34) — the telemetry pilot screen, full §6.1 parity.
+//
+// This component owns the URL (selector state) and threads it to every section:
+// it reads the validated search, exposes the component-facing array shape, and
+// applies the cascading reset (changing year clears GP/session/drivers, etc.).
+// Sections are dumb consumers of `search` — the lap chart writes loaded laps to
+// the dashboard store, the telemetry grid + circuit map read them.
+
+import { useEffect } from 'react'
+import { Link, getRouteApi } from '@tanstack/react-router'
+import { Header } from '@/app/Header'
+import { Button } from '@/components/Button'
+import { SelectorsToolbar } from './components/SelectorsToolbar'
+import { LapChartSection } from './components/LapChartSection'
+import { CircuitDominationSection } from './components/CircuitDominationSection'
+import { TelemetryGrid } from './components/TelemetryGrid'
+import { useDashboardStore } from './store'
+import { fromRaw, toRaw, type DashboardSearch } from './search'
+
+const routeApi = getRouteApi('/dashboard')
+
+export function DashboardPage() {
+  const raw = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const search = fromRaw(raw)
+  const pruneLaps = useDashboardStore((s) => s.pruneLaps)
+  const clearLaps = useDashboardStore((s) => s.clearLaps)
+
+  // A loaded lap only means something within one (year, GP, session). If any of
+  // those change — including via a Back/Forward jump or an incoming link that
+  // doesn't go through the selectors — drop every loaded lap, otherwise a stale
+  // driver→lap would be re-fetched against the NEW session's key.
+  const contextKey = `${search.year ?? ''}|${search.gp ?? ''}|${search.session ?? ''}`
+  useEffect(() => {
+    clearLaps()
+  }, [contextKey, clearLaps])
+
+  // Within the same session, removing a driver prunes just their loaded lap
+  // (the other drivers' stay).
+  const driverKey = search.drivers.join(',')
+  useEffect(() => {
+    pruneLaps(driverKey ? driverKey.split(',') : [])
+  }, [driverKey, pruneLaps])
+
+  /** Patch the URL selection, applying the cascading reset of dependent levels. */
+  const handleChange = (patch: Partial<DashboardSearch>) => {
+    // Re-picking the SAME value from a dropdown must not wipe the downstream
+    // selection (the combobox fires onChange even when the value is unchanged).
+    if ('year' in patch && patch.year === search.year) return
+    if ('gp' in patch && patch.gp === search.gp) return
+    if ('session' in patch && patch.session === search.session) return
+
+    const next: DashboardSearch = { ...search, ...patch }
+    if ('year' in patch) {
+      next.gp = undefined
+      next.session = undefined
+      next.drivers = []
+    } else if ('gp' in patch) {
+      next.session = undefined
+      next.drivers = []
+    } else if ('session' in patch) {
+      next.drivers = []
+    }
+    void navigate({ search: toRaw(next) })
+  }
+
+  return (
+    <>
+      <Header title="Dashboard">
+        <Link to="/comparison" search={toRaw(search)}>
+          <Button variant="ghost" size="sm">
+            ⚖️ Go to comparison
+          </Button>
+        </Link>
+      </Header>
+
+      <div className="flex flex-col gap-8">
+        <SelectorsToolbar value={search} onChange={handleChange} />
+        <LapChartSection search={search} />
+        <CircuitDominationSection search={search} />
+        <TelemetryGrid search={search} />
+      </div>
+    </>
+  )
+}

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -1,0 +1,256 @@
+// Shared ECharts line chart for the TELEMETRY grid (issue #34, §6.1). One
+// component (`ChannelChart`) covers 6 of the 7 channels via `ChannelConfig`
+// (channels.ts); Delta is cross-driver — it needs a reference lap to diff
+// every other driver against, not a single telemetry array — so it gets its
+// own `DeltaChart` below. Both share `SyncedLineChart`, the thin ECharts
+// wrapper that joins every telemetry chart to one crosshair group.
+//
+// Streamlit parity: frontend/components/telemetry/*.py — same x-axis
+// (distance), one line per loaded driver in the team colour, and
+// `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
+// scrubbing any one chart shows every driver's value at that distance.
+
+import { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import * as echarts from 'echarts'
+import { registerF1Theme } from '@/charts/registerEcharts'
+import { F1_THEME } from '@/charts/echartsTheme'
+import type { LapTelemetry } from '@/lib/api/telemetry'
+import { getDriverColor } from '../lib/drivers'
+import type { ChannelConfig } from './channels'
+
+// Register the token theme at module load, before any chart's init runs
+// (echarts-for-react inits with the `theme` prop in componentDidMount, which
+// fires before a parent's passive effect — see charts/Gauge.tsx).
+registerF1Theme()
+
+const CHART_HEIGHT = 320
+
+// Every telemetry ECharts instance joins this group so `echarts.connect`
+// moves every chart's crosshair together when one is scrubbed. That's a
+// meaningful sync, not just a visual one: x is distance on all 7 charts.
+const CROSSHAIR_GROUP = 'telemetry-crosshair'
+
+const AXIS_TOOLTIP: EChartsOption['tooltip'] = { trigger: 'axis', axisPointer: { type: 'line' } }
+
+/** Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
+ *  chart reuses; callers only supply the y-axis and series. The y-axis name is
+ *  anchored to the left of the axis line (`align: 'left'`) so a label like
+ *  "Throttle (%)" extends into the plot instead of half of it clipping off the
+ *  container's left edge. */
+function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): EChartsOption {
+  const yAxisStyled = {
+    // `scale: true` autoranges around the data instead of forcing a 0 baseline
+    // (Plotly's default in the Streamlit original) — RPM/Speed/Delta would
+    // otherwise waste half the plot. Channels that set explicit min/max
+    // (throttle 0-100, gear, DRS) override this, so it only affects the
+    // free-ranged ones.
+    scale: true,
+    nameLocation: 'end' as const,
+    nameGap: 12,
+    nameTextStyle: { align: 'left' as const },
+    ...(yAxis as object),
+  }
+  return {
+    tooltip: AXIS_TOOLTIP,
+    legend: { data: driversWithData, top: 0 },
+    grid: { top: 44, left: 8, right: 20, bottom: 8, containLabel: true },
+    xAxis: { type: 'value', name: 'Distance (m)', nameLocation: 'middle', nameGap: 28 },
+    yAxis: yAxisStyled,
+  }
+}
+
+/**
+ * One ECharts line series per loaded driver, coloured by team. `points`
+ * returns a driver's [distance, value] pairs — the only thing that differs
+ * between a plain channel (read one array) and Delta (diff two arrays).
+ */
+function buildDriverSeries(
+  drivers: string[],
+  year: number | undefined,
+  stepped: boolean | undefined,
+  points: (driver: string) => Array<[number, number]>,
+): LineSeriesOption[] {
+  return drivers.map((driver) => ({
+    name: driver,
+    type: 'line',
+    showSymbol: false,
+    step: stepped ? 'end' : undefined,
+    lineStyle: { width: 2, color: getDriverColor(driver, year) },
+    itemStyle: { color: getDriverColor(driver, year) },
+    data: points(driver),
+  }))
+}
+
+function buildChannelOption(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+  year: number | undefined,
+  channel: ChannelConfig,
+): EChartsOption {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const series = buildDriverSeries(loaded, year, channel.stepped, (driver) => {
+    const telemetry = byDriver[driver]
+    const values = channel.transform(telemetry)
+    return telemetry.distance.map((distance, i): [number, number] => [distance, values[i]])
+  })
+
+  return {
+    ...baseOption(loaded, {
+      type: 'value',
+      name: channel.yName,
+      min: channel.yAxis?.min,
+      max: channel.yAxis?.max,
+      interval: channel.yAxis?.interval,
+      axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
+    }),
+    series,
+  }
+}
+
+/**
+ * ECharts wrapper shared by every telemetry chart: renders the F1-themed
+ * line chart and joins the crosshair group so scrubbing one channel moves
+ * the vertical guide on all the others at the same distance.
+ */
+function SyncedLineChart({ option, ariaLabel }: { option: EChartsOption; ariaLabel: string }) {
+  return (
+    <div role="img" aria-label={ariaLabel}>
+      <ReactECharts
+        theme={F1_THEME}
+        option={option}
+        style={{ height: CHART_HEIGHT }}
+        notMerge
+        onChartReady={(instance) => {
+          instance.group = CROSSHAIR_GROUP
+          echarts.connect(CROSSHAIR_GROUP)
+        }}
+      />
+    </div>
+  )
+}
+
+export interface ChannelChartProps {
+  title: string
+  byDriver: Record<string, LapTelemetry>
+  drivers: string[]
+  year: number | undefined
+  channel: ChannelConfig
+}
+
+/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
+ *  ECharts line per loaded driver, x = distance in meters. */
+export function ChannelChart({ title, byDriver, drivers, year, channel }: ChannelChartProps) {
+  const option = useMemo(
+    () => buildChannelOption(byDriver, drivers, year, channel),
+    [byDriver, drivers, year, channel],
+  )
+  return <SyncedLineChart option={option} ariaLabel={`${title} telemetry chart`} />
+}
+
+// ---- Delta: cross-driver, needs its own data prep --------------------------
+
+const MIN_DELTA_DRIVERS = 2
+
+/**
+ * Linear interpolation of `ys` at `x`, given a monotonically increasing `xs`
+ * (mirrors `numpy.interp`, used by the Streamlit original in
+ * `delta_graph.py::_calculate_deltas` to align a driver's time series onto
+ * the reference driver's distance grid). Values outside `[xs[0], xs[last]]`
+ * clamp to the nearest endpoint instead of extrapolating.
+ */
+function interp(x: number, xs: number[], ys: number[]): number {
+  const last = xs.length - 1
+  if (x <= xs[0]) return ys[0]
+  if (x >= xs[last]) return ys[last]
+
+  let lo = 0
+  let hi = last
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1
+    if (xs[mid] <= x) lo = mid
+    else hi = mid
+  }
+  const t = (x - xs[lo]) / (xs[hi] - xs[lo])
+  return ys[lo] + t * (ys[hi] - ys[lo])
+}
+
+/**
+ * The reference lap is the loaded driver with the smallest final cumulative
+ * time — the fastest lap among those currently loaded. `delta_graph.py`
+ * picks the same reference before diffing every other driver against it.
+ */
+function findReferenceDriver(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+): string | undefined {
+  let reference: string | undefined
+  let bestFinalTime = Infinity
+  for (const driver of drivers) {
+    const telemetry = byDriver[driver]
+    const finalTime = telemetry.time[telemetry.time.length - 1]
+    if (finalTime < bestFinalTime) {
+      bestFinalTime = finalTime
+      reference = driver
+    }
+  }
+  return reference
+}
+
+function buildDeltaOption(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+  year: number | undefined,
+): EChartsOption {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const reference = findReferenceDriver(byDriver, loaded)
+  if (!reference) return baseOption([], { type: 'value', name: 'Delta (s)' })
+
+  const refTelemetry = byDriver[reference]
+  const series = buildDriverSeries(loaded, year, false, (driver) => {
+    const telemetry = byDriver[driver]
+    return telemetry.distance.map((distance, i): [number, number] => {
+      const refTime = interp(distance, refTelemetry.distance, refTelemetry.time)
+      return [distance, telemetry.time[i] - refTime]
+    })
+  })
+
+  // Dashed y=0 reference guide — the reference driver's own delta line hugs
+  // it. ECharts attaches markLine per-series (no chart-level equivalent), so
+  // it rides on the first series (mutating in place; `firstSeries` is the
+  // same object as `series[0]`).
+  const firstSeries = series[0]
+  if (firstSeries) {
+    firstSeries.markLine = {
+      symbol: 'none',
+      silent: true,
+      lineStyle: { type: 'dashed', color: 'rgba(255,255,255,0.35)' },
+      data: [{ yAxis: 0 }],
+    }
+  }
+
+  return { ...baseOption(loaded, { type: 'value', name: 'Delta (s)' }), series }
+}
+
+export interface DeltaChartProps {
+  byDriver: Record<string, LapTelemetry>
+  drivers: string[]
+  year: number | undefined
+}
+
+/**
+ * Time delta vs. the fastest loaded driver, interpolated onto their distance
+ * grid. Needs >=2 loaded drivers to have anyone to compare against —
+ * `delta_graph.py` shows an `st.info` notice in the same case.
+ */
+export function DeltaChart({ byDriver, drivers, year }: DeltaChartProps) {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
+
+  if (loaded.length < MIN_DELTA_DRIVERS) {
+    return <p className="px-2 py-12 text-center text-sm text-fg-3">Delta needs ≥2 drivers</p>
+  }
+
+  return <SyncedLineChart option={option} ariaLabel="Delta telemetry chart" />
+}

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -1,0 +1,161 @@
+// CIRCUIT DOMINATION section (issue #34 §6.1) — Streamlit parity for
+// `frontend/components/telemetry/circuit_domination.py`. The backend already
+// computes microsector dominance (track rotation/scaling + per-segment
+// fastest driver); this component only draws the returned x/y/colors as a
+// coloured polyline. Inline SVG is the simpler pick over canvas: the map is
+// a static shape that only changes when the query data changes, so there is
+// no imperative redraw loop to manage, and the browser handles resizing for
+// free via the `viewBox` + `preserveAspectRatio` contract (see circuitDraw.ts).
+import type { DashboardSearch } from '../search'
+import { useCircuitDomination } from '../queries'
+import type { CircuitDomination } from '@/lib/api/telemetry'
+import { TelemetryLoader } from './TelemetryLoader'
+import { Card } from '@/components/Card'
+import { cn } from '@/lib/cn'
+import { computeBounds, computeViewBox, buildSegments } from './circuitDraw'
+
+export interface CircuitDominationSectionProps {
+  search: DashboardSearch
+}
+
+/** Streamlit gates the map behind >=2 selected drivers (a single driver has
+ *  no "dominance" to compare). */
+const MIN_DRIVERS_FOR_MAP = 2
+
+/** Matches the Streamlit figure's `height=360` (60% of its original 600px). */
+const MAP_HEIGHT_PX = 360
+
+/** Screen-pixel stroke width. Paired with `vector-effect="non-scaling-stroke"`
+ *  on each segment so the line reads the same thickness regardless of how
+ *  large the track's coordinate range is (some circuits span thousands of
+ *  metres, others a few hundred). */
+const SEGMENT_STROKE_PX = 5
+
+const SECTION_TITLE_CLASSNAME =
+  'text-center text-lg font-display font-medium uppercase tracking-wide text-fg-2'
+
+/**
+ * CIRCUIT DOMINATION: a track outline coloured by whichever driver was
+ * fastest through each microsector. Reads the shared dashboard `search`
+ * (year/GP/session/drivers) and fetches via the frozen `useCircuitDomination`
+ * query — this component owns only presentation.
+ */
+export function CircuitDominationSection({ search }: CircuitDominationSectionProps) {
+  const hasSelection = search.year != null && !!search.gp && !!search.session
+  const hasEnoughDrivers = search.drivers.length >= MIN_DRIVERS_FOR_MAP
+  const query = useCircuitDomination(search)
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className={SECTION_TITLE_CLASSNAME}>Circuit Domination</h2>
+      <CircuitDominationBody
+        hasSelection={hasSelection}
+        hasEnoughDrivers={hasEnoughDrivers}
+        isLoading={query.isLoading}
+        data={query.data ?? null}
+      />
+    </section>
+  )
+}
+
+interface CircuitDominationBodyProps {
+  hasSelection: boolean
+  hasEnoughDrivers: boolean
+  isLoading: boolean
+  data: CircuitDomination | null
+}
+
+/** Picks which of the four states to render: no selection yet, selection but
+ *  too few drivers, still loading, or the resolved map (or a soft empty
+ *  state if the query settled with no data). */
+function CircuitDominationBody({
+  hasSelection,
+  hasEnoughDrivers,
+  isLoading,
+  data,
+}: CircuitDominationBodyProps) {
+  if (!hasSelection) {
+    return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
+  }
+  if (!hasEnoughDrivers) {
+    return (
+      <p className="py-8 text-center text-sm text-fg-3">
+        Select 2+ drivers to see circuit domination
+      </p>
+    )
+  }
+  if (isLoading) {
+    return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
+  }
+  if (!data) {
+    return (
+      <p className="py-8 text-center text-sm text-fg-3">
+        No circuit domination data available for this selection
+      </p>
+    )
+  }
+  return <CircuitMap data={data} />
+}
+
+interface CircuitMapProps {
+  data: CircuitDomination
+}
+
+/** The track SVG plus its driver legend, centered in a narrower column so it
+ *  reads as a focal shape rather than stretching full-bleed (Streamlit
+ *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
+function CircuitMap({ data }: CircuitMapProps) {
+  const bounds = computeBounds(data.x, data.y)
+  const viewBox = computeViewBox(bounds)
+  const segments = buildSegments(data.x, data.y, data.colors)
+
+  return (
+    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-3xl flex-col gap-4 p-4')}>
+      <div
+        role="img"
+        aria-label="Circuit domination map: colored by fastest driver per microsector"
+        style={{ height: MAP_HEIGHT_PX }}
+      >
+        <svg viewBox={viewBox} width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+          {segments.map((segment, index) => (
+            <line
+              key={index}
+              x1={segment.x1}
+              y1={segment.y1}
+              x2={segment.x2}
+              y2={segment.y2}
+              stroke={segment.color}
+              strokeWidth={SEGMENT_STROKE_PX}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+        </svg>
+      </div>
+      <CircuitLegend drivers={data.drivers} />
+    </Card>
+  )
+}
+
+interface CircuitLegendProps {
+  drivers: { driver: string; color: string }[]
+}
+
+/** Colour-dot legend, one swatch per driver — the SVG equivalent of the
+ *  Streamlit figure's Plotly legend (invisible line traces named per driver). */
+function CircuitLegend({ drivers }: CircuitLegendProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+      {drivers.map((entry) => (
+        <div key={entry.driver} className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="inline-block size-3 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="font-mono text-xs tracking-wide text-fg-2">{entry.driver}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -1,0 +1,86 @@
+// Tyre compound legend. Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::_render_tyre_compound_legend`.
+//
+// One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
+// each annotated with per-driver lap counts. Counts always come from the
+// FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
+// chart, not "how many laps did each driver run on this tyre".
+
+import { Pill } from '@/components/Pill'
+import type { LapTime } from '@/lib/api/telemetry'
+import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
+
+/** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
+ *  which excludes the 'unknown' compound from the legend entirely. */
+function countLapsByCompound(lapTimes: LapTime[]): Map<string, Map<string, number>> {
+  const counts = new Map<string, Map<string, number>>()
+  for (const lap of lapTimes) {
+    if (lap.compound.toLowerCase() === 'unknown') continue
+    const driverCounts = counts.get(lap.compound) ?? new Map<string, number>()
+    driverCounts.set(lap.driver, (driverCounts.get(lap.driver) ?? 0) + 1)
+    counts.set(lap.compound, driverCounts)
+  }
+  return counts
+}
+
+/** Compounds present, ordered per `COMPOUND_ORDER`; anything not in that
+ *  list (should not happen once 'unknown' is excluded) sorts last. */
+function orderedCompounds(counts: Map<string, Map<string, number>>): string[] {
+  return [...counts.keys()].sort((a, b) => {
+    const indexA = COMPOUND_ORDER.indexOf(a.toLowerCase())
+    const indexB = COMPOUND_ORDER.indexOf(b.toLowerCase())
+    return (
+      (indexA === -1 ? COMPOUND_ORDER.length : indexA) -
+      (indexB === -1 ? COMPOUND_ORDER.length : indexB)
+    )
+  })
+}
+
+/** "VER: 12 laps · LEC: 8 laps" for the drivers who ran this compound, in
+ *  selection order, singular "lap" for a count of exactly one. */
+function driverLapSummary(driverCounts: Map<string, number>, drivers: string[]): string {
+  return drivers
+    .map((driver) => ({ driver, count: driverCounts.get(driver) ?? 0 }))
+    .filter(({ count }) => count > 0)
+    .map(({ driver, count }) => `${driver}: ${count} lap${count === 1 ? '' : 's'}`)
+    .join(' · ')
+}
+
+export interface CompoundLegendProps {
+  /** FULL (unfiltered) lap times. */
+  lapTimes: LapTime[]
+  drivers: string[]
+}
+
+/** Per-compound Pill row with each driver's lap count on that tyre. Renders
+ *  nothing when no laps are loaded yet (matches the Streamlit early-return). */
+export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
+  const counts = countLapsByCompound(lapTimes)
+  const compounds = orderedCompounds(counts)
+
+  if (compounds.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="font-display text-sm uppercase tracking-wide text-fg-2">
+        🏎️ Tyre Compounds Used
+      </h3>
+      <div className="flex flex-wrap gap-4">
+        {compounds.map((compound) => {
+          const variant = compoundVariant(compound)
+          const summary = driverLapSummary(counts.get(compound) ?? new Map(), drivers)
+          return (
+            <div key={compound} className="flex flex-col items-start gap-1">
+              {variant ? (
+                <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+              ) : (
+                <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+              )}
+              {summary ? <span className="text-xs text-fg-3">{summary}</span> : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -1,0 +1,185 @@
+// Lap-time line chart (ECharts). Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::render_lap_graph`.
+//
+// One line+marker series PER DRIVER, coloured by TEAM colour (never by
+// compound — compound is tooltip-only information). Clicking a point loads
+// that lap's telemetry via `onLapClick`, which the section wires to the
+// dashboard store's `setLap` (click-to-load; this component never fetches
+// telemetry itself).
+
+import { useCallback, useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
+import { registerF1Theme } from '@/charts/registerEcharts'
+import { echartsTheme, F1_THEME } from '@/charts/echartsTheme'
+import type { LapTime } from '@/lib/api/telemetry'
+import { getDriverColor } from '../lib/drivers'
+import { compoundEmoji, compoundLabel } from '../lib/compounds'
+import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
+
+// Register the token theme at module load, before any chart's init runs
+// (mirrors charts/Gauge.tsx — echarts-for-react inits with the `theme` prop
+// in componentDidMount, which can fire before an effect-time registration).
+registerF1Theme()
+
+// Reuse the shared theme's axis-label color/font for axis NAMES ("Lap
+// Number", "Lap Time") so they read consistently with the tick labels
+// without duplicating the theme's magic color values here.
+const AXIS_NAME_STYLE = {
+  color: echartsTheme.valueAxis.axisLabel.color,
+  fontFamily: echartsTheme.valueAxis.axisLabel.fontFamily,
+}
+
+/** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
+ *  alongside so the tooltip can show tyre info without a second lookup. */
+interface LapPoint {
+  value: [number, number]
+  compound: string
+}
+
+/** A single driver's series — kept as our own shape (not `echarts`'
+ *  `LineSeriesOption`) so the extra `compound` field on each point never
+ *  gets excess-property-checked against the library's stricter data type;
+ *  it is still structurally assignable into `EChartsOption.series`. */
+interface DriverSeriesOption {
+  name: string
+  type: 'line'
+  symbolSize: number
+  lineStyle: { color: string }
+  itemStyle: { color: string }
+  data: LapPoint[]
+}
+
+/** Runtime narrowing for whatever `unknown` an ECharts callback hands back. */
+function isLapPoint(data: unknown): data is LapPoint {
+  if (!data || typeof data !== 'object') return false
+  const candidate = data as { value?: unknown; compound?: unknown }
+  return (
+    Array.isArray(candidate.value) &&
+    candidate.value.length === 2 &&
+    typeof candidate.value[0] === 'number' &&
+    typeof candidate.value[1] === 'number' &&
+    typeof candidate.compound === 'string'
+  )
+}
+
+/** Group already-filtered laps by driver code, preserving lap order. */
+function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
+  const byDriver = new Map<string, LapTime[]>()
+  for (const lap of laps) {
+    const list = byDriver.get(lap.driver) ?? []
+    list.push(lap)
+    byDriver.set(lap.driver, list)
+  }
+  return byDriver
+}
+
+/** Build one driver's line+marker series, coloured by TEAM colour. */
+function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
+  return {
+    name: driver,
+    type: 'line',
+    symbolSize: 7,
+    lineStyle: { color },
+    itemStyle: { color },
+    data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
+  }
+}
+
+/** Tooltip text: `<emoji> DRIVER — Lap N — M:SS.mmm — Compound`. */
+function formatLapTooltip(raw: unknown): string {
+  if (!raw || typeof raw !== 'object') return ''
+  const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
+  if (!isLapPoint(data)) return ''
+  const [lapNumber, lapTime] = data.value
+  return `${compoundEmoji(data.compound)} ${seriesName ?? ''} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundLabel(data.compound)}`
+}
+
+/** Build the full chart option from the per-driver series list. */
+function buildLapChartOption(seriesList: DriverSeriesOption[]): EChartsOption {
+  return {
+    tooltip: { trigger: 'item', formatter: formatLapTooltip },
+    legend: { data: seriesList.map((series) => series.name), top: 0 },
+    grid: { top: 44, left: 56, right: 24, bottom: 44, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap Number',
+      nameLocation: 'middle',
+      nameGap: 26,
+      nameTextStyle: AXIS_NAME_STYLE,
+      scale: true,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Lap Time',
+      nameLocation: 'middle',
+      nameGap: 48,
+      nameTextStyle: AXIS_NAME_STYLE,
+      axisLabel: { formatter: formatLapTimeAxis },
+      // Autorange around the lap times (~78-95 s) instead of forcing a 0:00
+      // baseline, which would squash every line into the top of the plot.
+      scale: true,
+    },
+    series: seriesList,
+  }
+}
+
+/** A driver code + lap number pulled off a click event, or null when the
+ *  click missed a data point (background/axis click). */
+interface LapClickTarget {
+  driver: string
+  lapNumber: number
+}
+
+function extractLapClick(raw: unknown): LapClickTarget | null {
+  if (!raw || typeof raw !== 'object') return null
+  const params = raw as { seriesName?: string; data?: unknown; value?: unknown }
+  const driver = params.seriesName
+  const fromData = isLapPoint(params.data) ? params.data.value[0] : undefined
+  const fromValue =
+    Array.isArray(params.value) && typeof params.value[0] === 'number' ? params.value[0] : undefined
+  const lapNumber = fromData ?? fromValue
+  if (!driver || lapNumber == null) return null
+  return { driver, lapNumber }
+}
+
+export interface LapChartProps {
+  /** Laps already passed through `applyLapFilters` (the visible set). */
+  laps: LapTime[]
+  /** Selection order — controls series/legend order (Streamlit parity). */
+  drivers: string[]
+  year: number | undefined
+  onLapClick: (driver: string, lapNumber: number) => void
+}
+
+/** Lap-time chart: one coloured-by-driver line per selected driver, with
+ *  click-to-load and a compound-aware tooltip. */
+export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
+  const option = useMemo(() => {
+    const byDriver = groupByDriver(laps)
+    const seriesList = drivers
+      .filter((driver) => byDriver.has(driver))
+      .map((driver) =>
+        buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
+      )
+    return buildLapChartOption(seriesList)
+  }, [laps, drivers, year])
+
+  const handleClick = useCallback(
+    (raw: unknown) => {
+      const click = extractLapClick(raw)
+      if (click) onLapClick(click.driver, click.lapNumber)
+    },
+    [onLapClick],
+  )
+
+  return (
+    <ReactECharts
+      theme={F1_THEME}
+      option={option}
+      style={{ height: 400 }}
+      notMerge
+      onEvents={{ click: handleClick }}
+    />
+  )
+}

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -1,0 +1,117 @@
+// LAP CHART section. Streamlit parity: `frontend/components/dashboard/lap_graph.py`.
+//
+// Owns the data fetch (`useLapTimes`) and the store reads/writes; the three
+// sub-components (`LapChart`, `LapControls`, `CompoundLegend`) are dumb
+// renderers of whatever slice they're handed. The outlier/invalid filters are
+// applied here (client-side, no refetch — `applyLapFilters`) and only the
+// resulting `visible` laps are plotted; buttons and the legend keep working
+// off the FULL `lapTimes`, matching the Streamlit source's split between
+// "what's plotted" and "what's counted".
+
+import { useMemo } from 'react'
+import type { DashboardSearch } from '../search'
+import { useLapTimes } from '../queries'
+import { useDashboardStore } from '../store'
+import { applyLapFilters } from '../lib/outliers'
+import { Skeleton } from '@/components/Skeleton'
+import { LapChart } from './LapChart'
+import { LapControls } from './LapControls'
+import { CompoundLegend } from './CompoundLegend'
+
+export interface LapChartSectionProps {
+  search: DashboardSearch
+}
+
+/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`. */
+function NoLapDataBanner() {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-3 rounded-xl border border-hairline border-l-4 border-l-info bg-bg-3 px-4 py-3 text-sm text-fg-2"
+    >
+      <span aria-hidden="true">ℹ️</span>
+      <span>No lap data available. Select drivers and ensure backend is running.</span>
+    </div>
+  )
+}
+
+/** `{ driver, lap }` pairs for the "Showing telemetry" caption, in the
+ *  store map's insertion order (click order / fastest-laps batch order). */
+function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
+  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
+}
+
+/** LAP CHART section: chart (or its loading/empty state), control buttons,
+ *  a click-to-load tip, the current telemetry-selection caption, and the
+ *  tyre compound legend, in that order. */
+export function LapChartSection({ search }: LapChartSectionProps) {
+  const lapTimesQuery = useLapTimes(search)
+  const lapTimes = useMemo(() => lapTimesQuery.data ?? [], [lapTimesQuery.data])
+
+  const showOutliers = useDashboardStore((s) => s.showOutliers)
+  const showInvalidLaps = useDashboardStore((s) => s.showInvalidLaps)
+  const toggleOutliers = useDashboardStore((s) => s.toggleOutliers)
+  const toggleInvalidLaps = useDashboardStore((s) => s.toggleInvalidLaps)
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
+  const setLap = useDashboardStore((s) => s.setLap)
+  const setFastestLaps = useDashboardStore((s) => s.setFastestLaps)
+
+  const filterResult = useMemo(
+    () => applyLapFilters(lapTimes, showOutliers, showInvalidLaps),
+    [lapTimes, showOutliers, showInvalidLaps],
+  )
+
+  const isEmpty = search.drivers.length === 0 || lapTimes.length === 0
+  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-center font-display text-lg uppercase tracking-wide text-fg-2">
+        Lap Chart
+      </h2>
+
+      {lapTimesQuery.isLoading ? (
+        <Skeleton className="h-100 w-full" />
+      ) : isEmpty ? (
+        <NoLapDataBanner />
+      ) : (
+        <LapChart
+          laps={filterResult.visible}
+          drivers={search.drivers}
+          year={search.year}
+          onLapClick={setLap}
+        />
+      )}
+
+      <LapControls
+        lapTimes={lapTimes}
+        drivers={search.drivers}
+        showOutliers={showOutliers}
+        showInvalidLaps={showInvalidLaps}
+        outlierCount={filterResult.outlierCount}
+        invalidCount={filterResult.invalidCount}
+        onSelectFastestLaps={setFastestLaps}
+        onToggleOutliers={toggleOutliers}
+        onToggleInvalidLaps={toggleInvalidLaps}
+      />
+
+      <p className="text-sm text-fg-3">
+        💡 Tip: Click on any point in the LAP CHART above to load that lap's telemetry
+      </p>
+
+      {captionParts.length > 0 ? (
+        <p className="text-sm text-fg-2">
+          📊 Showing telemetry:{' '}
+          {captionParts.map((part, index) => (
+            <span key={part.driver}>
+              {index > 0 ? ', ' : ''}
+              <strong className="font-semibold text-fg-1">{part.driver}</strong> (Lap {part.lap})
+            </span>
+          ))}
+        </p>
+      ) : null}
+
+      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} />
+    </section>
+  )
+}

--- a/webapp/src/features/dashboard/components/LapControls.tsx
+++ b/webapp/src/features/dashboard/components/LapControls.tsx
@@ -1,0 +1,99 @@
+// Lap-chart control row. Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::render_control_buttons` /
+// `_display_filter_status`.
+//
+// Pure presentational + one pure computation (fastest lap per driver); all
+// store writes happen in the caller (`LapChartSection`) so this component
+// never touches Zustand directly.
+
+import { Button } from '@/components/Button'
+import type { LapTime } from '@/lib/api/telemetry'
+
+/** Each driver's fastest lap (by `lap_time`), computed from the FULL
+ *  (unfiltered) lap times — the outlier/invalid toggles must not hide a
+ *  driver's genuine fastest lap from this shortcut. */
+function fastestLapPerDriver(lapTimes: LapTime[], drivers: string[]): Record<string, number> {
+  const fastest: Record<string, number> = {}
+  for (const driver of drivers) {
+    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
+    if (driverLaps.length === 0) continue
+    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
+    fastest[driver] = quickest.lap_number
+  }
+  return fastest
+}
+
+/** "Showing/Hiding N outlier laps | Hiding N invalid laps" status line,
+ *  matching `_display_filter_status`'s message assembly exactly. */
+function buildFilterStatus(
+  outlierCount: number,
+  invalidCount: number,
+  showOutliers: boolean,
+  showInvalidLaps: boolean,
+): string {
+  const parts: string[] = []
+  if (outlierCount > 0) {
+    parts.push(
+      showOutliers
+        ? `📊 Showing ${outlierCount} outlier laps`
+        : `🚫 Hiding ${outlierCount} outlier laps`,
+    )
+  }
+  if (invalidCount > 0 && !showInvalidLaps) {
+    parts.push(`🚫 Hiding ${invalidCount} invalid laps`)
+  }
+  return parts.join(' | ')
+}
+
+export interface LapControlsProps {
+  /** FULL (unfiltered) lap times — fastest-lap selection ignores the toggles. */
+  lapTimes: LapTime[]
+  drivers: string[]
+  showOutliers: boolean
+  showInvalidLaps: boolean
+  outlierCount: number
+  invalidCount: number
+  onSelectFastestLaps: (laps: Record<string, number>) => void
+  onToggleOutliers: () => void
+  onToggleInvalidLaps: () => void
+}
+
+/** Fastest-laps shortcut + outlier/invalid visibility toggles, plus the
+ *  resulting filter-status line. */
+export function LapControls({
+  lapTimes,
+  drivers,
+  showOutliers,
+  showInvalidLaps,
+  outlierCount,
+  invalidCount,
+  onSelectFastestLaps,
+  onToggleOutliers,
+  onToggleInvalidLaps,
+}: LapControlsProps) {
+  const filterStatus = buildFilterStatus(outlierCount, invalidCount, showOutliers, showInvalidLaps)
+
+  /** Load each driver's fastest lap — no-op when there are no laps yet, so the
+   *  button can't wipe the current selection with an empty map. */
+  const handleSelectFastest = () => {
+    const fastest = fastestLapPerDriver(lapTimes, drivers)
+    if (Object.keys(fastest).length > 0) onSelectFastestLaps(fastest)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Button variant="ghost" onClick={handleSelectFastest}>
+          🏁 SELECT FASTEST LAPS
+        </Button>
+        <Button variant="ghost" onClick={onToggleOutliers}>
+          {showOutliers ? 'HIDE OUTLIERS' : 'SHOW OUTLIERS'}
+        </Button>
+        <Button variant="ghost" onClick={onToggleInvalidLaps}>
+          {showInvalidLaps ? 'HIDE INVALID LAPS' : 'SHOW INVALID LAPS'}
+        </Button>
+      </div>
+      {filterStatus ? <p className="text-sm text-fg-3">{filterStatus}</p> : null}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -1,0 +1,106 @@
+// Cascading Year → GP → Session → Drivers toolbar (Streamlit parity, see
+// `frontend/components/dashboard/data_selectors.py`). This component is a
+// dumb renderer: it only reads `value` and fires single-key patches via
+// `onChange`. The page (`DashboardPage`) owns the URL and applies the
+// cascading reset when an upstream selector changes.
+import type { ReactNode } from 'react'
+import type { DashboardSearch } from '../search'
+import { MAX_DRIVERS } from '../search'
+import { useGps, useSessions, useDrivers } from '../queries'
+import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
+import { cn } from '@/lib/cn'
+
+export interface SelectorsToolbarProps {
+  value: DashboardSearch
+  /** Patch the URL search (page merges + navigates). Passing a key resets its dependents. */
+  onChange: (patch: Partial<DashboardSearch>) => void
+}
+
+// Streamlit hardcodes this same list — no `/years` endpoint exists.
+const YEAR_OPTIONS: ComboboxOption[] = [2025, 2024, 2023].map((year) => ({
+  value: String(year),
+  label: String(year),
+}))
+
+const EYEBROW_CLASSNAME = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+
+/** A labelled selector cell: the small uppercase eyebrow above its control,
+ *  matching `StatCard`'s eyebrow styling so the toolbar reads as one system. */
+function SelectorField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className={EYEBROW_CLASSNAME}>{label}</span>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Horizontal toolbar of the 4 cascading dashboard selectors. Each selector is
+ * disabled until its upstream dependency is chosen, and options come from the
+ * live telemetry API (`useGps`/`useSessions`/`useDrivers`) rather than a
+ * hardcoded roster, so the driver list always matches who actually ran.
+ */
+export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
+  const gpsQuery = useGps(value.year)
+  const sessionsQuery = useSessions(value.year, value.gp)
+  const driversQuery = useDrivers(value.year, value.gp, value.session)
+
+  const gpOptions: ComboboxOption[] = (gpsQuery.data ?? []).map((gp) => ({ value: gp, label: gp }))
+  const sessionOptions: ComboboxOption[] = (sessionsQuery.data ?? []).map((session) => ({
+    value: session,
+    label: session,
+  }))
+  const driverOptions: ComboboxOption[] = (driversQuery.data ?? []).map((driver) => ({
+    value: driver.code,
+    label: driver.code,
+  }))
+
+  return (
+    <div className={cn('grid grid-cols-1 gap-4', 'sm:grid-cols-2', 'lg:grid-cols-4')}>
+      <SelectorField label="Year">
+        <Combobox
+          ariaLabel="Year"
+          options={YEAR_OPTIONS}
+          value={value.year != null ? String(value.year) : undefined}
+          onChange={(year) => onChange({ year: Number(year) })}
+          placeholder="Select year"
+        />
+      </SelectorField>
+
+      <SelectorField label="GP">
+        <Combobox
+          ariaLabel="Grand Prix"
+          options={gpOptions}
+          value={value.gp}
+          onChange={(gp) => onChange({ gp })}
+          placeholder="Select GP"
+          disabled={value.year == null || gpsQuery.isLoading}
+        />
+      </SelectorField>
+
+      <SelectorField label="Session">
+        <Combobox
+          ariaLabel="Session"
+          options={sessionOptions}
+          value={value.session}
+          onChange={(session) => onChange({ session })}
+          placeholder="Select session"
+          disabled={!value.gp || sessionsQuery.isLoading}
+        />
+      </SelectorField>
+
+      <SelectorField label="Drivers">
+        <MultiCombobox
+          ariaLabel="Drivers (max 3)"
+          options={driverOptions}
+          value={value.drivers}
+          onChange={(drivers) => onChange({ drivers })}
+          placeholder="Select drivers (max 3)"
+          disabled={!value.session || driversQuery.isLoading}
+          max={MAX_DRIVERS}
+        />
+      </SelectorField>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -1,0 +1,159 @@
+// TELEMETRY section (issue #34, §6.1): 7 per-channel charts — Speed, Delta,
+// Throttle, Brake, RPM, Gear, DRS, matching the render order in
+// frontend/pages/dashboard.py — in a grid<->stack layout, each plotting one
+// line per loaded driver against distance. Delta is cross-driver (needs a
+// reference lap) so it renders through the dedicated `DeltaChart`; the other
+// 6 channels share the generic `ChannelChart`, driven by `channels.ts`.
+//
+// Data comes from `useLapTelemetries`, keyed by the store's
+// `selectedLapsPerDriver` (the lap chart writes to it on click-to-load).
+// Until at least one lap has loaded, every card shows `TelemetryLoader`
+// instead of a chart — Víctor's hard requirement, see TelemetryLoader.tsx.
+
+import type { ReactNode } from 'react'
+import { ChartCard } from '@/components/ChartCard'
+import { Button } from '@/components/Button'
+import { cn } from '@/lib/cn'
+import type { DashboardSearch } from '../search'
+import { useLapTelemetries } from '../queries'
+import { useDashboardStore, type ChartLayout } from '../store'
+import { TelemetryLoader } from './TelemetryLoader'
+import { ChannelChart, DeltaChart } from './ChannelChart'
+import { CHANNELS, DELTA_TITLE } from './channels'
+
+export interface TelemetryGridProps {
+  search: DashboardSearch
+}
+
+const LAYOUT_CLASSNAMES: Record<ChartLayout, string> = {
+  grid: 'grid grid-cols-1 gap-4 xl:grid-cols-2',
+  stack: 'flex flex-col gap-4',
+}
+
+/** One ChartCard: its chart once at least one lap has loaded, the shared
+ *  loader before that. Keeps the loader-vs-chart branch in a single place
+ *  instead of repeating it per card. */
+function TelemetryCard({
+  title,
+  hasAny,
+  children,
+}: {
+  title: string
+  hasAny: boolean
+  children: ReactNode
+}) {
+  return <ChartCard title={title}>{hasAny ? children : <TelemetryLoader />}</ChartCard>
+}
+
+/** Human note for laps that came back without telemetry (pit / out / incomplete
+ *  laps return an empty body). Mirrors the Streamlit tip that told the user to
+ *  pick a different lap instead of leaving them staring at a spinner. */
+function noTelemetryMessage(failedDrivers: string[]): string {
+  const who = failedDrivers.length > 0 ? failedDrivers.join(', ') : 'the selected lap(s)'
+  return `No telemetry for ${who} — pit, out and incomplete laps have no telemetry data. Click a different lap in the chart above (or use SELECT FASTEST LAPS).`
+}
+
+/** Full-width notice shown when every selected lap settled with no telemetry —
+ *  replaces a grid of loaders that would otherwise never resolve. */
+function NoTelemetryNotice({ failedDrivers }: { failedDrivers: string[] }) {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
+    >
+      <span aria-hidden="true">⚠️</span>
+      <span>{noTelemetryMessage(failedDrivers)}</span>
+    </div>
+  )
+}
+
+function LayoutToggle({ layout, onToggle }: { layout: ChartLayout; onToggle: () => void }) {
+  const modes: { mode: ChartLayout; label: string }[] = [
+    { mode: 'grid', label: 'Grid' },
+    { mode: 'stack', label: 'Stack' },
+  ]
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-hairline p-1">
+      {modes.map(({ mode, label }) => (
+        <Button
+          key={mode}
+          variant={layout === mode ? 'primary' : 'ghost'}
+          size="sm"
+          aria-pressed={layout === mode}
+          onClick={() => layout !== mode && onToggle()}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+export function TelemetryGrid({ search }: TelemetryGridProps) {
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
+  const chartLayout = useDashboardStore((s) => s.chartLayout)
+  const toggleChartLayout = useDashboardStore((s) => s.toggleChartLayout)
+  const { byDriver, hasAny, isLoading, hasSelection, failedDrivers } = useLapTelemetries(
+    search,
+    selectedLapsPerDriver,
+  )
+  const { drivers, year } = search
+
+  // Every selected lap settled with no telemetry → show one notice instead of
+  // a grid of loaders that would never resolve. A PARTIAL failure (some driver
+  // loaded, another didn't) still renders the charts, with a note on top.
+  const settledEmpty = hasSelection && !isLoading && !hasAny
+  const showPartialNote = hasAny && failedDrivers.length > 0
+
+  // Speed leads, Delta is hardcoded second (cross-driver, not part of
+  // CHANNELS), then the rest of CHANNELS in their declared order — matches
+  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs).
+  const [speedChannel, ...restChannels] = CHANNELS
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-display text-lg tracking-wide text-fg-2 uppercase">Telemetry</h2>
+        <LayoutToggle layout={chartLayout} onToggle={toggleChartLayout} />
+      </div>
+
+      {settledEmpty ? (
+        <NoTelemetryNotice failedDrivers={failedDrivers} />
+      ) : (
+        <>
+          {showPartialNote ? (
+            <p className="text-sm text-warning">{noTelemetryMessage(failedDrivers)}</p>
+          ) : null}
+
+          <div className={cn(LAYOUT_CLASSNAMES[chartLayout])}>
+            <TelemetryCard title={speedChannel.title} hasAny={hasAny}>
+              <ChannelChart
+                title={speedChannel.title}
+                byDriver={byDriver}
+                drivers={drivers}
+                year={year}
+                channel={speedChannel}
+              />
+            </TelemetryCard>
+
+            <TelemetryCard title={DELTA_TITLE} hasAny={hasAny}>
+              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} />
+            </TelemetryCard>
+
+            {restChannels.map((channel) => (
+              <TelemetryCard key={channel.key} title={channel.title} hasAny={hasAny}>
+                <ChannelChart
+                  title={channel.title}
+                  byDriver={byDriver}
+                  drivers={drivers}
+                  year={year}
+                  channel={channel}
+                />
+              </TelemetryCard>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/webapp/src/features/dashboard/components/TelemetryLoader.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryLoader.tsx
@@ -1,0 +1,50 @@
+// The "Waiting for telemetry data…" loader, kept 1:1 from Streamlit (a
+// ScaleLoader — 5 purple bars pulsing on a staggered delay). Shown by the
+// telemetry charts and the circuit map before a lap's telemetry is loaded.
+// Víctor's hard requirement: preserve this loading state before charts render.
+
+interface TelemetryLoaderProps {
+  /** Message under the bars. Defaults to the Streamlit copy. */
+  label?: string
+  /** Container min-height in px (charts use 400, matching Streamlit). */
+  minHeight?: number
+}
+
+const BAR_COLOR = '#a78bfa'
+const BAR_COUNT = 5
+
+export function TelemetryLoader({
+  label = 'Waiting for telemetry data...',
+  minHeight = 400,
+}: TelemetryLoaderProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-hairline"
+      style={{ minHeight }}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-end gap-1.5" aria-hidden="true">
+        {Array.from({ length: BAR_COUNT }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              display: 'inline-block',
+              width: 6,
+              height: 35,
+              background: BAR_COLOR,
+              borderRadius: 2,
+              animation: 'f1-scaleloader 1s ease-in-out infinite',
+              animationDelay: `${i * 0.1}s`,
+            }}
+          />
+        ))}
+      </div>
+      <p className="text-sm text-fg-2">{label}</p>
+      <style>{`@keyframes f1-scaleloader {
+        0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
+        20% { transform: scaleY(1); opacity: 1; }
+      }`}</style>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -1,0 +1,85 @@
+// Channel configs for the TELEMETRY grid (issue #34, §6.1). Six of the seven
+// charts (everything but Delta) are pure "plot this array against distance"
+// jobs and share the generic `ChannelChart` component — this file is that
+// shared data. Delta is cross-driver (it diffs every loaded lap against a
+// reference lap's interpolated time, not a single telemetry array) so it
+// gets its own `DeltaChart` component in ChannelChart.tsx instead of an
+// entry here; `DELTA_TITLE` is exported so its ChartCard heading still lives
+// next to the other six.
+//
+// Streamlit parity: frontend/components/telemetry/{speed,throttle,brake,rpm,
+// gear,drs}_graph.py. `transform` mirrors each module's data-prep step (only
+// DRS transforms its raw values; the rest plot the FastF1 array as-is).
+
+import type { LapTelemetry } from '@/lib/api/telemetry'
+
+export const DELTA_TITLE = 'Delta'
+
+export interface ChannelYAxis {
+  min?: number
+  max?: number
+  interval?: number
+  /** Custom tick label, e.g. DRS's 0/1 -> "Disabled"/"Enabled". */
+  formatter?: (value: number) => string
+}
+
+export interface ChannelConfig {
+  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'drs'
+  /** ChartCard header + chart title. */
+  title: string
+  /** Y-axis name shown on the chart. */
+  yName: string
+  /** 'end' draws a stairstep line instead of interpolating between samples —
+   *  gear and DRS are discrete states (gear_graph.py / drs_graph.py both use
+   *  a step shape for this reason), not continuous quantities. */
+  stepped?: boolean
+  yAxis?: ChannelYAxis
+  /** Extracts the plotted series from a driver's telemetry. */
+  transform: (telemetry: LapTelemetry) => number[]
+}
+
+/**
+ * DRS reads "open" only once actively deployed. FastF1 values 10/12/14 mean
+ * on; 0-1 is off and 2-8 covers intermediate/eligible-but-not-open states.
+ * Mirrors drs_graph.py's `_process_drs_data`.
+ */
+function binarizeDrs(telemetry: LapTelemetry): number[] {
+  return telemetry.drs.map((value) => (value >= 10 ? 1 : 0))
+}
+
+const DRS_TICKS: Record<number, string> = { 0: 'Disabled', 1: 'Enabled' }
+
+export const CHANNELS: ChannelConfig[] = [
+  { key: 'speed', title: 'Speed', yName: 'Speed (km/h)', transform: (t) => t.speed },
+  {
+    key: 'throttle',
+    title: 'Throttle',
+    yName: 'Throttle (%)',
+    yAxis: { min: 0, max: 100 },
+    transform: (t) => t.throttle,
+  },
+  { key: 'brake', title: 'Brake', yName: 'Brake', transform: (t) => t.brake },
+  { key: 'rpm', title: 'RPM', yName: 'RPM', transform: (t) => t.rpm },
+  {
+    key: 'gear',
+    title: 'Gear',
+    yName: 'Gear',
+    stepped: true,
+    // min 0 so neutral (nGear=0, seen at launch / in the pits) isn't clipped.
+    yAxis: { min: 0, max: 8, interval: 1 },
+    transform: (t) => t.gear,
+  },
+  {
+    key: 'drs',
+    title: 'DRS',
+    yName: 'DRS',
+    stepped: true,
+    yAxis: {
+      min: 0,
+      max: 1,
+      interval: 1,
+      formatter: (value) => DRS_TICKS[value] ?? String(value),
+    },
+    transform: binarizeDrs,
+  },
+]

--- a/webapp/src/features/dashboard/components/circuitDraw.ts
+++ b/webapp/src/features/dashboard/components/circuitDraw.ts
@@ -1,0 +1,104 @@
+// Pure geometry helpers for the Circuit Domination map. The backend already
+// did all the hard work (rotation, scaling, per-microsector dominant driver);
+// these functions only turn its raw x/y/colors arrays into something an SVG
+// can draw without distorting the track shape.
+//
+// Two things an SVG needs help with that the backend data doesn't provide:
+//  1. Aspect-ratio lock — track x/y are in real-world units (metres), and a
+//     naive "fit width x fit height" would stretch the circuit. Mirrors
+//     Plotly's `scaleanchor="y"` / matplotlib's `axis('equal')` from the
+//     original Streamlit chart (circuit_domination.py::_create_circuit_figure).
+//  2. Y-flip — track y is mathematical (up = positive), SVG y grows downward,
+//     so plotting raw y values renders the track upside down.
+
+/** Bounding box of a coordinate list, in track units. */
+export interface Bounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+/** One drawable segment: point[i] -> point[i+1], coloured by that
+ *  microsector's dominant driver. Coordinates are already y-flipped. */
+export interface Segment {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  color: string
+}
+
+/** Extra room around the track so segments near the edge aren't clipped by
+ *  the viewBox, as a fraction of each axis's range. */
+const VIEWBOX_PADDING_RATIO = 0.06
+
+/** Fallback stroke colour for a segment whose driver colour is missing,
+ *  matching the neutral grey used elsewhere for "no data". */
+const FALLBACK_SEGMENT_COLOR = '#94a3b8'
+
+/**
+ * Bounding box of the track's x/y coordinates.
+ * Falls back to a degenerate 0..1 box for empty input so downstream ratio
+ * math (division by range) never divides by zero.
+ */
+export function computeBounds(x: number[], y: number[]): Bounds {
+  if (x.length === 0 || y.length === 0) {
+    return { minX: 0, maxX: 1, minY: 0, maxY: 1 }
+  }
+  return {
+    minX: Math.min(...x),
+    maxX: Math.max(...x),
+    minY: Math.min(...y),
+    maxY: Math.max(...y),
+  }
+}
+
+/** Flip track y (mathematical, up = positive) to SVG-local y (down = positive). */
+export function flipY(y: number): number {
+  return -y
+}
+
+/**
+ * SVG `viewBox` string ("minX minY width height") for the given bounds, with
+ * padding. Locking the aspect ratio to the track's own width/height and
+ * relying on SVG's default `preserveAspectRatio="xMidYMid meet"` is what
+ * fits + centers the track without distortion, no manual pixel scaling
+ * needed on the component side.
+ */
+export function computeViewBox(bounds: Bounds): string {
+  const rangeX = Math.max(bounds.maxX - bounds.minX, 1e-6)
+  const rangeY = Math.max(bounds.maxY - bounds.minY, 1e-6)
+  const padX = rangeX * VIEWBOX_PADDING_RATIO
+  const padY = rangeY * VIEWBOX_PADDING_RATIO
+
+  // After the y-flip, the track's old maxY becomes the new (smaller) minY.
+  const flippedMinY = flipY(bounds.maxY)
+  const minX = bounds.minX - padX
+  const minY = flippedMinY - padY
+  const width = rangeX + 2 * padX
+  const height = rangeY + 2 * padY
+
+  return `${minX} ${minY} ${width} ${height}`
+}
+
+/**
+ * Builds one line segment per consecutive coordinate pair, each carrying the
+ * colour of the driver who dominated that microsector. `colors[i]` paints
+ * the segment from `point[i]` to `point[i+1]` (so `colors.length === x.length - 1`
+ * on well-formed data); a mismatched length is tolerated defensively.
+ */
+export function buildSegments(x: number[], y: number[], colors: string[]): Segment[] {
+  const segmentCount = Math.min(x.length, y.length) - 1
+  const segments: Segment[] = []
+  for (let i = 0; i < segmentCount; i++) {
+    segments.push({
+      x1: x[i],
+      y1: flipY(y[i]),
+      x2: x[i + 1],
+      y2: flipY(y[i + 1]),
+      color: colors[i] ?? FALLBACK_SEGMENT_COLOR,
+    })
+  }
+  return segments
+}

--- a/webapp/src/features/dashboard/lib/compounds.ts
+++ b/webapp/src/features/dashboard/lib/compounds.ts
@@ -1,0 +1,57 @@
+// Tyre-compound presentation helpers, matching the Streamlit dashboard:
+// compounds are shown in the lap-chart HOVER (emoji + capitalised name) and in
+// the compound legend (per-driver lap counts). Points/lines themselves are
+// coloured by DRIVER, never by compound (see LapChart).
+//
+// FastF1 returns compound lowercase ('soft'|'medium'|'hard'|'intermediate'|
+// 'inter'|'wet'|'unknown'). `inter` is an alias of `intermediate`.
+
+/** Canonical Pill `compound` variant values (uppercase), for the legend pills. */
+export type CompoundVariant = 'SOFT' | 'MEDIUM' | 'HARD' | 'INTERMEDIATE' | 'WET'
+
+const EMOJI: Record<string, string> = {
+  soft: '🔴',
+  medium: '🟡',
+  hard: '⚪',
+  intermediate: '🟢',
+  inter: '🟢',
+  wet: '🔵',
+}
+const UNKNOWN_EMOJI = '⚫'
+
+// Display order used by the legend (Streamlit: soft→medium→hard→inter→wet).
+export const COMPOUND_ORDER = ['soft', 'medium', 'hard', 'intermediate', 'inter', 'wet']
+
+/** Emoji marker for a compound (hover text). */
+export function compoundEmoji(compound: string): string {
+  return EMOJI[compound.toLowerCase()] ?? UNKNOWN_EMOJI
+}
+
+/** Human label, capitalised (e.g. 'medium' → 'Medium'). */
+export function compoundLabel(compound: string): string {
+  if (!compound) return 'Unknown'
+  const lower = compound.toLowerCase()
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
+}
+
+/**
+ * Map a raw FastF1 compound to the Pill `compound` variant, or null when it
+ * has no branded colour (unknown). `inter` folds into INTERMEDIATE.
+ */
+export function compoundVariant(compound: string): CompoundVariant | null {
+  switch (compound.toLowerCase()) {
+    case 'soft':
+      return 'SOFT'
+    case 'medium':
+      return 'MEDIUM'
+    case 'hard':
+      return 'HARD'
+    case 'intermediate':
+    case 'inter':
+      return 'INTERMEDIATE'
+    case 'wet':
+      return 'WET'
+    default:
+      return null
+  }
+}

--- a/webapp/src/features/dashboard/lib/drivers.ts
+++ b/webapp/src/features/dashboard/lib/drivers.ts
@@ -1,0 +1,127 @@
+// Year-aware driver → team colour palette, ported 1:1 from the Streamlit
+// original (`frontend/components/common/driver_colors.py`) so the migrated
+// charts keep IDENTICAL colours. Each driver gets their team's colour for that
+// season (2023-2025 lineups). Keep in sync with the Python source if lineups
+// change.
+
+const RED_BULL = '#3671C6'
+const RED_BULL_2 = '#1B3D8E'
+const FERRARI = '#E8002D'
+const FERRARI_2 = '#A30000'
+const MERCEDES = '#27F4D2'
+const MERCEDES_2 = '#6CD3BF'
+const MCLAREN = '#FF8700'
+const MCLAREN_2 = '#FFB347'
+const ASTON = '#229971'
+const ASTON_2 = '#2BA572'
+const ALPINE_PINK = '#FF87BC'
+const ALPINE_PINK_2 = '#FFC0E3'
+const ALPINE_BLUE = '#0093CC'
+const ALPINE_BLUE_2 = '#00B0F0'
+const WILLIAMS = '#041E42'
+const WILLIAMS_2 = '#64C4FF'
+const RB = '#6692FF'
+const RB_2 = '#4682B4'
+const SAUBER = '#52E252'
+const SAUBER_2 = '#00E701'
+const HAAS = '#B6BABD'
+const HAAS_2 = '#787878'
+
+/** Fallback colour for a driver absent from the season map. */
+export const DEFAULT_DRIVER_COLOR = '#A259F7'
+
+const DRIVER_COLORS_BY_YEAR: Record<number, Record<string, string>> = {
+  2025: {
+    VER: RED_BULL,
+    LAW: RED_BULL_2,
+    LEC: FERRARI,
+    HAM: FERRARI_2,
+    RUS: MERCEDES,
+    ANT: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_BLUE,
+    DOO: ALPINE_BLUE_2,
+    ALB: WILLIAMS_2,
+    SAI: WILLIAMS,
+    TSU: RB,
+    HAD: RB_2,
+    HUL: SAUBER,
+    BOR: SAUBER_2,
+    OCO: HAAS,
+    BEA: HAAS_2,
+  },
+  2024: {
+    VER: RED_BULL,
+    PER: RED_BULL_2,
+    LEC: FERRARI,
+    SAI: FERRARI_2,
+    HAM: MERCEDES,
+    RUS: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_PINK,
+    OCO: ALPINE_PINK_2,
+    ALB: WILLIAMS_2,
+    SAR: WILLIAMS,
+    COL: WILLIAMS,
+    TSU: RB,
+    RIC: '#F5F5F5',
+    LAW: RB_2,
+    BOT: SAUBER,
+    ZHO: SAUBER_2,
+    MAG: HAAS_2,
+    HUL: HAAS,
+    BEA: HAAS,
+  },
+  2023: {
+    VER: RED_BULL,
+    PER: RED_BULL_2,
+    LEC: FERRARI,
+    SAI: FERRARI_2,
+    HAM: MERCEDES,
+    RUS: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_PINK,
+    OCO: ALPINE_PINK_2,
+    ALB: WILLIAMS_2,
+    SAR: WILLIAMS,
+    TSU: RB,
+    RIC: '#F5F5F5',
+    LAW: RB_2,
+    BOT: SAUBER,
+    ZHO: SAUBER_2,
+    MAG: HAAS_2,
+    HUL: HAAS,
+  },
+}
+
+// Flat fallback = 2025 colours (mirrors the Python `DRIVER_COLORS`).
+const DRIVER_COLORS_FLAT = DRIVER_COLORS_BY_YEAR[2025]
+
+/**
+ * Team colour for a driver in a given season.
+ * @param code Three-letter driver code (case-insensitive).
+ * @param year Season year; when omitted uses the flat 2025 fallback.
+ */
+export function getDriverColor(code: string, year?: number): string {
+  const key = code.toUpperCase()
+  if (year && DRIVER_COLORS_BY_YEAR[year]) {
+    return DRIVER_COLORS_BY_YEAR[year][key] ?? DEFAULT_DRIVER_COLOR
+  }
+  return DRIVER_COLORS_FLAT[key] ?? DEFAULT_DRIVER_COLOR
+}
+
+/** Build a `{ driver: colour }` map for the selected drivers. */
+export function driverColorMap(drivers: string[], year?: number): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const code of drivers) map[code] = getDriverColor(code, year)
+  return map
+}

--- a/webapp/src/features/dashboard/lib/lapTime.ts
+++ b/webapp/src/features/dashboard/lib/lapTime.ts
@@ -1,0 +1,20 @@
+// Lap-time formatting. The Streamlit lap chart shows MM:SS ticks on the y-axis
+// (integer seconds, no milliseconds — matching `utils/time_formatters.py`),
+// while hover shows the finer M:SS.mmm value.
+
+/** Seconds → "M:SS" (integer seconds), for axis ticks. e.g. 79.4 → "1:19". */
+export function formatLapTimeAxis(seconds: number): string {
+  const total = Math.round(seconds)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+/** Seconds → "M:SS.mmm", for hover / precise readouts. e.g. 79.367 → "1:19.367". */
+export function formatLapTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const rem = seconds - mins * 60
+  const secs = Math.floor(rem)
+  const millis = Math.round((rem - secs) * 1000)
+  return `${mins}:${secs.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`
+}

--- a/webapp/src/features/dashboard/lib/outliers.test.ts
+++ b/webapp/src/features/dashboard/lib/outliers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { applyLapFilters, detectOutlierIndices } from './outliers'
+import type { LapTime } from '@/lib/api/telemetry'
+
+function lap(driver: string, lap_number: number, lap_time: number): LapTime {
+  return { driver, lap_number, lap_time, is_valid: true, compound: 'medium' }
+}
+
+describe('detectOutlierIndices', () => {
+  it('skips drivers with fewer than 4 laps', () => {
+    const laps = [lap('VER', 1, 80), lap('VER', 2, 200), lap('VER', 3, 81)]
+    expect(detectOutlierIndices(laps).size).toBe(0)
+  })
+
+  it('flags a high outlier with the 1.5×IQR index-quartile rule', () => {
+    // 8 tight laps (~79s) + one 120s lap. n=9 → q1=idx2, q3=idx6 on sorted.
+    const times = [79.0, 79.1, 79.2, 79.3, 79.4, 79.5, 79.6, 79.7, 120.0]
+    const laps = times.map((t, i) => lap('VER', i + 1, t))
+    const outliers = detectOutlierIndices(laps)
+    expect(outliers.has(8)).toBe(true) // the 120s lap
+    expect(outliers.size).toBe(1)
+  })
+
+  it('computes outliers per driver independently', () => {
+    const ver = [79.0, 79.1, 79.2, 79.3, 130.0].map((t, i) => lap('VER', i + 1, t))
+    const lec = [80.0, 80.1, 80.2, 80.3].map((t, i) => lap('LEC', i + 1, t))
+    const outliers = detectOutlierIndices([...ver, ...lec])
+    expect(outliers.has(4)).toBe(true) // VER's 130s lap (index 4 overall)
+    expect([...outliers].every((i) => i < 5)).toBe(true) // none from LEC
+  })
+})
+
+describe('applyLapFilters', () => {
+  const laps = [79.0, 79.1, 79.2, 79.3, 79.4, 79.5, 79.6, 79.7, 120.0].map((t, i) =>
+    lap('VER', i + 1, t),
+  )
+
+  it('hides outliers when showOutliers is false', () => {
+    const { visible, outlierCount } = applyLapFilters(laps, false, true)
+    expect(outlierCount).toBe(1)
+    expect(visible).toHaveLength(8)
+  })
+
+  it('keeps outliers when showOutliers is true', () => {
+    const { visible } = applyLapFilters(laps, true, true)
+    expect(visible).toHaveLength(9)
+  })
+
+  it('invalid filter is a no-op with the current backend shape', () => {
+    const { visible, invalidCount } = applyLapFilters(laps, true, false)
+    expect(invalidCount).toBe(0)
+    expect(visible).toHaveLength(9)
+  })
+})

--- a/webapp/src/features/dashboard/lib/outliers.ts
+++ b/webapp/src/features/dashboard/lib/outliers.ts
@@ -1,0 +1,95 @@
+// Client-side lap filtering, ported 1:1 from the Streamlit dashboard
+// (`components/dashboard/lap_graph.py`). Both toggles are pure transforms over
+// the already-fetched laps — no refetch (parity requirement F1-5 / P4-3).
+//
+// PARITY NOTES (faithful to the original, quirks included):
+//  - Outlier IQR uses INDEX-based quartiles (n//4, 3n//4) on the sorted times,
+//    NOT linear-interpolation quartiles; multiplier 1.5; drivers with <4 laps
+//    are skipped (never flagged).
+//  - "Invalid" = `not is_accurate or is_pit_out_lap`. The /lap-times response
+//    does not currently include these fields, so with safe defaults every lap
+//    counts as valid → the toggle is effectively a no-op today, exactly as in
+//    Streamlit. Reading the optional fields keeps it correct if the backend
+//    later starts sending them.
+
+import type { LapTime } from '@/lib/api/telemetry'
+
+/** Lap with the (currently unsent) accuracy flags the invalid filter would use. */
+type LapWithFlags = LapTime & { is_accurate?: boolean; is_pit_out_lap?: boolean }
+
+/** Integer floor division, matching Python's `//`. */
+function floorDiv(a: number, b: number): number {
+  return Math.floor(a / b)
+}
+
+/**
+ * Indices (into `laps`) flagged as lap-time outliers, computed per driver via
+ * the 1.5×IQR rule with index-based quartiles. Drivers with <4 laps are skipped.
+ */
+export function detectOutlierIndices(laps: LapTime[]): Set<number> {
+  const byDriver = new Map<string, number[]>()
+  laps.forEach((lap, idx) => {
+    const list = byDriver.get(lap.driver) ?? []
+    list.push(idx)
+    byDriver.set(lap.driver, list)
+  })
+
+  const outliers = new Set<number>()
+  for (const indices of byDriver.values()) {
+    if (indices.length < 4) continue
+    const times = indices.map((i) => laps[i].lap_time)
+    const sorted = [...times].sort((a, b) => a - b)
+    const n = sorted.length
+    const q1 = sorted[floorDiv(n, 4)]
+    const q3 = sorted[floorDiv(3 * n, 4)]
+    const iqr = q3 - q1
+    const lower = q1 - 1.5 * iqr
+    const upper = q3 + 1.5 * iqr
+    for (const i of indices) {
+      const t = laps[i].lap_time
+      if (t < lower || t > upper) outliers.add(i)
+    }
+  }
+  return outliers
+}
+
+/** Whether a lap is "invalid" per the Streamlit rule (see parity note). */
+function isInvalid(lap: LapTime): boolean {
+  const flagged = lap as LapWithFlags
+  const accurate = flagged.is_accurate ?? true
+  const pitOut = flagged.is_pit_out_lap ?? false
+  return !accurate || pitOut
+}
+
+export interface LapFilterResult {
+  visible: LapTime[]
+  outlierCount: number // total outliers detected (regardless of toggle)
+  invalidCount: number // total invalid laps detected (regardless of toggle)
+}
+
+/**
+ * Apply the outlier + invalid toggles in place (no refetch).
+ * Hides outliers when `showOutliers` is false; hides invalid when
+ * `showInvalidLaps` is false. Returns the visible laps plus the total counts so
+ * the caller can render the "Hiding/Showing N …" status line.
+ */
+export function applyLapFilters(
+  laps: LapTime[],
+  showOutliers: boolean,
+  showInvalidLaps: boolean,
+): LapFilterResult {
+  const outlierIdx = detectOutlierIndices(laps)
+  let invalidCount = 0
+  const visible: LapTime[] = []
+
+  laps.forEach((lap, idx) => {
+    const outlier = outlierIdx.has(idx)
+    const invalid = isInvalid(lap)
+    if (invalid) invalidCount += 1
+    if (!showOutliers && outlier) return
+    if (!showInvalidLaps && invalid) return
+    visible.push(lap)
+  })
+
+  return { visible, outlierCount: outlierIdx.size, invalidCount }
+}

--- a/webapp/src/features/dashboard/queries.ts
+++ b/webapp/src/features/dashboard/queries.ts
@@ -1,0 +1,204 @@
+// TanStack Query hooks for the Dashboard data layer. All wrap the typed
+// openapi-fetch client and narrow the `unknown` telemetry bodies (see
+// lib/api/telemetry.ts). Historical data never changes, so `staleTime:
+// Infinity` — nav and UI toggles never trigger a refetch (perf target P4-3).
+//
+// Design: the store holds the SELECTED laps; `useLapTelemetries` turns that
+// selection map into N parallel queries (useQueries) and returns a
+// `{ driver: telemetry }` record, so click-to-load / fastest-laps are just
+// store writes and the charts fetch reactively.
+
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api/client'
+import { queryKeys } from '@/lib/queryKeys'
+import {
+  narrowCircuitDomination,
+  narrowDrivers,
+  narrowLapTelemetry,
+  narrowLapTimes,
+  narrowStringList,
+  type CircuitDomination,
+  type DriverOption,
+  type LapTelemetry,
+  type LapTime,
+} from '@/lib/api/telemetry'
+import type { DashboardSearch } from './search'
+
+const HISTORICAL = { staleTime: Infinity, gcTime: Infinity } as const
+
+/** Available GPs for a season. */
+export function useGps(year: number | undefined) {
+  return useQuery({
+    queryKey: year != null ? queryKeys.telemetry.gps(year) : ['telemetry', 'gps', 'idle'],
+    queryFn: async (): Promise<string[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/gps', {
+        params: { query: { year: year! } },
+      })
+      if (error) throw error
+      return narrowStringList(data, 'gps')
+    },
+    enabled: year != null,
+    ...HISTORICAL,
+  })
+}
+
+/** Available sessions for a GP. */
+export function useSessions(year: number | undefined, gp: string | undefined) {
+  return useQuery({
+    queryKey:
+      year != null && gp
+        ? queryKeys.telemetry.sessions(year, gp)
+        : ['telemetry', 'sessions', 'idle'],
+    queryFn: async (): Promise<string[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/sessions', {
+        params: { query: { year: year!, gp: gp! } },
+      })
+      if (error) throw error
+      return narrowStringList(data, 'sessions')
+    },
+    enabled: year != null && !!gp,
+    ...HISTORICAL,
+  })
+}
+
+/** Drivers who ran in a session (used to populate the driver multiselect). */
+export function useDrivers(
+  year: number | undefined,
+  gp: string | undefined,
+  session: string | undefined,
+) {
+  return useQuery({
+    queryKey:
+      year != null && gp && session
+        ? queryKeys.telemetry.drivers(year, gp, session)
+        : ['telemetry', 'drivers', 'idle'],
+    queryFn: async (): Promise<DriverOption[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/drivers', {
+        params: { query: { year: year!, gp: gp!, session: session! } },
+      })
+      if (error) throw error
+      return narrowDrivers(data)
+    },
+    enabled: year != null && !!gp && !!session,
+    ...HISTORICAL,
+  })
+}
+
+const ready = (s: DashboardSearch) => s.year != null && !!s.gp && !!s.session
+
+/** Lap-time series for the selected drivers (feeds the lap chart). */
+export function useLapTimes(search: DashboardSearch) {
+  const { year, gp, session, drivers } = search
+  // Sort the CSV (like the Streamlit original's `tuple(sorted(...))`) so
+  // VER,LEC and LEC,VER are one cache entry / one backend call, not two.
+  const driversCsv = [...drivers].sort().join(',')
+  const enabled = ready(search) && drivers.length > 0
+  return useQuery({
+    queryKey: enabled
+      ? queryKeys.telemetry.lapTimes(year!, gp!, session!, driversCsv)
+      : ['telemetry', 'lap-times', 'idle'],
+    queryFn: async (): Promise<LapTime[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/lap-times', {
+        params: { query: { year: year!, gp: gp!, session: session!, drivers: driversCsv } },
+      })
+      if (error) throw error
+      return narrowLapTimes(data)
+    },
+    enabled,
+    ...HISTORICAL,
+  })
+}
+
+/** Microsector-dominance map (needs >=2 drivers). */
+export function useCircuitDomination(search: DashboardSearch) {
+  const { year, gp, session, drivers } = search
+  const driversCsv = [...drivers].sort().join(',')
+  const enabled = ready(search) && drivers.length >= 2
+  return useQuery({
+    queryKey: enabled
+      ? queryKeys.telemetry.circuitDomination(year!, gp!, session!, driversCsv)
+      : ['telemetry', 'circuit-domination', 'idle'],
+    queryFn: async (): Promise<CircuitDomination | null> => {
+      const { data, error } = await api.GET('/api/v1/circuit-domination', {
+        params: { query: { year: year!, gp: gp!, session: session!, drivers: driversCsv } },
+      })
+      if (error) throw error
+      return narrowCircuitDomination(data)
+    },
+    enabled,
+    ...HISTORICAL,
+  })
+}
+
+export interface LapTelemetriesResult {
+  /** driver code → that driver's loaded-lap telemetry. */
+  byDriver: Record<string, LapTelemetry>
+  /** True while at least one selected lap is still loading. */
+  isLoading: boolean
+  /** True once at least one lap's telemetry has loaded. */
+  hasAny: boolean
+  /** True when the user has selected any lap (vs. the initial idle state). */
+  hasSelection: boolean
+  /** Selected drivers whose lap settled with NO telemetry (pit / out / incomplete
+   *  lap → backend `{}`) or errored — so the UI can explain the empty state
+   *  instead of spinning the loader forever. */
+  failedDrivers: string[]
+}
+
+/**
+ * Fetch telemetry for every currently-selected (driver, lap) in parallel.
+ * Turns the store's `selectedLapsPerDriver` map into N reactive queries so
+ * click-to-load and SELECT FASTEST LAPS need no manual prefetch.
+ */
+export function useLapTelemetries(
+  search: DashboardSearch,
+  selectedLapsPerDriver: Record<string, number>,
+): LapTelemetriesResult {
+  const { year, gp, session } = search
+  const entries = Object.entries(selectedLapsPerDriver)
+  const canFetch = ready(search)
+
+  const results = useQueries({
+    queries: entries.map(([driver, lap]) => ({
+      queryKey: canFetch
+        ? queryKeys.telemetry.lapTelemetry(year!, gp!, session!, driver, lap)
+        : ['telemetry', 'lap-telemetry', 'idle', driver, lap],
+      queryFn: async (): Promise<LapTelemetry | null> => {
+        const { data, error } = await api.GET('/api/v1/telemetry/lap-telemetry', {
+          params: { query: { year: year!, gp: gp!, session: session!, driver, lap_number: lap } },
+        })
+        if (error) throw error
+        return narrowLapTelemetry(data)
+      },
+      enabled: canFetch,
+      ...HISTORICAL,
+    })),
+  })
+
+  const byDriver: Record<string, LapTelemetry> = {}
+  const failedDrivers: string[] = []
+  let anyLoading = false
+  results.forEach((r, i) => {
+    if (!canFetch) return
+    const driver = entries[i][0]
+    if (r.isLoading) {
+      anyLoading = true
+      return
+    }
+    if (r.data) {
+      byDriver[driver] = r.data
+      return
+    }
+    // Settled (success with a `{}` body → null, or error after retries) but no
+    // telemetry: a pit/out/incomplete lap or a failed fetch.
+    if (r.isError || r.isSuccess) failedDrivers.push(driver)
+  })
+
+  return {
+    byDriver,
+    isLoading: anyLoading,
+    hasAny: Object.keys(byDriver).length > 0,
+    hasSelection: entries.length > 0,
+    failedDrivers,
+  }
+}

--- a/webapp/src/features/dashboard/search.ts
+++ b/webapp/src/features/dashboard/search.ts
@@ -1,0 +1,92 @@
+// URL search-param contract for the Dashboard. Selector state (year / GP /
+// session / drivers) lives in the URL so a link like
+// `?year=2023&gp=Monaco Grand Prix&session=R&drivers=VER,LEC` reproduces the
+// screen (the big UX unlock, U2-1). This is the single source of truth read by
+// the selectors toolbar AND every data query on the page.
+//
+// Two shapes, one boundary:
+//  - RawDashboardSearch — what lives in the URL / what `validateSearch` returns.
+//    `drivers` is a comma-joined string so the URL stays `?drivers=VER,LEC`.
+//  - DashboardSearch — the component-facing shape (`drivers` as an array).
+// The page converts raw↔component; every component only ever sees the array
+// shape. The 3-driver cap is enforced at this boundary, so a hand-edited URL
+// cannot exceed it.
+
+export const MAX_DRIVERS = 3
+
+/** Component-facing selection (drivers as an array). */
+export interface DashboardSearch {
+  year?: number
+  gp?: string
+  session?: string
+  drivers: string[]
+}
+
+/** URL / validated selection (drivers comma-joined). */
+export interface RawDashboardSearch {
+  year?: number
+  gp?: string
+  session?: string
+  drivers?: string
+}
+
+function coerceYear(raw: unknown): number | undefined {
+  if (raw == null || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isNaN(n) ? undefined : n
+}
+
+function coerceStr(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined
+}
+
+/**
+ * Normalise a raw drivers param (array or comma string) to a capped comma
+ * string. Driver codes are upper-cased and de-duplicated so a hand-edited URL
+ * like `?drivers=ver,VER,lec` can't produce duplicate chart series or a
+ * case-mismatch against the backend's upper-case driver rows.
+ */
+function capDriversCsv(raw: unknown): string | undefined {
+  let list: string[] = []
+  if (Array.isArray(raw)) list = raw.map(String).filter(Boolean)
+  else if (typeof raw === 'string' && raw !== '') list = raw.split(',').filter(Boolean)
+  const normalized = [...new Set(list.map((code) => code.trim().toUpperCase()).filter(Boolean))]
+  const capped = normalized.slice(0, MAX_DRIVERS)
+  return capped.length > 0 ? capped.join(',') : undefined
+}
+
+/** `validateSearch` for the /dashboard route: coerce raw router search. */
+export function validateDashboardSearch(raw: Record<string, unknown>): RawDashboardSearch {
+  const year = coerceYear(raw.year)
+  const gp = coerceStr(raw.gp)
+  const session = coerceStr(raw.session)
+  const drivers = capDriversCsv(raw.drivers)
+  return {
+    ...(year != null ? { year } : {}),
+    ...(gp ? { gp } : {}),
+    ...(session ? { session } : {}),
+    ...(drivers ? { drivers } : {}),
+  }
+}
+
+/** URL shape → component shape. */
+export function fromRaw(raw: RawDashboardSearch): DashboardSearch {
+  return {
+    year: raw.year,
+    gp: raw.gp,
+    session: raw.session,
+    drivers: raw.drivers ? raw.drivers.split(',').filter(Boolean).slice(0, MAX_DRIVERS) : [],
+  }
+}
+
+/** Component shape → URL shape (empty fields dropped so the URL stays clean). */
+export function toRaw(search: DashboardSearch): RawDashboardSearch {
+  const drivers =
+    search.drivers.length > 0 ? search.drivers.slice(0, MAX_DRIVERS).join(',') : undefined
+  return {
+    ...(search.year != null ? { year: search.year } : {}),
+    ...(search.gp ? { gp: search.gp } : {}),
+    ...(search.session ? { session: search.session } : {}),
+    ...(drivers ? { drivers } : {}),
+  }
+}

--- a/webapp/src/features/dashboard/store.ts
+++ b/webapp/src/features/dashboard/store.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+// Dashboard UI state (Zustand). This holds the user's SELECTIONS and view
+// toggles only — the telemetry DATA for each selected lap lives in TanStack
+// Query (keyed by driver+lap), so click-to-load is just `setLap()` and the
+// charts read the query cache. Mirrors the Streamlit session-state keys
+// `selected_laps_per_driver`, `show_outliers`, `show_invalid_laps`.
+//
+// Only `chartLayout` persists (a view preference); lap selections + filter
+// toggles reset per load, matching the Streamlit defaults.
+
+export type ChartLayout = 'grid' | 'stack'
+
+interface DashboardState {
+  /** driver code → the lap number whose telemetry is loaded. */
+  selectedLapsPerDriver: Record<string, number>
+  /** Merge one driver's loaded lap (click-to-load). */
+  setLap: (driver: string, lap: number) => void
+  /** Replace the whole map (SELECT FASTEST LAPS batch load). */
+  setFastestLaps: (laps: Record<string, number>) => void
+  /** Drop selections for drivers no longer chosen (call on selection change). */
+  pruneLaps: (drivers: string[]) => void
+  clearLaps: () => void
+
+  showOutliers: boolean
+  showInvalidLaps: boolean
+  toggleOutliers: () => void
+  toggleInvalidLaps: () => void
+
+  chartLayout: ChartLayout
+  toggleChartLayout: () => void
+}
+
+export const useDashboardStore = create<DashboardState>()(
+  persist(
+    (set) => ({
+      selectedLapsPerDriver: {},
+      setLap: (driver, lap) =>
+        set((s) => ({ selectedLapsPerDriver: { ...s.selectedLapsPerDriver, [driver]: lap } })),
+      setFastestLaps: (laps) => set({ selectedLapsPerDriver: laps }),
+      pruneLaps: (drivers) =>
+        set((s) => {
+          const allowed = new Set(drivers)
+          const next: Record<string, number> = {}
+          for (const [driver, lap] of Object.entries(s.selectedLapsPerDriver)) {
+            if (allowed.has(driver)) next[driver] = lap
+          }
+          return { selectedLapsPerDriver: next }
+        }),
+      clearLaps: () => set({ selectedLapsPerDriver: {} }),
+
+      showOutliers: false,
+      showInvalidLaps: true,
+      toggleOutliers: () => set((s) => ({ showOutliers: !s.showOutliers })),
+      toggleInvalidLaps: () => set((s) => ({ showInvalidLaps: !s.showInvalidLaps })),
+
+      chartLayout: 'grid',
+      toggleChartLayout: () =>
+        set((s) => ({ chartLayout: s.chartLayout === 'grid' ? 'stack' : 'grid' })),
+    }),
+    { name: 'f1sl.dashboard', partialize: (s) => ({ chartLayout: s.chartLayout }) },
+  ),
+)

--- a/webapp/src/lib/api/telemetry.ts
+++ b/webapp/src/lib/api/telemetry.ts
@@ -1,0 +1,93 @@
+// Telemetry response types + light runtime narrowing.
+//
+// The generated OpenAPI schema types every telemetry 200 body as `unknown`
+// (the backend ships no response models), so the typed client returns `unknown`
+// and we narrow here — one place, so callers get real types. The backend is the
+// same app (trusted), so these are light casts with safe fallbacks, not full
+// schema validation (that would be over-engineering for an in-house contract).
+//
+// --- WHERE TO CHANGE IF THE BACKEND CONTRACT CHANGES ---
+// backend/services/telemetry/telemetry_service.py (lap-times/lap-telemetry shapes)
+// backend/services/telemetry_service.py::get_circuit_domination_data (domination shape)
+
+/** One lap on the lap-time chart. `compound` is lowercase from FastF1. */
+export interface LapTime {
+  driver: string
+  lap_number: number
+  lap_time: number // seconds
+  is_valid: boolean // IsPersonalBest (see parity note in dashboard queries)
+  compound: string // 'soft' | 'medium' | 'hard' | 'intermediate' | 'inter' | 'wet' | 'unknown'
+}
+
+/** Full channel telemetry for a single (driver, lap). One call = all 7 channels. */
+export interface LapTelemetry {
+  driver: string
+  lap_number: number
+  distance: number[]
+  time: number[]
+  speed: number[]
+  throttle: number[]
+  brake: number[]
+  rpm: number[]
+  gear: number[]
+  drs: number[]
+}
+
+/** Microsector dominance map: colors[i] paints the segment point[i]→point[i+1]. */
+export interface CircuitDomination {
+  x: number[]
+  y: number[]
+  colors: string[]
+  drivers: { driver: string; color: string }[]
+}
+
+export interface DriverOption {
+  code: string
+  name: string
+}
+
+/** Pull a string[] out of a `{ [key]: string[] }` wrapper, tolerating a bad shape. */
+export function narrowStringList(data: unknown, key: string): string[] {
+  const record = data as Record<string, unknown> | null
+  const list = record?.[key]
+  return Array.isArray(list) ? (list as string[]) : []
+}
+
+export function narrowDrivers(data: unknown): DriverOption[] {
+  const record = data as { drivers?: unknown } | null
+  const list = record?.drivers
+  return Array.isArray(list) ? (list as DriverOption[]) : []
+}
+
+export function narrowLapTimes(data: unknown): LapTime[] {
+  const record = data as { lap_times?: unknown } | null
+  const list = record?.lap_times
+  return Array.isArray(list) ? (list as LapTime[]) : []
+}
+
+export function narrowLapTelemetry(data: unknown): LapTelemetry | null {
+  const record = data as LapTelemetry | null
+  // Every channel must be an array: the backend returns `{}` (→ null here) for
+  // laps without telemetry (pit / out / incomplete laps), and a partial body
+  // would crash the channel `.map(...)` downstream. All-or-nothing is safest.
+  if (
+    !record ||
+    !Array.isArray(record.distance) ||
+    !Array.isArray(record.time) ||
+    !Array.isArray(record.speed) ||
+    !Array.isArray(record.throttle) ||
+    !Array.isArray(record.brake) ||
+    !Array.isArray(record.rpm) ||
+    !Array.isArray(record.gear) ||
+    !Array.isArray(record.drs)
+  ) {
+    return null
+  }
+  return record
+}
+
+export function narrowCircuitDomination(data: unknown): CircuitDomination | null {
+  const record = data as CircuitDomination | null
+  if (!record || !Array.isArray(record.x) || !Array.isArray(record.colors)) return null
+  return record
+}

--- a/webapp/src/lib/queryKeys.ts
+++ b/webapp/src/lib/queryKeys.ts
@@ -7,6 +7,12 @@ export const queryKeys = {
     sessions: (year: number, gp: string) => ['telemetry', 'sessions', year, gp] as const,
     drivers: (year: number, gp: string, session: string) =>
       ['telemetry', 'drivers', year, gp, session] as const,
+    lapTimes: (year: number, gp: string, session: string, drivers: string) =>
+      ['telemetry', 'lap-times', year, gp, session, drivers] as const,
+    lapTelemetry: (year: number, gp: string, session: string, driver: string, lap: number) =>
+      ['telemetry', 'lap-telemetry', year, gp, session, driver, lap] as const,
+    circuitDomination: (year: number, gp: string, session: string, drivers: string) =>
+      ['telemetry', 'circuit-domination', year, gp, session, drivers] as const,
   },
   chat: {
     health: () => ['chat', 'health'] as const,


### PR DESCRIPTION
## What

The **Dashboard** telemetry screen (migration pilot, #34) — full parity with the Streamlit `pages/dashboard.py`, section 6.1 of the migration plan. First real feature window of the React SPA.

## Why

Proves the migration's data layer end to end: typed API client, URL-as-selector-state, ECharts theme, the design-system primitives, and the store/query split — the pattern every subsequent screen (#35+) copies.

## How

- **Feature folder** `webapp/src/features/dashboard/`: `DashboardPage` owns the URL (typed `validateSearch` on the `/dashboard` route); `search.ts` splits the URL shape (`?drivers=VER,LEC`) from the component shape (`string[]`); `store.ts` (Zustand) holds only the user's selections + toggles; `queries.ts` (TanStack Query, `staleTime: Infinity`) holds the data, turning the selected-laps map into N parallel `useQueries` fetches so click-to-load is just a store write.
- **Selectors**: cascading Year -> GP -> Session -> Drivers (max 3), bound to URL search params so a link reproduces the screen.
- **Lap chart** (ECharts): one line per driver, coloured by team colour (compound only in hover + legend, identical to Streamlit); click a point loads that lap's telemetry; SELECT FASTEST LAPS; client-side IQR outlier + invalid-lap toggles (pure transforms, no refetch); tyre-compound legend with per-driver counts; context caption.
- **7 telemetry charts** (Speed/Delta/Throttle/Brake/RPM/Gear/DRS) in a grid/stack layout with synced crosshairs; Delta interpolates onto the fastest driver's distance grid; DRS binarized; gear stepped. Per-chart collapse + maximize (design-system `ChartCard`).
- **Circuit domination**: SVG polyline from the backend `{x, y, colors}`, aspect-locked, coloured by microsector-fastest driver.
- **Loader**: the "waiting for telemetry" purple loader is preserved (shown before charts have data).
- Adds a typed telemetry API layer (`lib/api/telemetry.ts`), extends `queryKeys`, and adds an `ariaLabel` prop to `Combobox`/`MultiCombobox` for accessible selector names.

## Verification

- Local pipeline green: typecheck, lint, 33 unit tests (incl. the IQR detector), build, format.
- Screenshot-verified against the Streamlit reference (empty state + real 2023 Monaco Race, VER + LEC) — dark theme (light theme is the deferred E1 enhancement; dark-only at parity).
- Adversarial review (Fable): 2 P1 fixed before this PR — value-axis was forcing a 0 baseline (lap chart squashed) -> `scale: true`; pit/out laps returned an empty body and hung the loader -> the grid now shows a "no telemetry, pick another lap" notice. Plus re-select-same-value no longer clears the downstream selection, loaded laps clear on session change, driver codes are de-duped/sorted, and gear no longer clips neutral.

## Out of scope

- Light theme (E1), keyboard alternative to click-to-load (WCAG follow-up), and a separate `fix` PR for a Windows-only backend print crash discovered while verifying (telemetry endpoints return empty on cp1252 consoles).

Closes #34
