### PR TITLE
fix(telemetry): UTF-8 stdout so telemetry endpoints don't return empty on Windows

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,17 @@
 import logging
+import sys
 from contextlib import asynccontextmanager
+
+# Force UTF-8 on this process's streams. Several services print non-ASCII
+# glyphs (e.g. telemetry_service's "✓"/"⚠"/"❌"); on a Windows cp1252 console
+# those `print(...)` calls raise UnicodeEncodeError, and because they sit inside
+# broad try/except blocks the crash is swallowed and the endpoint silently
+# returns empty data (the whole telemetry Dashboard shows "no data"). The
+# hasattr guard keeps this safe under a captured stdout (e.g. pytest).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
 from backend.core.config import FRONTEND_URL, mcp_enabled


### PR DESCRIPTION
Closes #89. Force UTF-8 on the API process's stdout/stderr so the non-ASCII glyphs printed by `telemetry_service` don't raise `UnicodeEncodeError` on a Windows cp1252 console (which the broad except swallowed, making `get_lap_times` return `[]` and the Dashboard show no data). Guarded by `hasattr` for captured streams under pytest. Verified: 148 laps for 2023 Monaco R (VER,LEC) without `PYTHONUTF8`. Found while verifying #34.