### PR TITLE
perf(telemetry): reuse loaded FastF1 sessions + non-blocking endpoints

### DIFF
--- a/backend/api/v1/endpoints/circuit_domination.py
+++ b/backend/api/v1/endpoints/circuit_domination.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/circuit-domination", tags=["telemetry"])
 
 
 @router.get("")
-async def get_circuit_domination(
+def get_circuit_domination(
     year: int = Query(..., ge=2018, le=2030, description="Racing season year"),
     gp: str = Query(..., min_length=1, description="Grand Prix name (e.g., 'Spain', 'Belgium')"),
     session: str = Query(..., pattern="^(FP1|FP2|FP3|Q|R|S|SQ)$", description="Session type"),

--- a/backend/api/v1/endpoints/telemetry.py
+++ b/backend/api/v1/endpoints/telemetry.py
@@ -10,14 +10,22 @@ from backend.services.telemetry.telemetry_service import (
     get_lap_times,
     get_telemetry_data_from_db,
 )
+from backend.services.telemetry.session_cache import prewarm_session
 from backend.utils.laps_cache import get_laps_df
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 router = APIRouter(prefix="/telemetry", tags=["telemetry"])
 
+# NOTE (perf): these handlers are plain ``def`` (NOT ``async def``) on purpose.
+# They call synchronous, CPU/IO-blocking FastF1 code; a ``def`` handler runs in
+# Starlette's threadpool, so several telemetry requests fired by one selection
+# (lap-times + N lap-telemetry + circuit-domination) run concurrently instead of
+# serializing on the event loop — and a slow FastF1 parse no longer freezes the
+# whole server. See session_cache.py for the parse-once half of the fix.
+
 
 @router.get("/data")
-async def get_telemetry_data(
+def get_telemetry_data(
     year: int = Query(...),
     gp: str = Query(...),
     session: str = Query(...),
@@ -28,8 +36,26 @@ async def get_telemetry_data(
     return data
 
 
+@router.post("/prewarm", status_code=202)
+def prewarm(
+    background_tasks: BackgroundTasks,
+    year: int = Query(...),
+    gp: str = Query(...),
+    session: str = Query(...),
+):
+    """Warm the FastF1 session cache for (year, gp, session) in the background.
+
+    The frontend calls this when the user picks a session, so the ~2-15s parse
+    starts while they choose drivers — by the time lap-times/telemetry fire, the
+    session is already loaded and the charts fall in instead of hanging.
+    Returns 202 immediately; the load runs after the response is sent.
+    """
+    background_tasks.add_task(prewarm_session, year, gp, session)
+    return {"status": "prewarming", "year": year, "gp": gp, "session": session}
+
+
 @router.get("/gps")
-async def get_gps(year: int = Query(..., description="Year of the season (e.g., 2024)")):
+def get_gps(year: int = Query(..., description="Year of the season (e.g., 2024)")):
     """
     Get available Grand Prix events for a specific year.
     """
@@ -38,7 +64,7 @@ async def get_gps(year: int = Query(..., description="Year of the season (e.g., 
 
 
 @router.get("/sessions")
-async def get_sessions(
+def get_sessions(
     year: int = Query(..., description="Year of the season"),
     gp: str = Query(..., description="Grand Prix name")
 ):
@@ -50,7 +76,7 @@ async def get_sessions(
 
 
 @router.get("/drivers")
-async def get_drivers(
+def get_drivers(
     year: int = Query(..., description="Year of the season"),
     gp: str = Query(..., description="Grand Prix name"),
     session: str = Query(..., description="Session type (FP1, FP2, FP3, SQ, Q, S, R)")
@@ -77,7 +103,7 @@ async def get_drivers(
         "asks to FORECAST a future race lap."
     ),
 )
-async def get_laps(
+def get_laps(
     year: int = Query(..., description="Season year (2023, 2024 or 2025)."),
     gp: str = Query(..., description="Grand Prix name (city/circuit form preferred, country names also accepted)."),
     session: str = Query(
@@ -108,7 +134,7 @@ async def get_laps(
         "compare_drivers instead."
     ),
 )
-async def get_lap_telemetry_endpoint(
+def get_lap_telemetry_endpoint(
     year: int = Query(..., description="Season year (2023, 2024 or 2025)."),
     gp: str = Query(..., description="Grand Prix name (city/circuit form preferred)."),
     session: str = Query(

--- a/backend/services/telemetry/fastf1_client.py
+++ b/backend/services/telemetry/fastf1_client.py
@@ -1,6 +1,7 @@
-import fastf1
 import pandas as pd
 from typing import List, Optional
+
+from backend.services.telemetry.session_cache import get_loaded_session
 
 
 class SessionData:
@@ -15,9 +16,11 @@ class SessionData:
         self.session_data = self._load_session()
 
     def _load_session(self):
-        session = fastf1.get_session(self.year, self.circuit, self.current_session)
-        session.load(telemetry=self.telemetry, laps=self.laps, weather=self.weather)
-        return session
+        # Delegates to the process-wide session cache: the same FastF1 session is
+        # parsed once and reused across the 4-6 SessionData objects a single
+        # dashboard interaction builds (see session_cache.py). Read-only after
+        # load, so sharing one object across requests is safe.
+        return get_loaded_session(self.year, self.circuit, self.current_session)
 
     def get_driver_lap_times(self, drivers: Optional[List[str]] = None):
         """

--- a/backend/services/telemetry/session_cache.py
+++ b/backend/services/telemetry/session_cache.py
@@ -1,0 +1,91 @@
+"""In-process cache of loaded FastF1 sessions.
+
+Loading + parsing a FastF1 session (telemetry + laps + weather) costs 2-15s and,
+without a cache, runs on EVERY ``SessionData(...)`` construction — from disk each
+time. A single dashboard interaction builds 4-6 ``SessionData`` objects for the
+SAME session (lap-times, each lap-telemetry, circuit-domination, driver list), so
+the same parse used to run 4-6x, serialized. This caches the loaded session by
+``(year, gp, session)`` with a small LRU and a per-key lock, so concurrent
+requests for the same session wait for ONE load instead of stampeding.
+
+Loaded FastF1 sessions are read-only after ``load()``, so sharing a single object
+across requests is safe (all downstream use is reads: ``laps.pick_drivers``,
+``get_car_data``, ``pick_fastest`` …).
+
+--- WHERE TO CHANGE IF THE LOAD CONTRACT CHANGES ---
+``fastf1_client.SessionData._load_session`` delegates here; the endpoints just
+build ``SessionData`` as before. Raise ``_MAXSIZE`` only with memory in mind (a
+race session with telemetry is hundreds of MB).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from typing import Dict, Tuple
+
+import fastf1
+
+# A race session with telemetry is hundreds of MB; 2 covers the common
+# dashboard-then-comparison pattern without unbounded growth.
+_MAXSIZE = 2
+
+_Key = Tuple[int, str, str]
+
+_cache: "OrderedDict[_Key, object]" = OrderedDict()
+_cache_lock = threading.Lock()          # guards _cache structure
+_key_locks: Dict[_Key, threading.Lock] = {}
+_key_locks_guard = threading.Lock()
+
+
+def _lock_for(key: _Key) -> threading.Lock:
+    """Return the dedicated load-lock for a key, creating it once."""
+    with _key_locks_guard:
+        lock = _key_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _key_locks[key] = lock
+        return lock
+
+
+def get_loaded_session(year: int, gp: str, session: str):
+    """Return a fully-loaded FastF1 Session for (year, gp, session), cached.
+
+    The first call for a key parses from disk (slow); later calls return the same
+    object instantly. Concurrent first-calls for the same key are serialized by a
+    per-key lock so the parse runs exactly once (no thundering herd).
+    """
+    key: _Key = (year, gp, session)
+
+    # Fast path: already cached.
+    with _cache_lock:
+        if key in _cache:
+            _cache.move_to_end(key)
+            return _cache[key]
+
+    # Slow path: exactly one loader per key.
+    with _lock_for(key):
+        # Another thread may have loaded it while we waited for the lock.
+        with _cache_lock:
+            if key in _cache:
+                _cache.move_to_end(key)
+                return _cache[key]
+
+        loaded = fastf1.get_session(year, gp, session)
+        loaded.load(telemetry=True, laps=True, weather=True)
+
+        with _cache_lock:
+            _cache[key] = loaded
+            _cache.move_to_end(key)
+            while len(_cache) > _MAXSIZE:
+                _cache.popitem(last=False)
+        return loaded
+
+
+def prewarm_session(year: int, gp: str, session: str) -> None:
+    """Load a session into the cache without returning it (fire-and-forget).
+
+    Called from the prewarm endpoint so the parse starts while the user is still
+    picking drivers, turning "30s after the click" into "the charts fall in".
+    """
+    get_loaded_session(year, gp, session)

--- a/backend/services/telemetry/telemetry_service.py
+++ b/backend/services/telemetry/telemetry_service.py
@@ -180,66 +180,14 @@ def get_lap_times(year: int, gp: str, session: str, drivers: List[str]) -> List[
 
         print(f"Filtered to {len(laps_filtered)} valid laps (excluded pit laps and inaccurate laps)")
 
-        # Additional filter: Verify each lap has COMPLETE telemetry data for ALL TELEMETRY GRAPHS
-        # This ensures that all telemetry graphs (Speed, Throttle, Brake, RPM, Gear, DRS, Delta)
-        # can be painted for the selected laps.
-        #
-        # NOTE: X, Y (GPS) are NOT required here because:
-        # - Circuit Domination uses its own API endpoint (get_circuit_domination)
-        # - Distance can be calculated from Speed and Time if GPS is missing
-        #
-        # Required columns from FastF1 for telemetry graphs:
-        # - Speed: For speed graph
-        # - Throttle: For throttle graph
-        # - Brake: For brake graph
-        # - RPM: For RPM graph
-        # - nGear: For gear graph (FastF1 uses 'nGear' not 'Gear')
-        # - DRS: For DRS graph
-        # - Time: For delta graph and distance calculation
-
-        REQUIRED_COLUMNS = ['Speed', 'Throttle', 'Brake', 'RPM', 'nGear', 'DRS', 'Time']
-
-        laps_with_complete_telemetry = []
-        for idx, lap_data in laps_filtered.iterrows():
-            try:
-                # Try to get telemetry for this lap
-                telemetry = lap_data.get_car_data()
-
-                # Check if telemetry exists and is not empty
-                if telemetry is None or telemetry.empty:
-                    continue
-
-                # Verify ALL required columns exist
-                missing_columns = [col for col in REQUIRED_COLUMNS if col not in telemetry.columns]
-                if missing_columns:
-                    print(f"Lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')} missing columns: {missing_columns}")
-                    continue
-
-                # Verify each required column has valid data (not all NaN)
-                has_valid_data = True
-                for col in REQUIRED_COLUMNS:
-                    if telemetry[col].isna().all():
-                        print(f"Lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')}: column '{col}' has no valid data")
-                        has_valid_data = False
-                        break
-
-                # Only include lap if all columns have valid data
-                if has_valid_data:
-                    laps_with_complete_telemetry.append(idx)
-
-            except Exception as e:
-                # Skip laps that fail to load telemetry
-                print(f"Skipping lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')}: {e}")
-                continue
-
-        # Filter to only laps with complete telemetry data
-        if laps_with_complete_telemetry:
-            laps_filtered = laps_filtered.loc[laps_with_complete_telemetry]
-            print(f"✓ Verified {len(laps_filtered)} laps have COMPLETE telemetry data for ALL graphs")
-        else:
-            print("⚠ No laps with complete telemetry data found")
-            laps_filtered = pd.DataFrame()  # Empty DataFrame
-
+        # NOTE (perf): the previous per-lap telemetry validation loop
+        # (`lap.get_car_data()` for EVERY candidate lap, ~50-150 pandas slices per
+        # request, 5-20s on its own even with the session cached) was removed. It
+        # only pre-filtered laps that lack complete telemetry — a guard the UI now
+        # handles gracefully: /lap-telemetry returns {} for such a lap and the
+        # dashboard shows a "pick another lap" notice (since #34). The cheap
+        # IsAccurate + LapTime + no-pit filter above is sufficient to build the
+        # chart, and dropping this loop is the single biggest lap-times speedup.
         result = []
 
         # Iterate through filtered laps

--- a/backend/services/telemetry_service.py
+++ b/backend/services/telemetry_service.py
@@ -15,6 +15,7 @@ import os
 import warnings
 
 from backend.core.driver_colors import get_driver_color
+from backend.services.telemetry.session_cache import get_loaded_session
 
 # Suppress specific FastF1/pandas warnings
 warnings.filterwarnings('ignore', message='.*fill_value.*')
@@ -94,9 +95,9 @@ def get_circuit_domination_data(
     try:
         logger.info(
             f"Requesting session from FastF1: {year} {gp} {session_type}")
-        session = fastf1.get_session(year, gp, session_type)
-        logger.info("Loading session data (this may take time on first run)...")
-        session.load()
+        # Reuse the process-wide session cache (parse once, shared with the
+        # telemetry endpoints) instead of a fresh load per request.
+        session = get_loaded_session(year, gp, session_type)
         logger.info("Session loaded successfully")
     except Exception as e:
         logger.error(f"Failed to load session: {e}", exc_info=True)
@@ -394,10 +395,9 @@ def fetch_lap_telemetry(
     logger.info(
         f"Fetching lap telemetry: {year} {gp} {session_type} - {driver} {lap_description}")
 
-    # Load session
+    # Load session (reuse the process-wide session cache)
     try:
-        session = fastf1.get_session(year, gp, session_type)
-        session.load()
+        session = get_loaded_session(year, gp, session_type)
         logger.info(f"Session loaded: {year} {gp} {session_type}")
     except Exception as e:
         logger.error(f"Failed to load session: {e}")


### PR DESCRIPTION
Backend performance for the Dashboard (polish plan PR1). Root cause: telemetry endpoints were `async def` calling blocking FastF1, so the 4-6 requests one selection fires serialized on the event loop, each re-parsing the same session (~13s each).

- **Session cache** (`session_cache.py`, LRU 2 + per-key lock): parse a FastF1 session once, reuse across lap-times / each lap-telemetry / circuit-domination / drivers. Verified: 2nd call ~13s -> **0.01s**.
- **`async def` -> `def`** on the telemetry + circuit-domination endpoints -> run in the threadpool, concurrent, no event-loop freeze.
- **Removed the per-lap `get_car_data()` validation loop** in `get_lap_times` (~50-150 pandas slices/request); laps without telemetry are handled by the dashboard pick-another-lap notice (since #34).
- **`POST /telemetry/prewarm`** to warm a session in the background on session-select (frontend wires it in the Dashboard-elevation PR).

Real-run tested (2023 Monaco R VER,LEC): lap-times 148 laps, lap-telemetry 287 pts, circuit-domination 578 pts, all correct; backend.main imports cleanly (no circular import). Effect: a full interaction goes from ~60s of serialized re-parses to one ~13s parse + everything else instant.