### PR TITLE
docs(migration): design-first specs for the 5 unmigrated tabs

### DIFF
--- a/docs/migration/design-specs/chat-voice.md
+++ b/docs/migration/design-specs/chat-voice.md
@@ -1,0 +1,171 @@
+# AI Chat + Voice — Design-First Spec (issues #39 + #40)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit AI Chat + Voice functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared vocabulary from `strategy.md`/`model-lab.md` (`ActionBadge`, `CompoundPill`, `ConfidenceDial`, `NlpMessageCard`, state tiers, deep-links-never-auto-fire). Sources: `frontend/pages/chat.py` (532), `frontend/components/chatbot/*` (~1.5k), `frontend/components/voice/*` + `streamlit_audio_viz` (React+ogl orb), `frontend/services/{chat_service,voice_api}.py`, `frontend/utils/{chat_state,chat_navigation,report_storage}.py`, `backend/api/v1/endpoints/{chat,voice}.py`, `backend/services/chatbot/chat_engine.py`, `backend/models/tool_schemas.py`, MIGRATION_PLAN §6.6/§6.7/§6.8/E4/E5/E8/W7/W8, `st_6_AI_Chat.png`.
+
+## 1. Purpose & the job
+
+Chat is the **conversational front door to the entire model family**: an analyst that CALLS the real tools. The backend chat engine is an MCP client exposing 14 tools (6 predictors + orchestrator + RAG regulations + FastF1 telemetry/lap-times/compare/race-data + listings) to the LLM via OpenAI `tools=`; the SPA speaks **REST/SSE only** and never touches MCP. Its job: *"Ask anything about a race moment in plain language, watch the system pick and run the right instrument, and get the evidence (metrics, strategy cards, INLINE charts) plus a plain-English read - then take the whole session home as a Markdown report."* Voice is the same analyst hands-free, fronted by the audio-reactive orb - the demo's emotional signature. This surface is the TFG agent work made tangible; it must feel like a serious Claude/ChatGPT-class client, not a widget.
+
+**FIVE KEY DISCOVERIES in the Streamlit source** that drive this design:
+1. **Stop is cosmetic today.** The Stop button only sets `chat_should_stop`, checked *between* SSE events (`chat.py:337-339`); the HTTP stream and the LLM keep running server-side. The SPA's `postStream` + AbortController + `reader.cancel()` (`sse.ts:54-57`) actually tears the connection down - a real Stop, free.
+2. **The status-poller thread is a Streamlit workaround.** A daemon thread polls `GET /chat/status` every 1 s to relabel the spinner (`chat.py:99-128`) because Streamlit can't consume the `stage` SSE events mid-rerun. The stream already carries them (`chat_engine.py:158-314`) - the SPA renders stages inline and drops the poller AND the endpoint dependency.
+3. **"Rename" doesn't exist, and saved chats collide.** §6.6 lists "saved-chat list + rename"; `chat_sidebar.py` has no rename UI, and chats are keyed by an auto-generated *name* (first 30 chars of message 1, `chat_state.py:159-197`) - two chats opening with the same words silently overwrite each other. The SPA stores id-keyed records with a `title` field + real inline rename: satisfies the parity row AND fixes the collision bug.
+4. **The voice loop is tool-less.** `POST /voice-chat` goes straight to the LLM (`voice.py:257-345`, no MCP dispatch): "tyre status for VER lap 30" *typed* runs the TCN; *spoken*, it gets improvised prose. The three building blocks (`/transcribe`, `/tool-message-stream`, `/synthesize`) already exist - the SPA can compose a tool-aware voice loop client-side (§7.1).
+5. **The orb hot-mics on mount.** `useAudioLevel.start()` fires as soon as the orb renders (`AudioOrb.tsx:53-57`) - the mic is live with no visible indicator. The SPA requests mic permission only on entering Voice mode and shows an explicit listening state.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+### 2.1 Chat (§6.6)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | Sidebar Text/Voice toggle (`chat_sidebar.py:38-58`) | KEEP | Segmented `Tabs` at sidebar top; mode in URL (`?mode=voice`). |
+| 2 | New Chat button (`:61-71`) | KEEP | Primary `Button`; also `⌘/Ctrl+Shift+O`. |
+| 3 | Saved-chat list, active highlight, load, delete-current (`:74-113`) | KEEP + FIX | Id-keyed `ConversationList` (Discovery 3): inline rename (pencil / double-click), per-row delete with `Toast`+undo, active ring. Auto-title from first message preserved (`chat_state.py:176-180` logic ported). |
+| 4 | Reports(n) expander: list + download + delete + clear all (`:116-145`) | KEEP | `ReportsPanel` disclosure; rows = timestamp · chat title · size, download + delete actions. Cap 20 (parity, `report_storage.py:50-52`). |
+| 5 | Empty state: hint line + 4 example-prompt chips (`chat_history.py:199-236`) | **KEEP VERBATIM** | Same copy + behavior (click = send that exact prompt). Chips: Tyre status → "Tyre status for VER at lap 30 in Bahrain" · Pace prediction → "Predict pace for LEC lap 25 Monaco" · FIA regulation → "What do articles 55 and 57 say about safety car procedures?" · Full strategy → "Full strategy for NOR lap 40 Australia risk 0.7". Hint: "Mention a **driver**, **GP**, and **lap** to trigger an analysis, or try an example below." Chip click auto-sends (explicit in-page action - allowed; deep links are not, §5.4). |
+| 6 | `st.chat_input` Enter-to-send (`chat_input.py:31-37`) | KEEP + IMPROVE | `Composer`: autosize textarea, Enter=send, Shift+Enter=newline, disabled-with-Stop while streaming. |
+| 7 | Image attach behind expander, png/jpg/jpeg → base64 data-URI (`chat_input.py:20-28`, `chat_service.py:23-48`) | KEEP + IMPROVE | Paperclip popover with `FileDrop` + paste-from-clipboard + drag-anywhere-onto-thread; preview `AttachmentChip` with remove. Client-side downscale to ≤768 px JPEG before send (the Qwen3-VL sizing rationale from `chat_navigation.py:85-101`, now client-side). |
+| 8 | Latest user image rides along on text-only follow-ups (`chat.py:297-306`) | KEEP | Subtle but load-bearing: `_last_user_image` port in the send builder, so "and what about the braking zones?" still sees the screenshot. |
+| 9 | SSE streaming, token-by-token bubble (`chat.py:309-369`, `chat_service.py:311-377`) | KEEP (free upgrade) | `useChatStream` on `postStream` (`lib/api/sse.ts` - already built). Tokens append to a live `Markdown` bubble; no rerun-per-token. |
+| 10 | Stage narration via /chat/status poll thread (`chat.py:33-52,99-128`) | KEEP labels / DROP poller | `StageTicker` renders the inline `stage` events with the SAME humanized copy map (`_STAGE_LABELS`, ported verbatim - it's good copy). Poller + `X-Request-Id` plumbing dropped (Discovery 2; keep sending a uuid header for backend logs). |
+| 11 | Stop button, partial kept + "_[Response stopped by user]_" marker (`chat.py:68-96,349-350`) | KEEP + FIX | Real abort (Discovery 1). Same marker text appended to the persisted partial. Esc also stops. |
+| 12 | Tool-call badge per invoked tool (`tool_result_renderer.py:38-46`) | KEEP + IMPROVE | `ToolBadge`: lucide icon per tool family + label + state (running pulse → done / error). Appears at `calling_<tool>` stage, resolves when `tool_result` lands - the badge IS the tool timeline. |
+| 13 | Tool result renderers by display_type: metrics / strategy_card / table / text / chart (`tool_result_renderer.py:331-337`) | KEEP (reshaped) | `ToolResultCard` switches on `display_type` (§6.3). strategy_card renders with the **shared Strategy vocabulary**: `ActionBadge` + confidence + scenario scores + reasoning disclosure - a mini `DecisionCard`, same visual language as `/strategy`. |
+| 14 | Inline charts for lap-times / telemetry / compare / race-data, Plotly (`chart_builders.py`) | KEEP (re-engined) | `InlineChart` + TS option-builder dispatcher → ECharts (F1-1, §6.3). Compound-tinted markers, pit-stop markLines, pit-lap outlier masking all ported as pure lib fns with tests. |
+| 15 | Graceful tool-error: red error card + LLM plain-English follow-up (`tool_result_renderer.py:244-271`, dossier #36) | KEEP (both halves) | `ToolErrorCard` (danger left edge, tool name, message) for the `{"error": …}` envelope; the token stream that follows IS the LLM explanation - render both, never swallow either. |
+| 16 | Report generation → save + Markdown download; reports in sidebar (`chat.py:382-423`, `chat_service.py:381-426`) | KEEP + IMPROVE (=E4) | One click: header action "Generate report" → button spinner → saves to Reports + triggers download + `Toast`. Two-step dance dropped (E4 accepted). Same backend call: `POST /tool-message` with the fixed summary instruction, temp 0.4, max_tokens 4000. |
+| 17 | System prompt + injected F1 context (`chat_system_prompt`, `chat_f1_context`) | KEEP (clarified) | The real system prompt lives server-side (`chat_engine._SYSTEM_PROMPT`); the session key is vestigial (always ""). SPA keeps only `context{}` on the wire - held by `ContextCapsule` (§5.4) and the chat record. |
+| 18 | LLM health warning banner (`chat.py:450-455`) | KEEP (demoted) | `GET /chat/health` on mount (Query, staleTime 30 s) → amber "LLM offline" `Pill` in the header; non-blocking, composer stays usable. |
+| 19 | History/saved/reports lost on refresh | IMPROVE (accepted §6.8) | Chat slice persisted (§6.5). Voice stays ephemeral (parity). |
+| 20 | Cross-page "Ask AI" pending-message flow, auto-send (`chat_navigation.py:15-72`, `chat.py:167-223,515-527`) | KEEP (re-gated) | Deep-link INTO chat with context + optional image; lands as prefilled, focused composer + `ContextCapsule` - **one Enter to fire, never auto-send** (§5.4; documented deviation, consistent with the sibling-spec rule that deep links never auto-fire LLM calls). |
+| 21 | Empty-SSE defensive fallback message (`chat.py:358-363`) | KEEP | If a stream ends with no tokens and no tool_result, render the same "no response received" notice instead of a blank bubble. |
+| 22 | Injected bubble/sidebar CSS, python-markdown rendering (`chat_history.py:21-193`, `chat_message.py`) | DROP | `Markdown` component + tokens carry it; zero injected CSS. |
+
+### 2.2 Voice (§6.7)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 23 | Audio-reactive orb, React+ogl Iridescence shader, states idle/recording/processing/playing (`streamlit_audio_viz/frontend/src/*`) | **KEEP - lift verbatim** | It is already React+TS. Drop the `streamlit-component-lib` bridge (`index.tsx`), keep `AudioOrb.tsx` + `Iridescence.tsx` + `useAudioLevel.ts` + `styles.css` as `features/chat/voice/orb/`. Delete the `console.log` debug (`AudioOrb.tsx:31-37`). Mic capture gated on explicit mode entry (Discovery 5) + visible LISTENING chip. `prefers-reduced-motion` → static gradient orb, level-driven only. |
+| 24 | Voice picker: curated 4-voice catalog, never calls the API (`voice_chat.py:16-22,292-313`) | KEEP + FIX row | §6.7 says "picker from `GET /voice/voices`" but Streamlit hardcodes `VOICE_CATALOG`. SPA: curated 4 as the default list (same ids + descriptions), "All voices…" expands from the real endpoint. Row satisfied for the first time. |
+| 25 | Mic record via `st.audio_input`, dedupe vs `last_processed_audio` (`voice_input.py:14-65`) | IMPROVE | `MicBar`: 44 px record toggle + live mono timer + cancel; MediaRecorder (webm/opus - backend accepts `.webm`, `voice_api.py:274-280`). Dedupe hack dies with Streamlit reruns. |
+| 26 | Full loop `POST /voice-chat` (STT→LLM→TTS), voice form field (`voice_api.py:194-246`) | KEEP (parity path) | `useVoiceSession` state machine drives it. Tool-aware composed loop is §7.1 (needs a 3-LOC backend additive for voice selection). |
+| 27 | Exchange history: transcript bubble + reply bubble + MP3 player, latest autoplays (`voice_chat.py:94-181`) | KEEP (reshaped) | `VoiceExchangeCard` in the same thread grammar: transcript (user), reply (assistant), replay button, `processing_time` chip. One shared `HTMLAudioElement` + analyser feeds the orb; autoplay latest only. |
+| 28 | Services-ready guard: poll /voice/health up to 60 s with warming copy (`voice_chat.py:256-289`) | KEEP + IMPROVE | Warmup panel over the orb: elapsed + "warming voice services (first launch downloads models)…", 2 s poll; record disabled until `stt_ready && tts_ready`. Failure → error card with the health JSON behind a disclosure. |
+| 29 | Playing badge tied to `is_playing`, reset on next recording (`voice_chat.py:198-236,479-485`) | KEEP | `useVoiceSession` status drives a single state chip (LISTENING / TRANSCRIBING / THINKING / SPEAKING) + orb state - one source of truth, no flicker. |
+| 30 | Voice report button (history → chat shape → generate_report) (`voice_chat.py:316-366`) | KEEP | Same one-click report treatment as #16. |
+| 31 | Clear history (`voice_chat.py:520-532`) | KEEP | Ghost button + confirm. Voice history ephemeral (§6.8 parity). |
+| 32 | Page-level iframe CSS nukes for the orb (`voice_chat.py:396-432`) | DROP (cause gone) | The orb is a native component now; no iframe, no blanket CSS overrides. |
+
+Zero functional loss; three deliberate re-gatings (#20 no auto-fire, #24 real endpoint, #23 mic consent), each documented here.
+
+## 3. Layout & IA
+
+Route `/chat` (stub exists, `router.tsx:70-74`). One page, two modes; the sidebar and thread grammar are shared so switching modes feels like changing instruments, not pages.
+
+```
+┌ SIDEBAR (acrylic; Sheet overlay <1024px) ┐┌ THREAD ─────────────────────────────────────┐
+│ [ 💬 Text ┃ 🎙 Voice ]  (segmented)      ││ header: "AI Chat"  (LLM offline·pill)       │
+│ [+ New chat]                             ││        [⤓ Generate report] (≥2 messages)   │
+│ HISTORY (3)                              ││                                             │
+│ ▸ Tyre status for VER at lap 3…  ✎ ⌫    ││ ┌ user ────────────────────── [img chip] ┐  │
+│   Predict pace for LEC lap 25…           ││ │ Full strategy for NOR lap 40 Australia │  │
+│   What do articles 55 and 57…            ││ └─────────────────────────────────────────┘ │
+│ REPORTS (2) ▾                            ││ ┌ assistant ──────────────────────────────┐ │
+│   07/14 09:12 · Tyre status…  ⬇ ✕       ││ │ [⛭ Recommend Strategy ●done]  ToolBadge │ │
+│                                          ││ │ ┌ mini DecisionCard ──────────────────┐ │ │
+│ (voice mode: same sidebar,               ││ │ │ [PIT_NOW] conf 82% · scenarios list │ │ │
+│  history list stays text-chats)          ││ │ │ ▸ reasoning                        │ │ │
+└──────────────────────────────────────────┘│ │ └────────────────────────────────────┘ │ │
+                                            │ │ Streamed prose (Markdown, live)…       │ │
+  EMPTY STATE (no messages):                │ └─────────────────────────────────────────┘ │
+  hint line + 4 example chips (2×2),        │ streaming: StageTicker "Running the full    │
+  verbatim copy (§2.1 #5)                   │ strategy orchestrator (5 agents + LLM)..."  │
+                                            │ ┌ COMPOSER ───────────────────────────────┐ │
+                                            │ │ [📎][img ×] Ask me anything about F1…   │ │
+                                            │ │            [▸ Send] / [⏹ Stop] while ⚡ │ │
+                                            │ └─────────────────────────────────────────┘ │
+                                            └─────────────────────────────────────────────┘
+VOICE MODE (same shell; thread center swaps):
+│   ╭────────╮   state chip: ● LISTENING / TRANSCRIBING / THINKING / SPEAKING │
+│   │  ORB   │   voice: [Aria - US female, conversational ▾]  (All voices…)  │
+│   ╰────────╯   warming overlay until stt_ready && tts_ready                │
+│   VoiceExchangeCards (transcript → reply · ▶ replay · 3.2s chip)           │
+│   MicBar: [ ● Record  00:07 ]  [✕ cancel]        [⤓ report] [⌫ clear]     │
+```
+
+**States:** Empty (hint + 4 chips; composer focused) · Streaming (StageTicker narrates stages; ToolBadge pulses on `calling_*`; tokens fill the bubble; composer → Stop; thread `aria-live=polite`) · Tool-error (ToolErrorCard + the streamed LLM explanation below it) · Transport error (Toast + inline "retry last message" on the failed bubble; input preserved) · Rate-limited (429 → Toast "Chat is limited to 20 requests/min"; composer stays) · LLM offline (amber header pill; send still attempts) · Voice warming (orb dimmed + progress copy; record disabled) · Voice error (per-stage: transcription failed → retry keeps the recording; TTS failed → text reply still shown with a "couldn't speak this" note) · Empty voice (orb idle-breathing + "hold Record and ask about a race moment").
+
+## 4. Components
+
+**Reuse as-is:** `Markdown` (message prose + reports), `Pill`, `Toast`, `FileDrop`, `Button`, `Card`, `Tabs` (mode toggle), `Tooltip`, `Skeleton`, `EmptyState`, `DataTable` (table display_type), `Sheet` (in `Modal.tsx` - mobile sidebar), **`postStream`** (`lib/api/sse.ts` - built for exactly this), ECharts + `F1_THEME` + `tireColors`, `lib/drivers.ts` (team colours in chart series).
+
+**Shared vocabulary from sibling specs (consume, don't fork):** `ActionBadge` + `ConfidenceDial` + `CompoundPill` (strategy.md §4) render the `strategy_card` display type - `recommend_strategy` / `predict_tire` / `predict_pit` results in chat look EXACTLY like their Strategy/Lab counterparts at `size="sm"`. `NlpMessageCard` (model-lab.md §4) upgrades `analyze_radio` results (display_type `table` stays as fallback). One model family, one visual language, third surface.
+
+**New shared (build here):**
+- `MessageThread` - `role=log` scrollable column of message groups; sticky day dividers; auto-scroll with "jump to latest" affordance when the user has scrolled up; `content-visibility:auto` on bubbles (no virtualization needed at these lengths).
+- `ToolBadge` - pill w/ lucide icon per tool family (Gauge=pace, CircleDot=tire, Swords=situation, Wrench=pit, RadioTower=radio, Scale=regulations, Brain=strategy, LineChart=telemetry family, List=listings) + running/done/error state. Also wanted by Model Lab's run header long-term.
+- `InlineChart` - lazy-mounted ECharts host for chat bubbles: fixed 340 px height, theme'd, toolbox save-image, `IntersectionObserver` render-on-visible (charts below the fold cost nothing).
+
+**Feature-local (`webapp/src/features/chat/`):**
+- `ChatPage.tsx` (owns `?mode&c`, mounts sidebar/thread/composer) · `search.ts` (`mode: 'text'|'voice'` default text; `c?: chatId`) · `store.ts` (persisted chat slice §6.5) · `useChatStream.ts` (postStream → typed event reducer: stage/tool_result/token/done; AbortController owner).
+- `components/`: `ChatSidebar` (+`ConversationList`, `ReportsPanel`), `MessageBubble`, `StageTicker`, `ToolResultCard` (display_type switch), `ToolErrorCard`, `Composer` (+`AttachmentChip`, `ExamplePrompts`), `ContextCapsule`.
+- `charts/`: `buildLapTimesOption.ts`, `buildTelemetryOption.ts`, `buildCompareOption.ts`, `buildRaceDataOptions.ts` (returns TWO options - positions + lap times, parity with `build_race_data_figure`), `index.ts` dispatcher `buildToolChartOptions(toolName, data): EChartsOption[] | null`. Pure, unit-tested against captured payload fixtures. Reuse `features/dashboard/components/channels.ts` series styling for the telemetry panes and the Comparison delta fill treatment for `compare_drivers` - do not invent a fourth chart dialect.
+- `voice/`: `VoicePanel.tsx`, `orb/` (lifted `AudioOrb`+`Iridescence`+`useAudioLevel`), `VoiceOrb.tsx` (thin wrapper mapping `useVoiceSession` status → orb props), `MicBar.tsx`, `VoicePicker.tsx`, `VoiceExchangeCard.tsx`, `useVoiceSession.ts` (state machine + MediaRecorder + playback analyser), `voiceStore.ts` (ephemeral).
+- Promote to `lib/`: `lib/lapMarks.ts` - `detectPitLaps()` + `maskPitLapOutliers()` ported pure from `chart_builders.py:66-151,471-490` with unit tests (stint-increment first, compound-change fallback; median×1.15 outlier mask). `lib/api/chat.ts` + `lib/api/voice.ts` types.
+
+## 5. Interactions & flows
+
+1. **Send** - Enter → optimistic user bubble (+image chip) → `useChatStream` fires POST `tool-message-stream` with history-before-this-message (the `_prepare_send_context` exclusion, trivial here) → `stage` events tick the StageTicker with the verbatim `_STAGE_LABELS` copy → `calling_<tool>` mounts a pulsing ToolBadge → `tool_result` renders the card/chart instantly (before the summary!) → `token`s stream the prose → `done` persists the turn + auto-titles a new chat. The tool card appearing *before* the LLM explanation is the correct dramaturgy: evidence first, narrative second - Streamlit already ordered it this way, the SPA makes it visible.
+2. **Stop** - Stop button or Esc → `abort()` → connection torn down (Discovery 1) → partial text kept + "_[Response stopped by user]_" → composer re-enabled. If a tool_result already landed, it stays.
+3. **Example chips** - click sends the verbatim prompt immediately (parity behavior; an explicit in-page click, not a deep link).
+4. **"Ask AI about this view" (E8, the product glue)** - other tabs call `navigate({to:'/chat'})` with a `pendingAsk` handoff written to the chat store (never URL - prompts/images don't belong in query strings): `{prompt, image?, context{year,gp,session,drivers,chart_type}, newChat?}`. Chat lands with a `ContextCapsule` chip row (GP · session · drivers, dismissible) + prefilled focused composer; **one Enter fires it**. Images come from ECharts `getDataURL()` client-side - the Plotly-kaleido server render (`chat_navigation.py:75-131`) dies. Capsule context rides as `context{}` on every subsequent send in that chat.
+5. **Report** - one click: button spins → `POST /tool-message` (fixed instruction, temp 0.4, max_tokens 4000) → saved to Reports + browser download + Toast (E4). Sidebar rows re-download anytime.
+6. **Chats** - New Chat snapshots current (auto-title) and opens fresh; switching loads instantly from the store; rename inline; delete with undo Toast. Active chat id in URL (`?c=`) → a conversation is shareable-in-place across refreshes.
+7. **Voice loop (parity path)** - Record (MediaRecorder, live timer) → stop → `useVoiceSession`: TRANSCRIBING → `POST /voice-chat` (multipart + `voice` field) → exchange card appended (transcript + reply) → SPEAKING: decode `audio_base64`, play through the shared audio element + analyser → orb reacts → idle. Errors per stage keep the recording for retry. 429 (6-cap / 12-min limit) → Toast with the budget.
+8. **Mode switch** - segmented toggle; both histories survive the switch (separate slices); mic permission requested on first Voice entry, orb shows LISTENING only while the analyser is actually running.
+9. **Keyboard** - Enter send · Shift+Enter newline · Esc stop · ⌘/Ctrl+Shift+O new chat · ↑ in empty composer edits your last message (recall). Thread is `role=log` + `aria-live=polite`; chips, badges and transport all real buttons.
+
+## 6. Data & migration notes
+
+**Chat endpoints** (`backend/api/v1/endpoints/chat.py`; all rate-limited capacity 10 / 20 per min):
+
+| Endpoint | Use |
+|---|---|
+| `POST /api/v1/chat/tool-message-stream` (:282) | THE chat call. Body `{text, image?: dataURI, chat_history[], context{}, model, temperature, max_tokens}` (+ optional `X-Request-Id` header, logs only). SSE events, in order: `stage {stage}` (keys: `preparing_tools`, `model_choosing_tool`, `calling_<tool>`, `summarizing_with_llm`, `composing_response` - label map ported verbatim from `chat.py:33-52` with the same sentence-case fallback for unknown keys) → optional `tool_result {tool_result:{tool_name, display_type, data, summary}}` → `token {token}` × N → `done {llm_model?, tokens_used?, error?}`. |
+| `POST /tool-message` (:244) | Non-streaming variant - report generation only. |
+| `GET /chat/health` (:43) | `{lm_studio_reachable}` → header pill. |
+| `GET /chat/status` (:233) | NOT used by the SPA (Discovery 2). Do not port the poller. |
+
+`display_type` contract (`tool_schemas.py:43-70`): metrics → `predict_pace`, `predict_situation` · strategy_card → `predict_tire`, `predict_pit`, `recommend_strategy` · table → `analyze_radio` · chart → `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data` · text → `query_regulations` (answer + source-articles disclosure), `list_gps`/`list_drivers` (chip lists), `get_lap_range` (one-liner), JSON fallback. Error envelope: `data == {"error": …}` (≤2 keys, `tool_result_renderer.py:244-250`) forces text → `ToolErrorCard`. **Type `data` tolerantly per family and always keep the JSON-disclosure fallback** - payloads are tool-shaped, not schema'd. One `tool_result` per turn today; type the store field as an array so a future multi-tool engine costs nothing.
+
+**Wire history:** `[{role:'user'|'assistant', type:'text'|'image'|'tool_result', content, timestamp}]` - keep the exact shape (backend `build_messages` compresses to the last 5 interactions server-side, `llm_service.py:397-421`). Improvement (verify against `build_messages` first): substitute `tool_result` content with its `summary` string on the wire - the LLM never consumed the raw chart arrays anyway, and today they inflate every subsequent request.
+
+**Voice endpoints** (`backend/api/v1/endpoints/voice.py`): `GET /voice/health` `{status, stt_ready, tts_ready, stt_model}` (cold start 30-60 s - model download; poll 2 s) · `GET /voice/voices` `{voices[{id,name,language}], count}` · `POST /voice/transcribe` multipart → `{text, language, duration}` · `POST /voice/synthesize` `{text, rate, volume}` → MP3 bytes (**no `voice` param today** - see §7.1) · `POST /voice/voice-chat` multipart + `voice` form field → `{transcript, response_text, audio_base64, processing_time}`, rate-limited capacity 6 / 12 per min.
+
+**State split (§6.8 disposition):** URL = `mode`, `c` (chat id). TanStack Query = `/chat/health`, `/voice/health` (polling), `/voice/voices`. Zustand `features/chat/store.ts` **persisted** = `chats: Record<id, {id, title, createdAt, context, messages[]}>`, `activeChatId`, `reports[{id, filename, markdown, chatTitle, createdAt, sizeKb}]` (cap 20). Streaming turn state (partial text, stages, abort ref) lives in `useChatStream` local state - never persisted mid-flight. `voiceStore` ephemeral (in-memory): `exchanges[]`, `status`, `selectedVoice`, `servicesReady`. Streamlit keys map 1:1: `chat_history/saved/current_chat_name` → chats+activeChatId · `chat_streaming/should_stop/current_request_id/stream_placeholder/input_key` → die with reruns · `chat_pending_message/pending_auto_send/chat_pending_text` → `pendingAsk` in-memory handoff · `exported_reports` → reports · voice keys → `useVoiceSession`/`voiceStore` · `current_page` → router.
+
+**Persistence gotcha (the one hard one):** image data-URIs (~100-250 kB each) blow the ~5 MB localStorage quota fast. Persist the chat slice through an **IndexedDB storage adapter** (`idb-keyval`, ~600 B) on Zustand `persist`; keep reports + prefs in localStorage. Belt-and-braces: store attachment images downscaled (≤768 px JPEG - already required for the model) and cap persisted chats at 50 with LRU eviction + Toast.
+
+**Other gotchas:** nginx already allows the payloads (`client_max_body_size 25m`, `webapp/nginx.conf:15`) · backend clamps `max_tokens` server-side (send 1000, parity) · empty-stream fallback message (#21) is a real edge, keep it · `compare_drivers` payload ships `pilot.color` - prefer it over `getDriverColor` fallback (same rule as Comparison) · assistant prose is bilingual (system prompt mirrors user language) - `Markdown` must not assume English · MediaRecorder mimeType negotiate `audio/webm;codecs=opus` with `audio/mp4` Safari fallback; name the file by actual type so `_get_audio_content_type` maps right.
+
+## 7. New features (ranked)
+
+1. **Tool-aware voice** ⚡ (M, the flagship) - compose the loop client-side: `/transcribe` → transcript card → **`/tool-message-stream`** (tools! inline charts! stage narration while the orb "thinks") → `/synthesize` the final prose (markdown-stripped) → orb speaks. Kills Discovery 4: spoken questions hit the same models as typed ones, and voice mode inherits every chat renderer free. Backend-additive **B1**: optional `voice` field on `TTSRequest` (~3 LOC) so the picker keeps working; until B1, composed-loop replies use the default voice and `/voice-chat` stays as the fallback path behind a flag.
+2. **Ask-AI deep links everywhere (E8)** ⚡ (S) - the `ContextCapsule` handoff (§5.4) + a ghost "Ask AI about this view" button on Dashboard/Comparison/Strategy/Lab cards. ECharts `getDataURL()` makes the screenshot free. This is what ties the six surfaces into one product.
+3. **Chat search + pin (E5)** (S) - filter-as-you-type over titles + message text (it's all client-side now); pin up to 3 chats above the list.
+4. **Slash commands** (S) - `/` in the empty composer opens a menu of the 4 example templates + `report`; picks fill the composer with editable placeholders (`/tyre VER 30 Bahrain`). Demo-friendly, zero backend.
+5. **Wire-history slimming** (S, verify) - tool_result → summary substitution (§6). Cuts token burn on long analytical chats.
+6. **Chart → page cross-links** (S) - inline lap-times/telemetry/compare charts get a "Open in Dashboard/Comparison" action carrying the context URL - the reverse of E8.
+7. **Voice previews** (XS, needs B1) - play a 2 s sample per voice in the picker.
+8. **Export-all / import** (XS) - download all chats as JSON from the sidebar footer (E5 tail); pairs with persistence.
+
+## 8. Better than Streamlit
+
+Real streaming (tokens render at DOM speed; the plan's measured ~95% per-token render cost cut) instead of rerun-per-token · a Stop that actually stops the backend stream, not a flag checked between frames · stage narration inline from SSE - the 1 s polling daemon thread and its endpoint dependency deleted · chats/reports survive refresh, id-keyed, renameable, deep-linkable (`?c=`) - no more same-title silent overwrites · inline charts are live ECharts (hover, zoom, save-image) in the one app-wide chart theme, not static Plotly re-rendered per rerun through 8 near-duplicate builders · tool evidence renders with the SAME `ActionBadge`/`CompoundPill`/`NlpMessageCard` vocabulary as Strategy/Lab - a tyre cliff looks identical on all three surfaces · the orb is a first-class component instead of a sandboxed iframe fought with page-level CSS nukes (`voice_chat.py:396-432` deleted) · mic consent explicit with a visible listening state instead of hot-mic-on-mount · voice can call the real models (§7.1) instead of improvising · screenshots for Ask-AI generated client-side by ECharts, no kaleido round-trip · accessible by construction: `role=log` live region, real buttons, keyboard map, reduced-motion orb.
+
+## Acceptance criteria (#39 + #40, condensed)
+
+§6.6 rows pass (with the rename amendment: rename EXISTS now, note in PR) + §6.7 rows pass (voice picker actually reads `GET /voice/voices`) · example chips byte-identical copy + click-sends (test asserts the 4 strings) · `useChatStream` reducer unit-tested against a captured SSE fixture (stage→tool_result→token→done, plus error-envelope and empty-stream cases) · Stop aborts the fetch (network-level assert: reader cancelled, no further tokens) and keeps the partial with the verbatim marker · dispatcher fixture tests per chart family incl. pit-vline detection + outlier masking parity with the Python fns · tool error renders card AND the following LLM explanation (dossier #36 regression test) · persistence round-trip: refresh restores chats incl. an image attachment (IndexedDB path) and reports · report is one-click and lands in the sidebar + download + toast · voice: record disabled until health-ready; each pipeline stage failure surfaces distinctly and keeps the recording; orb states track the session machine; reduced-motion honored · keyboard-only: send, stop, new chat, mode switch, chip activation · rate-limit 429s surface as Toasts with the budget, on both chat (20/min) and voice (12/min).
+
+**Key files:** `frontend/pages/chat.py` + `frontend/components/chatbot/{chat_sidebar,chat_history,chat_input,chat_message,tool_result_renderer,chart_builders}.py` + `frontend/services/{chat_service,voice_api}.py` + `frontend/utils/{chat_state,chat_navigation,report_storage}.py` · voice `frontend/components/voice/{voice_chat,voice_input}.py` + orb `frontend/components/streamlit_audio_viz/frontend/src/{AudioOrb,Iridescence,useAudioLevel}.tsx|ts` (lift these three + styles.css) · backend `backend/api/v1/endpoints/{chat.py,voice.py}`, `backend/services/chatbot/chat_engine.py:158-332` (event flow), `backend/models/tool_schemas.py:22-70` (tools + display map) · grammar `webapp/src/lib/api/sse.ts` (postStream - the cornerstone), `webapp/src/components/{Markdown,Pill,Toast,FileDrop,Tabs,Modal(Sheet)}.tsx`, `webapp/src/features/dashboard/components/{channels.ts,ChannelChart.tsx}` (chart styling to reuse), `webapp/src/styles/tokens.css` · sibling specs `docs/migration/design-specs/{strategy,comparison,model-lab}.md` (shared vocab) · route stub `webapp/src/app/router.tsx:70-74`.

--- a/docs/migration/design-specs/comparison.md
+++ b/docs/migration/design-specs/comparison.md
@@ -1,0 +1,139 @@
+# Comparison — Design-First Spec (issue #36, flagship)
+
+> Design-first blueprint (Fable, 2026-07-14). The app's demo centerpiece. Sources: `frontend/pages/comparison.py`, `frontend/components/comparison/synchronized_comparison_animation.py` (1116 LOC), `backend/api/v1/endpoints/comparison.py`, `backend/services/comparison_service.py`, MIGRATION_PLAN §1.2/§2.4-P4-2/§3.5/§4.2/§6.5/E3/W4, `st_5_Comparison.png`. `comparison/legacy/*` is dead — ignore.
+
+## 1. Purpose & the job
+
+Answers one question at three zoom levels: **"where does one driver gain on the other — and why?"** One glance = result banner (who won, by how much, microsector tally). One lap = the replay (watch the gap open/close at 60fps). One corner = pause anywhere, synced crosshairs across Delta/Speed/Brake/Throttle expose the mechanism.
+
+**The idea that changes everything:** Streamlit's replay is *distance-locked* — both dots advance one index/frame, always side-by-side, the "gap" only in the delta subplot. The new engine runs on a **TIME clock**: at t=34.2s each dot sits at its own distance-at-time → the faster driver visibly pulls away on track. The replay stops being an animated chart and becomes a race. Earns the expressive motion register — but only on the replay card (glow reserved for the one primary card).
+
+## 2. Functionality inventory (KEEP/IMPROVE/DROP)
+
+| # | Streamlit (file) | Verdict | Target |
+|---|---|---|---|
+| 1 | Year/GP/Session cascading selectors (`comparison.py:109`) | KEEP | Dashboard `SelectorsToolbar` grammar in a sticky context bar, state in URL. |
+| 2 | 2-driver multiselect cap 2 | KEEP | `Combobox` maxSelected=2, enforced in validateSearch. |
+| 3 | Explicit COMPARE button (not reactive) | KEEP | Fetch is expensive (cold FastF1 ~60s, 120s timeout); selection cheap+reactive, comparison explicit+cancellable. |
+| 4 | "Only fastest laps compared" notice | KEEP | Info chip (lucide `flag`) inline. |
+| 5 | "animation takes time" warning toast | DROP | Existed because of Plotly frame-baking; staged skeleton replaces it. |
+| 6 | "⏳ Rendering animation…" spinner (`:154`) | DROP | No frame pre-bake anymore; render instant on data. |
+| 7 | Lap-times box, winner in team colour, "X first by Ns" (`_render_lap_times_info`) | IMPROVE | `ResultBanner`: same + microsector tally ("16/25") client-side from `circuit.colors`. |
+| 8 | Q-phase green chip + amber fairness warning (`metadata.qualifying_phase`/`.warning`) | KEEP | `Pill` success/warning in banner. Real domain logic — surface verbatim. |
+| 9 | Circuit animation: 25 microsectors reveal, 50-pt trails, ringed dots | IMPROVE | `TrackCanvas` 60fps, time-domain (dots separate physically), smooth trails, dominance reveal preserved as signature moment. |
+| 10 | Delta subplot: faster = flat 0-line, slower = ±delta | IMPROVE | Single delta curve vs faster's zero baseline + signed area fill tinted by who's ahead — "who gains where" readable w/o motion. |
+| 11 | Speed/Brake/Throttle progressive painting | IMPROVE | Full static ECharts (never redrawn) + shared playhead cursor + translucent "future dimmer" sliding w/ playhead (compositor-only). Full trace inspectable while paused. |
+| 12 | Play 120ms/frame (~8fps) / Pause / ⟲ Reload | IMPROVE | `ReplayTransport`: real HTML buttons (fixes dossier #33 — Playwright couldn't click Play) + speed + keyboard. |
+| 13 | Frame slider "Frame: N" | IMPROVE | Time-based `ReplayScrubber` in seconds + S1/S2/S3 sector ticks + `aria-valuetext`. |
+| 14 | `hovermode='x unified'` cross-chart hover | KEEP | ECharts axisPointer + `echarts.connect` — the shipped `SyncedLineChart` pattern (ChannelChart.tsx). Active when paused. |
+| 15 | Ask-AI button w/ COMPARISON_TEMPLATE | KEEP | "Ask AI about this comparison" ghost → deep-link `/chat` w/ context. Ships disabled-w/-tooltip if #39 not landed. |
+| 16 | `session_state['comparison_data']` persistence | KEEP (free) | TanStack Query cache; survives navigation. |
+| 17 | 404 "driver not found" toast | KEEP | Toast + inline error + "change driver" hint. |
+
+Zero functional loss; two Streamlit workarounds (5,6) dropped because their cause is gone.
+
+## 3. Layout & IA
+
+Route `/comparison` (already stubbed sharing Dashboard search shape — keep, so "Go to comparison" carries context).
+
+```
+┌ STICKY CONTEXT BAR (acrylic) ────────────────────────────────────────────┐
+│ [2024▾][Monaco GP▾][Q▾][VER✕ LEC✕ ▾(max 2)]  [⚑ fastest laps]  [COMPARE▸]│
+├ RESULT BANNER (calm) ────────────────────────────────────────────────────┤
+│ VER 1:10.342  LEC 1:11.824   ●VER first by 1.482s                        │
+│ [✓ fastest laps from Q3] [⚠ phase warning]  faster in 16/25 microsectors │
+├ ╔═══════════ REPLAY CARD — the ONE glow card ═════════════════════════╗ ─┤
+│ ║   TRACK CANVAS (55%)          │ ┌DELTA(area±)┐ ┌SPEED(2 lines)┐    ║   │
+│ ║   dominance ribbon + trails   │ │     ┊cursor │ │      ┊cursor │    ║   │
+│ ║   + 2 team dots + gap "▲+.32s"│ ┌BRAKE────────┐ ┌THROTTLE──────┐    ║   │
+│ ╟───────────────────────────────────────────────────────────────────╢   │
+│ ║ TRANSPORT [⏮][▶/⏸][1×▾] 0:34.2 ──●──── 1:10.3  ticks S1│S2│S3 [⧉]║   │
+│ ╚═══════════════════════════════════════════════════════════════════╝   │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+Replay card = hero (glow, expressive register, ~80% viewport ≥1280px): track left 55%, 2×2 channel grid right 45%, transport docked full-width bottom — one instrument, one clock. <1280px: track full-width top (min 360px), charts 2×2 below (1-col <720px), transport sticky to card bottom. Selectors+banner frame it (solid bg-3, no glow, ≤180ms mounts).
+
+**States:** Idle (EmptyState, COMPARE disabled until all 5 selections — error-toast-on-click impossible by construction) · Comparing (skeleton of final layout, staged copy "Loading session→Extracting fastest laps→Synchronizing telemetry", cancel via AbortController) · Ready (paused t=0: full track neutral grey, dots on start line, full traces, delta fill; Play pulses once, motion-safe — already a complete static analysis screen) · Playing (clock runs, dominance reveals behind leader, trails stream, cursors sweep, live gap counts, hover suppressed) · Paused mid-lap (freeze; axisPointer hover + connect re-enabled → Dashboard-parity inspection) · Finished (full map lit, gap = final delta; ▶→⟲ Replay; no auto-loop unless toggled) · Error (404 detail inline + toast, Retry keeps selection).
+
+## 4. The replay engine — one-clock architecture
+
+**4.1 Clock is time, not frames.** Backend returns 500 pts/driver on a common DISTANCE grid + each driver's real `lap_time`, but NO time array (verified: `synchronize_telemetry` interpolates distance/x/y/speed/throttle/brake only). Client synthesizes each driver's time domain w/ the math the backend already uses for delta (`calculate_delta_time`):
+```
+tᵢ[k] = Σ_{j<k} Δd[j] / (vᵢ[j]/3.6)   (cumulative trapezoid, s)
+tᵢ    = tᵢ · (lap_timeᵢ / tᵢ[last])     (scale to real lap time)
+```
+Strictly increasing `timeAtDistance` per driver; inverse `distanceAtTime(t)` = binary-search+lerp (the `interp()` in `ChannelChart.tsx:163` → promote to `lib/interp.ts`). **Replay duration = max(lap_time₁, lap_time₂)** → faster dot parks at the line while the slower finishes — the gap made physical.
+
+**4.2 Data flow & state placement:**
+```
+URL search (TanStack Router, comparison/search.ts) — COMPARE sets compare=1 → enables query
+  ▼ useComparison(search)  (TanStack Query, staleTime:Infinity) → GET /comparison/compare
+  ▼ buildReplayModel(payload)  (PURE, memoized, UNIT-TESTED)
+     ├ Float32Array channels per driver (distance,x,y,speed,throttle,brake)
+     ├ timeAtDistance₁/₂ + distanceAtTime₁/₂ samplers
+     ├ delta series + sign-split area segments
+     ├ track geometry: bounds, y-flip, viewBox (reuses circuitDraw.ts), microsector segments
+     └ duration, sector-boundary times, winner metadata
+  ▼ useReplayClock(duration)  (the ONE clock)
+     ├ rAF loop; playhead in a REF, never React state
+     ├ transport API: play/pause/seek/setSpeed/restart
+     ├ subscribe(cb) → every frame w/ tSec  (canvas + cursor overlays)
+     └ useReplayTime(hz=10) → throttled React state (text readouts only)
+  ▼ consumers, all from the same tick: TrackCanvas · CursorOverlay×4 · FutureDimmer×4 · LiveGapReadout · ReplayTransport
+```
+State tiers (A5-1): **URL** = year/gp/session/drivers(cap 2)+optional `t` moment-link · **TanStack Query** = payload (immutable, staleTime:Infinity) · **Zustand replayStore** (`f1sl.replay`) = status/speed/loop/trackMode · **ref inside useReplayClock** = playhead time (60 setState/s would re-render the tree; refs + imperative draw = standard rAF discipline, §1.2).
+
+**4.3 rAF loop:** `t = min(t + dt·speed, duration); for cb of subscribers cb(t); if t>=duration finished`. Zero alloc in-loop (Float32Arrays pre-baked, trail slices = index ranges). `visibilitychange` pauses (no time jump on tab return). Budget <4ms/frame (canvas ~1-2ms, cursor transforms ~0). 60fps comfortable.
+
+**4.4 Track renderer (`TrackCanvas` + pure `trackDraw.ts`):** offscreen STATIC layer (ribbon once per data/resize, reuse computeBounds/flipY, add `fitCanvas()` track-units→px w/ aspect lock + DPR≤2 cap, base grey #94a3b8 low-alpha ~10px) + DYNAMIC layer every tick: (1) dominance reveal — microsector segments whose end-distance < leader's distance stroked in `circuit.colors` (25 sectors, per-pixel smooth), (2) trails — last ~2.5s of each driver's real x/y racing line, 3px alpha fade (off under reduced-motion), (3) dots — 7px team-colour fill (`pilot.color` from payload), 2px white ring, soft glow (the one glow on data — it IS the data), (4) gap link — when on-track separation <~8% track length, dashed line connects dots w/ live gap label. Canvas `role=img`+aria-label; visually-hidden `aria-live=polite` announces pause/finish.
+
+**4.5 Channel charts — ECharts static + DOM cursor (critical perf decision):** the 4 charts are ECharts w/ fully STATIC series — `setOption` once per data load, NEVER per frame. Playhead = **DOM overlay: absolutely-positioned 1px line, `transform: translateX(px)`** (compositor-only, ~0 main-thread) — chosen over `dispatchAction`/`setOption`-per-frame (both re-render chart internals). `CursorOverlay` maps playhead distance (leader's distance-at-time; all x-axes = distance like Dashboard) → px via `chart.convertToPixel({xAxisIndex:0}, d)` cached per resize (per-frame = one multiply-add). `FutureDimmer` = 2nd overlay (full-width `rgba(bg-2,.5)`, translateX(cursorPx)) restores progressive-reveal for free. Paused → overlays freeze, native `tooltip.trigger:axis` + `echarts.connect` group take over (Dashboard-parity). Delta: 1 series = slower's delta vs faster's zero baseline (dashed markLine at 0) + split-sign area fill tinted by who leads (driver-1 colour above zero, driver-2 below, 15% alpha) → dominance timeline even stopped.
+
+**4.6 Transport & a11y (fixes dossier #33):** `ReplayTransport` real HTML controls (Button ghost + lucide): ⏮restart, ▶/⏸ (aria-pressed, 44px hit), speed menu (0.25/0.5/1/2), loop toggle, track-mode menu (§7), share-moment. `ReplayScrubber` on Radix Slider: value=seconds, `aria-valuetext="34.2s of 70.3 — VER ahead 0.32s"`, mono readouts, **S1/S2/S3 sector ticks** (placeholder 25/50/75% if sector data absent); drag=seek() live (O(1) redraw — humiliates Plotly), drag pauses + resumes on release. **Keyboard** (scoped to focused card): Space/K play-pause, ←/→ ±0.5s, Shift+←/→ ±5s, Home/End, J/L speed, R restart. `prefers-reduced-motion`: no pulse/trails/GSAP; replay only on explicit action (never autoplays → V3-5 by construction). Focus rings, tab order play→scrubber→speed→secondary.
+
+## 5. Components
+
+Reuse: `Card` glow (replay card, the one glow), `Button`/`Pill`/`Toast`/`Skeleton`/`EmptyState`/`Tooltip`, `Combobox` maxSelected (cap 2), `Slider` (scrubber base), `SyncedLineChart`+`echartsTheme`+connect group (paused inspection), `circuitDraw.ts` (extended w/ canvas `fitCanvas()`), `dashboard/search.ts` pattern (cloned MAX_DRIVERS=2), `getDriverColor` (fallback only — payload ships colours).
+
+New (`webapp/src/features/comparison/`): `ComparisonPage.tsx`, `search.ts` (cap 2, optional t=), `queries.ts` (useComparison), `components/{ComparisonToolbar,ResultBanner,AskAiButton}.tsx`, `replay/{buildReplayModel.ts (PURE, unit-test seam), useReplayClock.ts, replayStore.ts, TrackCanvas.tsx, trackDraw.ts (PURE), ChannelGrid.tsx, ChannelPane.tsx, CursorOverlay.tsx, ReplayTransport.tsx, ReplayScrubber.tsx, LiveGapReadout.tsx}`. Promote `interp` → `lib/interp.ts`. **`ReplayTransport` + `useReplayClock` are the reusable seams** (future live-timing feed + Arcade consumers want a transport+clock abstraction — keep them free of comparison-specific types).
+
+## 6. Data & migration notes
+
+Endpoint (exists): `GET /api/v1/comparison/compare?year&gp&session&driver1&driver2` (schema.ts:191). Response:
+```jsonc
+{ "circuit": { "x":[500], "y":[500], "colors":["#hex"×500] },  // centreline avg; colors = 25-microsector dominance per point
+  "pilot1": { "distance":[500],"x":[500],"y":[500],"speed":[500],"throttle":[500],"brake":[500],
+              "lap_time":70.342,"color":"#3671C6","name":"VER","lap":14 },
+  "pilot2": { /* same */ },
+  "delta": [500],  // + = pilot1 slower here (speed-integrated, scaled to real lap-time diff)
+  "metadata": { "rotation":40,"aspect_ratio":1.8,"qualifying_phase":"Q3"|null,"warning":"..."|null } }
+```
+Payload ≈500pts×13 arrays×~10B ≈ **150-250 kB** vs multi-MB pre-baked Plotly figure (P4-2 −90%+ met by NOT shipping frames).
+
+Interp math to port (unit-test seam): (1) `np.interp`→`interp()` already in ChannelChart.tsx:163 → promote to `lib/interp.ts`; (2) time-domain synthesis + delta = TS port of `comparison_service.calculate_delta_time` (`Δd/(v/3.6)` cumulative + scale, comparison_service.py:185-232) in `buildReplayModel.ts`. **Golden-fixture test:** run the Python fns on 2023 Monaco Q VER/LEC → `tests/fixtures/comparison-monaco-2023.json`, assert TS port within 1e-6 (like `outliers.test.ts`). Pins the port to thesis-validated math.
+
+URL (`comparison/search.ts`): `/comparison?year=2023&gp=Monaco Grand Prix&session=Q&drivers=VER,LEC[&t=34.2]`. Drivers CSV upper/dedup/**cap 2**; `t` optional float clamped [0,duration], applied once on load (moment link), written only by share button. Dashboard's "Go to comparison" gracefully truncates 3 drivers → 2.
+
+**Optional additive backend (NOT parity gates):** B1 — real `time` arrays in compare payload (FastF1 has it; /lap-telemetry already returns it) → kills the speed-integration approx (client keeps synthesis as fallback), ~15 LOC. B2 — official S1/S2/S3 boundaries in metadata → true scrubber ticks + per-sector splits.
+
+## 7. New features (ranked)
+
+1. **Corner call-outs** (M) — detect braking zones (brake-rise) + apexes (speed minima) from arrays in hand; label T1..Tn; pause near one → micro-card "T5: LEC brakes 14m later, exits +6km/h, gains 0.09s". Pure client. **The** analyst feature.
+2. **Track colour modes** (S) — transport menu: Dominance (parity) · Speed heatmap · Gain/loss (delta-derivative). One draw-fn switch.
+3. **Ghost dot** (S) — hollow marker of the other driver at this elapsed time on your line; explains the delta visually.
+4. **Share a moment** (XS) — copy URL w/ `&t=34.2` + toast. Zero backend.
+5. **Export a clip** (M) — `canvas.captureStream(60)` + MediaRecorder → WebM for README/social. Dev-flag first.
+6. **Official sector splits** (S+backend) — needs B2.
+7. **3D upgrade (E3)** (L) — r3f track w/ elevation, chase-cam, emissive dominance. Lazy chunk, mounts on toggle, 2D fallback. Engine ready: useReplayClock subscribers don't care if consumer is canvas 2D or three. The defense flex; never parity.
+8. **Any-lap comparison** (M+backend) — not only fastest; needs lap1/lap2 params.
+
+Recommended for #36: parity + ranks 2-4 (near-free once engine exists). Rank 1 = fast-follow PR; 5-8 = backlog.
+
+## 8. Better than Streamlit (demo script)
+8fps→60fps (clock vs flipbook) · physically-true replay (dots on real time, you WATCH the gap open — no broadcast graphic does head-to-head like this) · multi-MB→~200kB · instant continuous scrubbing (seek(t) = 1 canvas frame, feels like a video editor) · accessible by construction (real buttons, labelled slider, keyboard map, live-region, reduced-motion) · paused = full analysis screen (complete curves + synced crosshairs) · shareable (`&t=` reproduces the moment) · state survives navigation.
+
+## Acceptance criteria (#36, condensed)
+§6.5 parity rows pass · 60fps sustained (DevTools trace in PR, <8ms/frame) · buildReplayModel golden test vs Python fixture green · keyboard-only transport (axe/Playwright can click Play — regression test named after dossier #33) · prefers-reduced-motion honored (no pulse/trails, replay only on explicit action) · URL round-trip incl `t=` · NO setOption inside the rAF loop (assert via spy).
+
+**Key files:** `frontend/pages/comparison.py` + `frontend/components/comparison/synchronized_comparison_animation.py` · port math `backend/services/comparison_service.py` (synchronize_telemetry, calculate_delta_time, calculate_microsector_colors) · endpoint `backend/api/v1/endpoints/comparison.py` · grammar `webapp/src/features/dashboard/{search.ts,store.ts,queries.ts,components/ChannelChart.tsx,components/circuitDraw.ts}` · route stub `webapp/src/app/router.tsx:63-67`.

--- a/docs/migration/design-specs/model-lab.md
+++ b/docs/migration/design-specs/model-lab.md
@@ -1,0 +1,184 @@
+# Model Lab — Design-First Spec (issue #38)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Model Lab's functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared vocabulary from `strategy.md` (`ActionBadge`, `CompoundPill`, `ConfidenceDial`, state tiers, raw↔component URL boundary). Sources: `frontend/pages/model_lab.py` (930 LOC), `backend/api/v1/endpoints/strategy.py`, agent output dataclasses in `src/agents/*.py`, MIGRATION_PLAN §6.4/E10/W6, `st_4_Model_Lab.png`.
+
+## 1. Purpose & the job
+
+Model Lab is the **model inspector**: put any ONE of the six predictors on the bench, feed it a real race moment, and see exactly what it says and why. Strategy shows the orchestrated *decision*; the Lab shows each *instrument* in isolation — the transparency surface for the TFG's model family (XGBoost pace, TCN+MC-Dropout tyres, LightGBM overtake/SC, HistGBT pit + LightGBM undercut, the N24 NLP radio pipeline). Its job: *"For this GP/driver/lap, what does model X predict, with what uncertainty, against what threshold — and what did the LLM layer say about it?"*
+
+Streamlit treats it as six repetitive form-tabs. The migrated version is a **workbench**: a model rail with identity cards (model type + thesis eval headline + run status), one shared bench frame (context → run → metrics → viz → reasoning), and a per-model run history. The audience is the developer/defender demoing models individually, and the curious analyst poking at a race moment.
+
+**THREE KEY DISCOVERIES in the Streamlit source** that drive this design:
+1. **Dead UI:** the Overtake tab's "Contextual factors" panel + factor bar chart (`model_lab.py:468-505`) read `data.contextual_factors` — a field **no agent ever returns** (zero matches in `src/agents/` and `backend/`). The panel has rendered its empty-fallback forever. Meanwhile the REAL context the agent returns (`gap_ahead_s`, `pace_delta_s`, `sc_currently_active`) is discarded.
+2. **Fabricated data:** the Safety-car tab's 3/5/7-lap horizon bars (`model_lab.py:541-543`) invent the 5- and 7-lap values client-side as `sc3×1.2` and `sc3×1.4`. The model has ONE trained target (`sc_within_3_laps`). Two of the three bars are made up.
+3. **Dropped fields:** `RadioOutput.corrections` (LLM-flagged NLP mismatches) and `rcm_events` are never rendered; both Overtake and SC tabs call the SAME `/situation` endpoint separately, so the one model runs twice and the two tabs can silently disagree.
+
+Fixing these is the core of the elevation — same honesty move as Strategy's 14-vs-6-field discovery.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" `st.warning` (`model_lab.py:48`) | KEEP (demoted) | Info chip in the context bar, same as Strategy §2.1. |
+| 2 | GP → Driver cascading selectors (`:50-74`) | KEEP | `Combobox`es, URL-bound, driver name in team colour. |
+| 3 | Lap-range slider + single-lap slider BOTH always visible (`:88-100`) | IMPROVE | Only the control the active model uses renders: Pace → `DualRangeSlider`; Tyres/Overtake/SC/Pit → single `Slider`; Radio → corpus pickers. Kills the "which slider matters?" confusion. |
+| 4 | `_fetch_lap_state` + session-state cache (`:105-132`) | KEEP (free) | TanStack Query keyed `['lab','lap-state',gp,driver,lap]`, staleTime Infinity. |
+| 5 | Lap-state 404 → "driver may have retired" warning (`:118-129`) | KEEP + IMPROVE | Inline in context bar + one-click "jump to last valid lap" (max from `/lap-range`). |
+| 6 | 6 tabs, each Run → metrics → chart → reasoning (`:896-929`) | KEEP (reshaped) | Model rail (vertical tablist) + ONE shared `RunFrame`; same run→metrics→viz→reasoning grammar for all six. §3. |
+| 7 | Pace: batch lap-range run, 45–60 s spinner (`:209-267`) | KEEP + IMPROVE | Elapsed timer + honest "~N laps · typically 45–60 s" framing + chart skeleton + Cancel (AbortController). No fake staged copy — it's one POST. P4-9. |
+| 8 | Pace chart: actual-vs-pred + CI band + compound dots + stint vlines + MAE badge (`:139-206`) | KEEP | ECharts: line + `ci_p10/p90` band, compound-coloured scatter via `tireColors`, stint `markLine`s, MAE chip in card header. Null `pred` rows (stint-first laps) render as gaps, never zeros. |
+| 9 | Pace summary metrics: last pred / CI / range MAE (`:240-263`) | KEEP | 3 `StatCard`s. |
+| 10 | Tyres: warning badge + 4 metrics (deg rate, cliff P10/50/90) (`:367-388`) | KEEP | `Pill` (PIT_SOON danger / MONITOR warning / OK success) + `StatCard`s, deg rate in mono. |
+| 11 | Tyres: overlay cliff bar chart (`:274-311`) | IMPROVE | Replace the confusing 3-overlaid-bars with a **`StintRunway`** — the lap-axis strip from Strategy's `StintTimeline`, reused: "now" marker → P10→P50→P90 cliff gradient zone. Same data, legible form. |
+| 12 | Tyres: degradation projection line + P50 cliff vline (`:314-347`) | KEEP | ECharts line + `markLine` at P50 cliff; area fill under curve. |
+| 13 | 60-lap cliff cap + "capped" caption (`:370-394`) | KEEP | Domain guard, honest caption. Cap in the view layer, raw values in the run record. |
+| 14 | Overtake: threat badge + probability gauge (`:441-466`) | KEEP + IMPROVE | Existing `Gauge` primitive + **threshold tick at 0.80** (the model's real `high_overtake` decision threshold from CFG) with caption. Threat `Pill`. |
+| 15 | Overtake: contextual-factors panel + factor bars (`:468-505`) | **DROP (dead)** → REPLACE | Field never exists (Discovery 1). Replace with a **SituationFacts strip** of what `/situation` actually returns: gap-ahead chip (DRS badge when <1.0 s), pace-delta trend arrow (±s/lap vs car ahead), `sc_currently_active` flag. Real data, zero backend work. |
+| 16 | SC: gauge (sc_prob_3lap) (`:534-538`) | KEEP + IMPROVE | `Gauge` + threshold tick at 0.30 (`high_sc`). |
+| 17 | SC: 3/5/7-lap horizon bars (`:539-558`) | **DROP (fabricated)** → REPLACE | Discovery 2: 5/7-lap values are invented multipliers. Replace with an honest **baseline-lift bar**: this lap's P(SC≤3 laps) vs the season base rate (the model's real framing — lift 1.67× headline from N14). **§6.4 parity row needs amending** — flagged, with rationale, rather than silently ported. |
+| 18 | SC: contextual factors panel (`:562-569`) | DROP (dead) | Same nonexistent field. SituationFacts strip covers it. |
+| 19 | Overtake & SC each POST `/situation` separately (`:445,520`) | IMPROVE | ONE shared situation run feeds both models' views (Discovery 3). Running either fills both; a "shared run — Situation agent scores both" caption keeps it honest. Halves calls, kills divergence. |
+| 20 | Pit: compound badge + stop P05/50/95 metrics (`:597-611`) | KEEP + IMPROVE | `CompoundPill` (strategy spec) + `ActionBadge` for `action` — **vocab must add `REACTIVE_SC`** (PitStrategyOutput emits it; strategy's 5-value enum doesn't include it): siren icon, danger, subtle pulse. |
+| 21 | Pit: 3-bar stop-duration chart (`:615-635`) | IMPROVE | P05—P50—P95 is one distribution, not 3 categories: render a horizontal **interval strip** (dumbbell: band P05→P95, dot at P50, mono labels). Honest, half the height. |
+| 22 | Pit: undercut gauge + window details (`:639-661`) | KEEP | `Gauge` (threshold 0.522 — N16's operating point) + detail list: `ActionBadge`, target driver in team colour, recommended lap. All fields nullable → conditional render. |
+| 23 | Radio: dual mode toggle (`:765-779`) | KEEP | Segmented `Tabs`: "Race radio" / "Free text". Both modes are §6.4 parity. |
+| 24 | Radio lookup: own GP/driver/lap pickers + transcript preview (`:782-830`) | KEEP + IMPROVE | Corpus has its own GP list (`/radio-available-gps`) — inherit the page GP/driver when present in the corpus, else prompt. Lap picker shows "(N with radio)"; transcript preview as a mono quote card. |
+| 25 | Radio free text: textarea + analyse (`:854-879`) | KEEP + IMPROVE | Add 3 example chips ("Box box box, Plan B", "Tyres are gone", "Yellow flag sector 2") that fill the textarea — demo-friendly. Text never goes in the URL. |
+| 26 | Radio results: alerts + NLP message cards (sentiment/intent/entities) + reasoning (`:672-762`) | KEEP + IMPROVE | `NlpMessageCard` component (sentiment-tinted edge, sentiment `Pill`, intent chip, typed entity chips) — **build once, share with Race Analysis Tab 3** (§6.3 renders the identical shape). |
+| 27 | `RadioOutput.corrections` + `rcm_events` | **NEW (dropped today)** | Discovery 3: render corrections as an "LLM cross-check" panel (original intent → suggested intent + reason) and RCM events as flag-coloured rows. Free data. |
+| 28 | Results persist silently across selector changes (`ml_*_result` keys) | IMPROVE | Stale-run honesty (same contract as Strategy): result stays visible but gets an amber "context changed — result is for Lap 18 / Monaco" banner + Re-run. |
+| 29 | `_warning_badge` / `_metric_html` raw-HTML injection | DROP | `Pill` / `StatCard` primitives carry it. |
+| 30 | Purple-border chart CSS injection (`:891`) | DROP | `ChartCard` + tokens. |
+
+Zero functional loss except two deliberate, documented drops (#15, #17) whose replacements show MORE real information than the originals.
+
+## 3. Layout & IA
+
+Route `/lab` (stub exists, `router.tsx:55-58`).
+
+**IA verdict: not 6 flat content-tabs — a model rail + one shared bench.** The six models keep tab semantics (vertical `role=tablist`), but each rail entry is a **model identity card**: icon, name, model-type chip (XGBoost / TCN+MC / LightGBM / HistGBT+LGBM / NLP×3), thesis eval headline (MAE 0.411 s · AUC-PR 0.549 · …), and a run-status dot (idle ○ / running ◐ pulse / done ● / stale ◍ amber). The rail answers at a glance "which models have I run against this moment?" — impossible in flat tabs. Below 1024 px the rail collapses to the horizontal segmented `Tabs` with the same status dots.
+
+```
+┌ Header: "Model Lab"                                  [→ Send to Strategy] ┐
+│ ╔═ CONTEXT BAR (sticky, acrylic) ═════════════════════════════════════╗   │
+│ ║ (2025 ·chip) [Grand Prix ▾]  [Driver ▾ NOR]   ⟨per-model lap ctrl⟩  ║   │
+│ ║   Pace:   Lap window ●━━━━━━━● 8–28                                 ║   │
+│ ║   others: Lap ●━━━○━━━ 18   · lap-state chip: ⟨MEDIUM · age 12 · P4⟩║   │
+│ ║   Radio:  [GP w/ radio ▾][Driver ▾][Lap (7 with radio) ▾] | mode ⇄  ║   │
+│ ╚═════════════════════════════════════════════════════════════════════╝   │
+│ ┌ MODEL RAIL ─────────┐ ┌ BENCH — RunFrame (shared scaffold) ──────────┐  │
+│ │ ● Pace              │ │ ┌ run header ────────────────────────────┐  │  │
+│ │   XGBoost·MAE .411s │ │ │ Tyre degradation · TCN + MC-Dropout    │  │  │
+│ │ ◐ Tyres      ←activo│ │ │ ⟨run for Lap 18 · 14:32⟩  [▶ Run] [✕]  │  │  │
+│ │   TCN·MC N=50       │ │ └────────────────────────────────────────┘  │  │
+│ │ ● Overtake ┐ shared │ │ [PIT_SOON pill]  [.041 s/lap][P10 6][P50 9] │  │
+│ │ ● Safety c ┘ run    │ │ ┌ STINT RUNWAY ──────────────────────────┐  │  │
+│ │ ○ Pit               │ │ │ now▼        ▒P10═P50═P90▒ cliff zone   │  │  │
+│ │ ○ Radio             │ │ └────────────────────────────────────────┘  │  │
+│ │                     │ │ ┌ DEG PROJECTION (ECharts line+cliff) ───┐  │  │
+│ │ run history ▾       │ │ └────────────────────────────────────────┘  │  │
+│ │  · L18 14:32 ●      │ │ ▸ 🧠 Agent reasoning (Markdown disclosure)  │  │
+│ │  · L18 14:29 ●      │ └──────────────────────────────────────────────┘  │
+│ └─────────────────────┘                                                    │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+**The shared frame contract** — every model renders the same four zones in order: (1) run header (title, model chip, run-context timestamp chip, Run/Re-run/Cancel), (2) verdict row (`Pill`s/`ActionBadge` + `StatCard`s), (3) viz zone (1–2 charts/gauges), (4) reasoning disclosure (`Markdown`, never truncated). Per model:
+
+| Model | Verdict row | Viz zone |
+|---|---|---|
+| Pace | last pred · CI P10–P90 · range MAE | actual-vs-pred chart (CI band, compound dots, stint lines) |
+| Tyres | warning `Pill` · deg rate · cliff P10/50/90 | `StintRunway` + deg projection line |
+| Overtake | threat `Pill` · SituationFacts strip (gap/DRS · Δpace · SC-active) | `Gauge` w/ 0.80 threshold tick |
+| Safety car | threat `Pill` · SituationFacts strip | `Gauge` w/ 0.30 tick + baseline-lift bar |
+| Pit | `ActionBadge` · `CompoundPill` · rec lap | stop-duration interval strip + undercut `Gauge` (0.522 tick) + window details |
+| Radio | alert banners (severity-sorted) | `NlpMessageCard` list + corrections panel + RCM rows |
+
+**States (per model, independent):**
+- **Idle** — identity card hero: one-line "what this model does", eval headline, ghosted preview sketch, `[▶ Run]` (disabled-with-reason until context complete; Radio-lookup additionally until a lap with radio is picked).
+- **Running** — Run→Cancel, elapsed mono timer. Pace: chart-shaped `Skeleton` + "Scoring ~21 laps · typically 45–60 s" (no fake stages — it's one POST; StatusStepper would be theatre here). Others resolve in ≤ a few s: button spinner + result skeleton.
+- **Done** — zones reveal staged (verdict → viz → reasoning, ≤400 ms total, motion-safe); run-context chip pinned ("Lap 18 · ran 14:32").
+- **Stale** — context no longer matches the run: amber banner "Result is for Lap 18 — you're now on Lap 22" + Re-run. Result never silently lies (fixes #28).
+- **Error** — 422/404 inline error card w/ agent name + Retry (config preserved); lap-state DNF 404 pinned to context bar with "jump to last valid lap"; 429 → `Toast` with limit info (pace-range is 5 runs/10 min — surface the budget).
+
+**Cancel** is a client abort (AbortController); the pace-range run continues server-side — the button says "Stop waiting" semantics and the toast notes the rate-budget still burns. Honest, zero backend change.
+
+## 4. Components
+
+**Reuse as-is:** `Combobox`, `Slider` + `DualRangeSlider` (from #35), `Tabs` (mobile rail + radio mode toggle), `Card`, `ChartCard`, `StatCard`, `Pill`, `Skeleton`, `EmptyState`, `Toast`, `Tooltip`, `Button`, `Markdown`, **`Gauge`** (`charts/Gauge.tsx` — built for exactly these three probabilities), ECharts + `F1_THEME` + `tireColors`, `lib/drivers.ts` (team colours; already promoted by #35).
+
+**Shared-primitive extensions (coordinate with #35):**
+- `Gauge` + optional `threshold?: number` prop — a hairline tick + caption at the model's real decision threshold (0.80 overtake · 0.30 SC · 0.522 undercut). One prop, big honesty win; keeps the clean progress-arc design (no traffic-light bands).
+- `ActionBadge` vocab + `REACTIVE_SC` (siren, danger, subtle pulse) — the Pit agent emits it; strategy's enum missed it.
+- `CompoundPill` — used verbatim (pit rec, pace-chart legend, lap-state chip).
+- `StintTimeline` (strategy spec) → parametrize into **`StintRunway`** shared under `src/components/` or `features/agents/`: Lab uses the bare form (now + cliff zone), Strategy the annotated form (+ pit target ▲, stint end).
+
+**New shared (build here, consumed elsewhere):**
+- `NlpMessageCard` — sentiment-edge card: sentiment `Pill`, intent chip, typed entity chips (driver/team/track entities get icons), mono transcript. **Race Analysis Tab 3 (§6.3) renders the identical shape — build once in `src/components/`, not feature-local.**
+
+**Feature-local (`webapp/src/features/lab/`):**
+- `LabPage.tsx` — owns URL, cascade resets, threads context.
+- `ModelRail.tsx` — vertical tablist of `ModelRailItem`s (identity + status dot); collapses to `Tabs` <1024 px.
+- `LabContextBar.tsx` — GP/Driver combos + per-model lap control + lap-state preview chip.
+- `RunFrame.tsx` — the shared scaffold; consumes a `ModelDef` (`{id, icon, title, modelChip, evalHeadline, contextNeeds, run, ResultView}`) — adding a 7th model = one registry entry.
+- `models/` — `PaceResultView`, `TyreResultView`, `SituationResultView` (two lenses: overtake/SC over ONE run), `PitResultView`, `RadioResultView` (+ `RadioLookupControls`, `FreeTextControls`, `CorrectionsPanel`), each with pure ECharts option-builder fns (`buildPaceChartOption` etc.) exported for reuse by Strategy's agent micro-tabs.
+- `RunHistoryStrip.tsx` — per-model past runs (context chip + verdict glyph); click restores.
+- `store.ts` — Zustand run records; `search.ts` — URL contract.
+
+## 5. Interactions & flows
+
+1. **Pick a model** — rail click; URL `model=` updates; bench swaps `ResultView` (fade ≤180 ms); context bar swaps the lap control. Status dots persist across switches.
+2. **Set the moment** — GP → Driver (cascade clears downstream); lap slider live-updates the lap-state chip (query prefetch on release, so single-lap models show compound/age/position before any run). Pace never fetches lap-state (server builds per-lap states itself).
+3. **Run** — mutation fires; button → Cancel + elapsed. Overtake/SC: one `/situation` mutation, `onSuccess` writes a run record tagged for BOTH models (rail shows both dots filled).
+4. **Read** — verdict first, viz second, reasoning one disclosure away. Threshold ticks put every probability in context ("87% vs the 80% action threshold").
+5. **Iterate** — nudge the lap → stale banner → Re-run; each run appends to history; two same-model runs at the same context expose MC-Dropout / LLM variance (tyre P50 wobble is a *feature* to show, not hide).
+6. **Radio dual-mode** — mode toggle in the bench (not the context bar). Lookup: corpus GP ▾ (auto-inherits page GP when the corpus has it, marked "inherited") → driver ▾ → lap ▾ ("7 with radio") → transcript quote card → Analyse. Free text: textarea + example chips → Analyse. Both funnel into the same `RadioResultView`.
+7. **Send to Strategy** — header action deep-links `/strategy?gp=…&driver=…&laps=…` prefilled ("what does the full council say about this moment?"). Never auto-runs (strategy rule).
+
+## 6. Data & migration notes
+
+All under `/api/v1/strategy` (`backend/api/v1/endpoints/strategy.py`):
+
+| Endpoint | Line | Rate limit | Notes |
+|---|---|---|---|
+| `GET /available-gps?year` · `/available-drivers?gp&year` · `/lap-range?gp&driver&year` | 235/244/254 | — | Shared with Strategy; same query keys → cache shared across pages. |
+| `GET /lap-state?gp&driver&lap&year` | 269 | — | 404 = DNF/no telemetry → context-bar error + jump-to-valid. |
+| `POST /pace-range {year,gp,driver,lap_start,lap_end}` | 419 | **5 / 10 min** | → `{predictions[{lap,actual,pred,ci_p10,ci_p90,compound,stint}], count}`. `pred:null` on stint-first laps (no `Prev_LapTime`) → chart gaps. 45–60 s. |
+| `POST /tire {lap_state}` | 538 | 20 / min | → `TireOutput`: `compound, current_tyre_life, deg_rate, laps_to_cliff_p10/p50/p90, warning_level(PIT_SOON\|MONITOR\|OK), reasoning`. |
+| `POST /situation {lap_state}` | 564 | 20 / min | → `RaceSituationOutput`: `overtake_prob, sc_prob_3lap, threat_level(LOW\|MEDIUM\|HIGH), gap_ahead_s, pace_delta_s, sc_currently_active, reasoning`. **Feeds both Overtake and SC views.** NO `contextual_factors`, NO 5/7-lap fields — do not type them. |
+| `POST /pit {lap_state}` | 590 | 20 / min | → `PitStrategyOutput`: `action(…+REACTIVE_SC), recommended_lap?, compound_recommendation, stop_duration_p05/p50/p95, undercut_prob?, undercut_target?, sc_reactive, reasoning`. Nullable undercut pair → conditional render. |
+| `POST /radio {lap_state, radio_msgs[], rcm_events[]}` | 616 | 20 / min | → `RadioOutput`: `radio_events[] (NLP dicts — type tolerantly: sentiment/intent/entities nested under `.analysis` or top-level), rcm_events[], alerts[], reasoning, corrections[{driver,original_intent,suggested_intent,span,reason}]`. Do NOT send a `source` key in radio_msgs (crashes `RadioMessage` — Streamlit comment `:837`). |
+| `GET /radio-available-gps?year` · `/radio-laps?gp&year[&driver]` · `/radio-transcript?gp&driver&lap&year` | 745/763/824 | — | Corpus lookups; `radio-laps` returns per-driver `laps[{lap,text,has_transcript,audio_path}]`. |
+
+Types in `lib/api/strategy.ts` (extend #35's file — same schemas, one source of truth).
+
+**URL** (`features/lab/search.ts`, raw↔component boundary as Dashboard): `/lab?model=tyres&gp=Hungarian Grand Prix&driver=NOR&lap=18&laps=8-28&rmode=lookup&rgp=…&rdrv=VER&rlap=12`. `model` 6-enum default `pace`; `lap` clamped to `/lap-range` after fetch; `laps` encoded `a-b`; radio params only serialized when ≠ inherited context; free text NEVER in URL. Cascade: gp→clears driver/lap/laps/radio-overrides; driver→clears lap/laps. **Deep links reproduce config, never auto-run** (compute + rate budget).
+
+**State split:** TanStack Query staleTime Infinity for gps/drivers/lap-range/lap-state/radio-corpus lookups. Model runs = **`useMutation`** (MC-Dropout + LLM reasoning are non-deterministic — a cache "hit" would misrepresent a fresh run), `onSuccess` appends to Zustand `features/lab/store.ts`: `runs: LabRun[]{id, model, context{gp,driver,lap|lapRange|radioInput}, result, ranAt}` (cap ~30, sessionStorage), `activeRunByModel: Record<ModelId, runId>`. Situation runs register under both `overtake` and `safetycar`. Stale = `run.context ≠ current context` (pure compare, rendered by `RunFrame`).
+
+**Parity amendment to flag in the PR:** §6.4 row "Safety car: gauge + 3/5/7-lap horizon bars" — the 5/7-lap bars are client-fabricated (`model_lab.py:542-543`); this spec replaces them with the real 3-lap probability + baseline-lift framing. Update the row to "gauge + baseline-lift comparison" with a pointer here.
+
+## 7. New features (ranked) & the Strategy overlap
+
+1. **Model identity cards w/ thesis eval headlines** ⚡ (S) — type chip + headline metric (pace MAE 0.4104 s · tyre coverage 0.7078 · overtake AUC-PR 0.5491 · SC 0.0723 (lift 1.67×) · pit P50 MAE 0.4893 s · undercut 0.6739) as static registry constants sourced from the IEEE report. Makes the Lab a model museum — the defense flex.
+2. **Run history + variance view** ⚡ (M, = plan E10) — history strip per model; select two runs of the same model+context → overlay (two runway zones / two dials) exposing MC-Dropout spread. Store already holds the records.
+3. **Surface the dropped Radio fields** ⚡ (S) — corrections cross-check panel + RCM event rows. Free data, real insight.
+4. **SituationFacts strip** ⚡ (S) — gap/DRS + Δpace + SC-active replacing the dead factors panel. Free.
+5. **Send to Strategy / from Strategy** (S) — cross-links both ways ("inspect this instrument" ↔ "convene the council"). URL-only.
+6. **Lap sweep for single-lap models** (M) — run Tyres (or Situation) across N laps sequentially (respects 20/min) → cliff-vs-lap curve; the pace-range treatment generalized. Client-side loop, progress per lap, cancelable.
+7. **Progressive pace streaming** (M, backend-additive) — SSE/NDJSON variant of `/pace-range` emitting per-lap rows → chart paints as it computes, killing the 45–60 s black box. Not parity; note the seam (`RunFrame` running-state accepts partial results).
+8. **Radio audio playback** (S, backend-additive) — corpus rows carry `audio_path`; a static-file route would enable a play button on `NlpMessageCard`.
+
+**Share vs keep distinct (Strategy's agent tabs = same 4 predictors):**
+- **SHARE:** result types (`lib/api/strategy.ts`), pure chart option-builders (`buildPaceChartOption`, `buildCliffRunway`, …), `Gauge`+threshold, `ActionBadge`/`CompoundPill`/`Pill` vocab, `StintRunway`, `NlpMessageCard` (also Race Analysis). Strategy's micro-tabs render the SAME builders at `size="micro"`; the Lab renders `size="full"`. One visual language for one model family — a tyre cliff looks identical everywhere.
+- **KEEP DISTINCT:** the page frames. Lab = run controls + history + education (you fire the model). Strategy tabs = read-only evidence of an orchestrator run (the council fired it). Merging them would blur *who ran what when* — precisely the provenance the stale-run contract protects.
+
+## 8. Better than Streamlit
+
+One relevant lap control instead of two always-on sliders · zero dead UI (empty factors panel gone) and **zero fabricated data** (invented 5/7-lap bars replaced by real baseline-lift) · one `/situation` run feeds two views instead of two divergent runs · stale results labelled instead of silently lying · thresholds ON the dials (a probability finally means something) · corrections + RCM events surfaced (dropped on the floor today) · 45–60 s run is cancelable, framed, and skeleton'd instead of a blind spinner · deep-linkable model+moment · run history makes MC variance a demo feature · model identity cards turn six forms into an instrument collection · one design system (no injected HTML badges/CSS).
+
+## Acceptance criteria (#38, condensed)
+
+§6.4 rows pass (with the documented SC-horizon amendment) · all six models runnable from one context in ≤3 interactions after page load · Overtake+SC provably share one request (network assert in test) · pace-range cancel leaves UI consistent + budget toast · stale banner appears on any context change post-run · `pred:null` laps gap the pace chart (fixture test) · REACTIVE_SC renders a designed badge (not the unknown fallback) · radio free-text round-trips without URL leakage · keyboard: rail is arrow-navigable tablist, Run reachable, disclosures toggle on Enter · reduced-motion: no pulse dots, no staged reveal.
+
+**Key files:** `frontend/pages/model_lab.py` (the source, 930 LOC) · `backend/api/v1/endpoints/strategy.py:398-870` (all endpoints) · output schemas `src/agents/{pace_agent.py:66, tire_agent.py:339, race_situation_agent.py:170, pit_strategy_agent.py:151, radio_agent.py:190}` · grammar `webapp/src/features/dashboard/{search.ts,store.ts,queries.ts,DashboardPage.tsx}` · `webapp/src/charts/Gauge.tsx` (exists — extend, don't rebuild) · sibling specs `docs/migration/design-specs/{strategy.md,comparison.md}` (shared vocab) · route stub `webapp/src/app/router.tsx:55-58`.

--- a/docs/migration/design-specs/race-analysis.md
+++ b/docs/migration/design-specs/race-analysis.md
@@ -1,0 +1,134 @@
+# Race Analysis — Design-First Spec (issues #36/#37)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Race Analysis tab's functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared decisions in `strategy.md` / `comparison.md` (CompoundPill, raw↔component URL boundary, state-tier contract, never-auto-fire-LLM rule).
+
+## 1. Purpose & the job
+
+Race Analysis is the **post-race debrief room**: the only surface that looks at a WHOLE race, whole field, through the engineered features the ML models trained on (fuel-adjusted degradation, deg rate, gap consistency — the featured parquet itself). Job: *"Load any 2025 race, pick up to 3 drivers, and reconstruct the strategic story: how the tyres died, where the pit windows opened, what the radio said, and what the rulebook allowed."* Dashboard = one lap's telemetry; Strategy = one lap's decision; Comparison = one lap head-to-head; **Race Analysis = the 60-lap narrative.**
+
+**THREE KEY DISCOVERIES (all fixable client-side, zero backend work):**
+1. **The radio lookup analyzes nothing.** `race_analysis.py` posts `/strategy/radio` with `lap_state` only and an EMPTY `radio_msgs` list — the agent needs the transcript IN `radio_msgs` (docstring `radio_agent.py:1106`; Model Lab does it right at `model_lab.py:838`). Today's tab runs the whole NLP stack on zero messages.
+2. **RAG citations never render.** Streamlit reads `data["sources"]` — the backend returns `{question, answer, chunks[{text,article,doc_type,year,score}], articles[]}` (`rag_agent.py:91`, `RegulationContext`). The `sources` key doesn't exist, so the citations expander is permanently empty while real article references sit unused in every response.
+3. **The NLP payload is half-discarded.** `run_pipeline` (`radio_agent.py:552`) returns `sentiment_score`, `intent_confidence`, entity `label`s and LLM `corrections[]` (the model auditing the NLP classifiers) — Streamlit drops all four. Also its intent icon map (`box_call`, `tyre_info`…) never matches the real vocab (`INFORMATION·PROBLEM·ORDER·WARNING·QUESTION`), so intent icons have never displayed.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" warning (`race_analysis.py:60`) | KEEP (demoted) | `2025 season` chip in the context bar, per strategy.md #1. |
+| 2 | GP selectbox + explicit "Load race data" button (`:70-95`) | KEEP + IMPROVE | GP `Combobox` URL-bound; **auto-fetch on selection** (TanStack Query kills the rerun-refetch reason the button existed for; picking from a combobox is already deliberate intent). The §6.3 "loader panel" = the context bar's loading state, cancellable. |
+| 3 | Manual CSV/parquet upload in expander (`:141`) | KEEP + IMPROVE | `FileDrop` (.csv/.parquet) inside a "Local data" disclosure of the context bar; becomes the offline/no-backend demo path. Sets a `Local dataset` pill; cleared by picking a GP. |
+| 4 | Driver multiselect max 3 filtering "all tabs" (`:99`) | KEEP + FIX the lie | Multi-`Combobox` cap 3 (Dashboard `MAX_DRIVERS` grammar), team-colour names, URL-bound. Truth today: it filters ONLY Tyres+Gaps (Radio has its own selector; Overview shows the unfiltered head(50)). Define the contract: filters Tyres+Gaps; Dataset gets an All/Selected toggle; Radio browser seeds from first selected driver. Filtering is **client-side over the cached frame — zero network**. |
+| 5 | "Viewing: GP · drivers · laps" caption (`:120-131`) | KEEP + IMPROVE | Proper context strip: GP · `2025` · N drivers · N laps + compounds seen (`CompoundPill` row) — absorbs half of Overview's metrics. |
+| 6 | Tab 1 Tyre deg: compound selectbox + 5 charts (`tire_charts.py`, `race_viz.py`) | KEEP all 5 | Chart switcher (segmented `Tabs`) + "Show all" stacked toggle per §6.3. Compound selector → `CompoundPill` toggle group (only compounds present). Driver-colour lines + compound dash encoding preserved verbatim. |
+| 7 | Tab 2 Gaps: 3 charts + 3-metric summary (`gap_charts.py`) | KEEP + IMPROVE | ECharts (zones → `markArea`, thresholds → labelled `markLine`); summary → 3 `StatCard`s **split per driver** (today the counts blur all selected drivers together) and clickable → highlights qualifying laps on the gap chart. |
+| 8 | Radio activation gate button (`:171-183`) | DROP (cause gone) | Existed to avoid corpus refetch on every Streamlit rerun/tab switch. TanStack Query fetches once on first tab open (`enabled`), cached forever. |
+| 9 | Radio driver/lap dropdowns (blind lap numbers) (`:196-224`) | IMPROVE hard | The `/radio-laps` response ALREADY ships transcript preview text per lap — Streamlit discards it and makes you pick a lap number blind. Build a **radio browser**: driver rail (team colours + message counts) → message list with transcript previews → select → Analyse. |
+| 10 | "Analyse radio" → `render_radio_panel(lap_state)` (`:230`) | KEEP + **FIX BUG** | Must post `radio_msgs=[{driver, lap, text}]` with the corpus transcript (discovery #1). Never pass `source` (crashes `RadioMessage`, per `model_lab.py:837`). |
+| 11 | Radio result: alerts + message cards + sentiment badge + intent + entity chips (`radio_panel.py`) | KEEP + IMPROVE | Premium NLP result card (§3): sentiment `Pill` + score, intent pill w/ correct-vocab lucide icon + confidence, **entities highlighted inline in the transcript**, alerts row, corrections footnote, reasoning disclosure. |
+| 12 | Radio "free text" expander with driver+lap inputs, NO text field (`:263-280`) | REPLACE | It's mislabelled and posts empty `radio_msgs` → analyzes nothing. Replace with a real free-text composer (textarea → `radio_msgs=[{driver:'UNK', lap:1, text}]`, Model Lab pattern) — one shared component that §6.4's Model Lab radio tab reuses. |
+| 13 | Radio JSON download (`:243`) | KEEP | Card header action, filename `radio_{gp}_{driver}_lap{lap}.json`. |
+| 14 | Tab 4 RAG: textarea + query button + answer markdown (`:283-300`) | KEEP + IMPROVE | Query card with suggested-question chips; answer via `Markdown`. |
+| 15 | RAG "Sources" expander (`:295`) | FIX (dead today) | Render `articles[]` as citation chips + `chunks[]` as expandable source passages with doc_type/year/similarity (discovery #2). |
+| 16 | RAG JSON download (`:305`) | KEEP | Card action, serializes the full result verbatim. |
+| 17 | Tab 5 Overview: 3 metrics + columns expander + `df.head(50)` + CSV export (`:315-345`) | KEEP + IMPROVE | Metrics absorbed into context strip; **full virtualized `DataTable`** (not head-50) with column-group presets (Timing / Tyres / Speeds / Gaps / Weather — 26 cols is too many at once); CSV export via DataTable's built-in `buildCsv`. |
+| 18 | Per-tab downloads (§6.3 row) | KEEP + EXTEND | Radio/RAG JSON as today; Dataset CSV; Tyres/Gaps get "Download series (CSV)" as a `ChartCard` action (new, cheap). |
+| 19 | Purple-border chart CSS injection (`:150`) | DROP | `ChartCard` + tokens carry the language (same verdict as strategy.md #21). |
+| 20 | `add_race_lap_column` on upload (`race_processing.py:12`) | KEEP (port) | Pure TS port (LapNumber from Stint+TyreAge cumulative), unit-tested; runs only on uploaded files missing `LapNumber`. |
+| 21 | Client `calculate_gap_consistency`/`calculate_strategic_windows` (`race_processing.py:44,99`) | KEEP (port, upload-only + windows) | `/race-data` already returns `consistent_gap_*`; port both as pure fns — consistency needed for uploads, strategic windows always derived client-side (trivial boolean masks). |
+
+**IA verdict — 5 flat tabs is the wrong grouping, keep 5 areas but in two families.** Tyres/Gaps/Dataset are views of ONE loaded frame; Radio needs only the GP (corpus, not parquet); Regulations needs NOTHING. Streamlit gates all five behind "Load race data" — the redesign gates only the three data tabs, enables Radio as soon as a GP is picked, and **never gates Regulations** (asking a rules question shouldn't require downloading a race).
+
+## 3. Layout & IA
+
+Route `/race` (stub exists, `router.tsx:49-51`).
+
+```
+┌ Header: "Race Analysis"                                  [🔗 Copy link] ┐
+│ ╔═ CONTEXT BAR (sticky, acrylic) ══════════════════════════════════════╗
+│ ║ (2025 · chip) [Grand Prix ▾ Spanish GP]  [Drivers ▾ VER✕ NOR✕ (max 3)]║
+│ ║ loaded strip:  1 182 rows · 20 drivers · 66 laps · 🛞 S M H          ║
+│ ║ ▸ Local data (FileDrop .csv/.parquet)        [Local dataset ✕] pill  ║
+│ ╚═══════════════════════════════════════════════════════════════════════╝
+│ ── Tabs (underline, URL-bound) ─────────────────────────────────────────
+│   TYRES   GAPS   DATASET   │   RADIO   REGULATIONS
+│   └── need loaded data ──┘     └ GP only┘ └ always on ┘
+│
+│ [TYRES]  CompoundPills (S)(M)(H) · switcher: Speed│Fuel-adj│Reg-vs-adj│Rate│% · [Show all]
+│   ┌ STINT GANTT (new): per driver, compound blocks across laps ────────┐
+│   │ VER ▓S▓▓▓│▓▓M▓▓▓▓▓│▓H▓▓   NOR ▓M▓▓▓▓│▓H▓▓▓▓▓                      │
+│   └ ChartCard: active chart (driver colour + compound dash) ───────────┘
+│ [GAPS]   ┌ Gap evolution ┐ ┌ Undercut zones (markArea) ┐
+│          └ Consistency bars ┘  StatCards/driver: Undercut 4 · Overcut 2 · Defend 3
+│ [RADIO]  ┌ browser: drivers rail → msg list w/ transcript previews ┐
+│          │ ▶ lap 23 "box box, we are…"  [Analyse]                  │
+│          └ NLP RESULT CARD: alerts row · blockquote transcript with │
+│            highlighted entities · sentiment+intent pills w/ conf %  │
+│            · corrections footnote · ▸ reasoning · [⬇ JSON]          │
+│          ▸ Free-text composer (shared w/ Model Lab)                 │
+│ [REGULATIONS] query card + suggested chips → ANSWER CARD:           │
+│            Markdown answer · citation chips ⚖ Art 48.3 ⚖ Art 55.1  │
+│            · ▸ source passages (doc_type · year · score) · [⬇ JSON] │
+│            · session Q&A history rail                               │
+│ [DATASET] column presets: Timing│Tyres│Speeds│Gaps│Weather · All/Selected
+│            virtualized DataTable (full frame) · [⬇ CSV]             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**States:** Idle (no GP: EmptyState hero + GP quick-pick from `available-gps` + FileDrop; only Regulations tab live) · Loading (context strip skeleton + tab-area `Skeleton`, cancellable AbortController) · Loaded (tabs enable, staged ≤300ms; no drivers selected → Tyres/Gaps show EmptyState with **podium quick-pick chips** — one click seeds the filter from final-lap `Position`) · Error (`/race-data` 404/500 → inline error card + Retry + FileDrop promoted as the fallback — its real job) · Upload-active (`Local dataset` pill; GP combobox cleared; radio/RAG unaffected) · Radio no-corpus (EmptyState "No radio corpus for this GP" + free-text composer still available) · RAG rate-limited (429 → Toast + button cooldown, burst capacity 5).
+
+## 4. Components
+
+Reuse: `Tabs` (underline top-level, segmented for the tyre chart switcher), `Combobox` (GP, drivers cap 3), `FileDrop`, `Pill` (+`compound` prop for tyre chips; tones for sentiment/intent/alerts), `DataTable`+`buildCsv`, `ChartCard` (collapse + actions slot), `StatCard`, `EmptyState`/`Skeleton`/`Toast`/`Tooltip`/`Button`/`Card`, `Markdown` (RAG answers, radio reasoning), ECharts+`F1_THEME`, `tireColors`, dashboard `lib/compounds.ts` (CompoundID→name map lives here) and `lib/drivers.ts` (lifted to `src/lib/` per strategy.md). Shared primitives from strategy.md: `CompoundPill` (stint gantt + compound toggles), `ConfidenceDial` at `sm` (sentiment/intent confidence).
+
+**No new SHARED primitives.** Feature-local (`features/race/components/`): `RaceContextBar` (selectors + loaded strip + FileDrop disclosure), `StintGantt` (SVG lap axis, compound blocks from Driver×Stint×Compound — doubles as the legend for compound dashes), `TyreChartSwitcher` (segmented + show-all; wraps the 5 ECharts builders), `GapCharts` (3 builders + `markArea` zones), `StrategicWindowCards`, `RadioBrowser` (driver rail + message list w/ previews), `RadioResultCard` (alerts + `TranscriptQuote` with entity `<mark>`s + pills + corrections + reasoning), `RadioFreeTextComposer` (**shared seam: Model Lab §6.4 imports this**), `RagQueryCard` + `RagAnswerCard` (+`CitationChip`, `SourcePassage` — Chat's future RAG rendering can lift them), `DatasetTable` (presets + toggle). Pure libs (`features/race/lib/`): `raceFrame.ts` (parse/normalize records, `addRaceLapColumn`, gap consistency + strategic windows ports — ALL unit-tested against Python behaviour), `tyreSeries.ts` / `gapSeries.ts` (frame → ECharts option builders, driver-colour + compound-dash encoding).
+
+## 5. Interactions & flows
+
+1. **Load** — pick GP → auto-fetch `/race-data` (staleTime Infinity) → strip fills, tabs enable. Upload path: FileDrop → parse client-side (CSV via Papa-style parser; parquet via `hyparquet`, lazy-loaded chunk) → normalize through `raceFrame.ts` → same downstream rendering, `Local dataset` pill.
+2. **Filter** — driver chips add/remove instantly (client-side slice of the cached frame, zero refetch). Cascade: GP change clears drivers + radio selection (URL boundary, Dashboard pattern).
+3. **Explore tyres** — compound pill filters chart 1; switcher flips between the 5 views; "Show all" stacks them (ChartCards, collapsible); stint gantt hover highlights that driver's series.
+4. **Explore gaps** — hover unified tooltip (axisPointer); click a window StatCard → `markPoint`s flag its laps; **"Analyse this lap in Strategy" context action** on chart click → deep-link `/strategy?gp&driver&laps=a-b` (prefilled, never auto-runs — coherence with strategy.md §6).
+5. **Radio** — open tab → corpus query fires once → browser renders; select message (URL `rdriver`/`rlap`) → Analyse → POST with the transcript in `radio_msgs` → result card staged reveal (alerts → transcript → pills → disclosure), `aria-live=polite`. Cached per (gp,driver,lap) — re-selecting a past message is instant. Free-text composer always one disclosure away.
+6. **Regulations** — type or tap a suggested chip → POST `/rag` → answer card; each Q&A appends to a session history rail (click restores). Deep link `?q=` prefills, never auto-fires.
+7. **Export** — per-tab: radio JSON, RAG JSON, dataset CSV, chart-series CSV.
+
+## 6. Data & migration notes
+
+Endpoints (all already in `lib/api/schema.ts` — typed client ready, zero backend work):
+- `GET /api/v1/strategy/available-gps?year=2025` (`strategy.py:235`) — GP list matching the featured parquet.
+- `GET /api/v1/telemetry/race-data?year&gp[&driver]` (`telemetry.py:226`) → `{race_data: Record[], count}`; 26 cols (`_RACE_DATA_COLS` + `TyreAge`): Driver, DriverNumber, LapNumber, Stint, SpeedI1/I2/FL/ST, Compound, TyreLife, FreshTyre, Team, Position, CompoundID, LapTime_s, FuelLoad, FuelAdjusted{LapTime,DegAbsolute,DegPercent}, DegradationRate, Air/TrackTemp, GP_Name, GapToCarAhead/Behind, consistent_gap_{ahead,behind}_laps. NaN→null already sanitized. Payload = whole field (~1-3 MB) → fetch once, filter client-side.
+- `GET /api/v1/strategy/radio-available-gps?year` (`strategy.py:746`) — badge radio availability on the GP combobox.
+- `GET /api/v1/strategy/radio-laps?gp&year[&driver]` (`:764`) → `{drivers:[{driver, driver_number, laps:[{lap, text, has_transcript, audio_path}]}]}` — **the browser's preview text is here**.
+- `POST /api/v1/strategy/radio {lap_state, radio_msgs, rcm_events}` (`:616`, rate 20/min) → `result: {radio_events[{message, timestamp, analysis:{sentiment, sentiment_score, intent, intent_confidence, entities[{text,label}], rcm}}], rcm_events[], alerts[{source,intent,message,driver}], reasoning, corrections[{driver, original_intent, suggested_intent, span, reason}]}`. **Contract: transcript goes IN `radio_msgs`** (discovery #1). Intent vocab: INFORMATION·PROBLEM·ORDER·WARNING·QUESTION; sentiment: negative/neutral/positive (normalize case).
+- `POST /api/v1/strategy/rag {question}` (`:656`, burst 5) → `result: {question, answer, chunks[{text, article, doc_type, year, score}], articles[]}` — cite from `articles`, never from answer prose (`rag_agent.py:84-88`: the LLM may hallucinate article numbers; chunk metadata is reliable).
+
+URL (`features/race/search.ts`, raw↔component boundary cloned from Dashboard): `/race?gp=Spanish Grand Prix&drivers=VER,NOR&tab=tyres[&compound=SOFT][&rdriver=VER&rlap=23][&q=...]`. `drivers` CSV upper/dedup/cap-3 (reuse `capDriversCsv` shape); `tab` enum tyres|gaps|dataset|radio|regs default tyres; year constant 2025. GP change cascades: clears drivers, rdriver/rlap, compound. Deep links reproduce selection; **POSTs never auto-fire.**
+
+State tiers: **URL** = gp/drivers/tab/compound/radio-selection/q-prefill · **TanStack Query** (staleTime Infinity) = race-data, radio-available-gps, radio-laps, and radio analyses as queries keyed `['strategy','agent','radio', gp, driver, lap]` enabled on Analyse (the agent-POST-as-query precedent from strategy.md §6 — caching per message for free, mirroring Streamlit's `radio_result_{gp}_{driver}_{lap}`) · **useMutation + Zustand history** = RAG Q&A (free-input generative → `features/race/store.ts`, `ragHistory` cap 10, not persisted) · **Zustand UI** = tyre show-all toggle, dataset column preset + All/Selected (ephemeral; only view-layout persists, Dashboard convention). Uploaded frames live in a non-persisted store slice (too big for storage), flagged `source:'upload'`.
+
+Gotchas: `race_analysis.py` maps codes↔numbers both ways — keep DriverNumber as the join key internally, codes in URL/UI · uploads may lack LapNumber → run `addRaceLapColumn` port · uploads lack gap-consistency cols → run the port before gap charts · `MAX_LAPS=66` clamp in every race_viz builder — preserve · compound dash map (solid/dash/dot/dashdot/longdash by CompoundID) is the established encoding, keep it · radio `laps[].has_transcript=false` entries: show greyed with "no transcript" (analysable only via Whisper on backend — out of scope, disable Analyse).
+
+## 7. New features (ranked)
+
+1. **Stint gantt** ⚡ (S) — the classic tyre-strategy graphic from Driver×Stint×Compound already in the frame; anchors the whole Tyres tab and legends the dash encoding. 
+2. **Entity-highlighted transcripts + confidence meters + corrections** ⚡ (S) — renders payload fields discarded today (`sentiment_score`, `intent_confidence`, entity labels, LLM `corrections[]` = "the model auditing the models", a thesis-demo gem).
+3. **RAG citations + source passages** ⚡ (S) — `articles[]` chips + `chunks[]` disclosures; fixes the permanently-empty Sources expander.
+4. **Radio browser with previews** (M) — transcript text already in `/radio-laps`; kills the blind lap dropdown.
+5. **Per-driver strategic-window cards + chart highlight** (S) — clickable counts → markPoints.
+6. **Cross-links with context** (S) — gap chart lap → `/strategy` prefilled; header "Ask AI about this race" → `/chat` (disabled-w/-tooltip until #39, comparison.md #15 pattern).
+7. **Podium quick-pick** (XS) — empty-filter EmptyState seeds top-3 from final `Position`.
+8. **Position/race-story chart** (M) — Position per lap is in the frame; a 6th "Race story" view (the `/race-data` docstring already envisions position evolution). Backlog, not parity.
+9. **Radio audio playback** (M + backend) — `audio_path` exists in the corpus but no serving endpoint; additive B1 if wanted.
+
+Recommended for the build issue: parity + ranks 1-5 (all client-side, mostly rendering data already in hand); 6-7 cheap follow-ups; 8-9 backlog.
+
+## 8. Better than Streamlit
+
+Radio analysis actually analyzes (the empty-`radio_msgs` bug is structurally impossible: the browser owns the transcript and the POST builder requires it) · RAG answers carry their citations (dead `sources` key → real `articles`/`chunks`) · the NLP result shows its confidence and its self-audit instead of discarding both · browse radio by transcript preview, not blind lap numbers · Regulations never gated behind a data load, Radio needs only the GP · driver filtering is instant and honest about scope (no fake "filters all tabs") · full virtualized table vs head(50) · every view deep-linkable (`tab`, `compound`, radio message in the URL) · no activation-gate ceremony, no injected CSS, one coherent chart language (ECharts F1_THEME, ChartCard, team colours everywhere).
+
+## Acceptance criteria (condensed)
+
+§6.3 parity rows all pass (5 tyre charts, 3 gap charts + summary, radio gate-flow superseded by lazy query + browser, RAG with citation, dataset + exports) · radio POST carries the corpus transcript in `radio_msgs` (regression test: never empty when a corpus message is selected) · RAG card renders `articles[]` when non-empty · `raceFrame.ts` ports (lap column, gap consistency, strategic windows) unit-tested against Python-derived fixtures · upload path: CSV + parquet round-trip renders all three data tabs · URL round-trip incl. `tab`/`rdriver`/`rlap` · Regulations usable with zero race data loaded · driver cap 3 enforced at the search boundary.
+
+**Key files:** `frontend/pages/race_analysis.py` · `frontend/components/race_analysis/{tire_charts,gap_charts,radio_panel}.py` · `frontend/utils/{race_viz,race_processing}.py` · `backend/api/v1/endpoints/telemetry.py:139-284` (`/race-data`) · `backend/api/v1/endpoints/strategy.py:616-871` (`/radio`, `/rag`, radio corpus GETs) · `src/agents/radio_agent.py:552` (pipeline schema) + `src/agents/rag_agent.py:62-111` (`RegulationContext`) · correct radio contract exemplar `frontend/pages/model_lab.py:832-841` · grammar `webapp/src/features/dashboard/{search,store,queries}.ts` + `webapp/src/components/{Tabs,DataTable,FileDrop,Pill,Markdown,ChartCard,StatCard,EmptyState}.tsx` + `charts/echartsTheme.ts` + `styles/tokens.css`.

--- a/docs/migration/design-specs/strategy.md
+++ b/docs/migration/design-specs/strategy.md
@@ -1,0 +1,114 @@
+# Strategy — Design-First Spec (issue #35)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Strategy tab's functionality and build the elevated migrated interface, NOT a 1:1 port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts, design-system primitives).
+
+## 1. Purpose & the job
+
+Strategy is the **pit-wall decision surface**: the UI of the N31 multi-agent orchestrator, the crown jewel of the TFG. Its job: *"Put me at any lap of any 2025 race, let me set my risk appetite, and give me a defensible strategy call — with the evidence trail (per-agent analysis, Monte Carlo scores, regulation basis) one click deep."*
+
+Streamlit treats this as a form → results dump. The migrated version = a **three-act experience**: configure a scenario → watch the agent council deliberate → read a decision brief. **KEY DISCOVERY: the orchestrator returns a 14-field v2 recommendation (`src/agents/strategy_orchestrator.py:319`) and Streamlit renders only 6.** The core move is surfacing the whole schema (pit plan, pace instruction, contingencies, key risks) — "a badge and prose" → a genuine strategy brief. Zero backend work.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" `st.warning` (`strategy.py:37`) | KEEP (demoted) | Info chip inside the scenario bar, not a full-width banner. §6.2. |
+| 2 | GP selector (`strategy.py:45`) | KEEP | `Combobox`, URL-bound. |
+| 3 | Driver selector, gated on GP (`strategy.py:60`) | KEEP | disabled until GP; cascading reset. |
+| 4 | Optional Rival selector (`strategy.py:70`) | KEEP + IMPROVE | Team-colour names; rival powers a "duel strip" with deltas. |
+| 5 | Lap-range dual slider + "analyses lap X (end of range)" (`strategy.py:94-100`) | KEEP + IMPROVE | `DualRangeSlider`; explicit "Analysing lap 28" chip; range = viewport of the Stint Timeline. |
+| 6 | Risk slider 0-1 + captions (`strategy.py:102-105`) | KEEP + IMPROVE | `Slider` with Conservative/Balanced/Aggressive tick labels + live zone label. |
+| 7 | Run button (`strategy.py:111`) | KEEP + IMPROVE | Primary CTA; disabled-with-reason; elapsed timer + cancel (client abort). |
+| 8 | `st.status` narrated stages (`strategy.py:210-230`) | KEEP + IMPROVE | `StatusStepper` → an **Agent Deliberation panel** (§5). Same scripted stages, premium choreography. |
+| 9 | Lap snapshot: compound/tyre age/gap/lap time/SC prob (`strategy.py:160-188`) | KEEP | 5 `StatCard`s; compound as `CompoundPill` in tyre colour. |
+| 10 | Rival snapshot (`strategy.py:120-157`) | KEEP + IMPROVE | Folded into the duel strip with computed deltas. |
+| 11 | Recommendation card (`strategy_card.py`) | KEEP + IMPROVE (the big one) | Glow `Card`. Surfaces the FULL v2 schema: `pace_mode`, `target_lap_time_s`, `pit_lap_target`, `compound_next`, `undercut_target`, `risk_posture`, `key_risks`, `contingencies`, `expected_stint_end` — all discarded by Streamlit today. |
+| 12 | Reasoning truncated to 800 chars (`strategy_card.py:65`) | DROP truncation | Full LLM prose via `Markdown` in an "Engineer's note" disclosure. |
+| 13 | `risk_level` metric (`strategy_card.py:59`) | DROP (superseded) | Render `risk_posture` (AGGRESSIVE/BALANCED/DEFENSIVE) pill; renderer stays tolerant if absent. |
+| 14 | Regulation context expander (`strategy_card.py:69`) | KEEP | Disclosure with lucide `Scale`, only when `regulation_context !== ""`. |
+| 15 | JSON download (`strategy.py:255`) | KEEP | Blob download as card header action; filename `strategy_{gp}_{driver}_lap{lap}.json`. |
+| 16 | Scenario score bars, winner in accent (`scenario_chart.py`) | KEEP + IMPROVE | ECharts bars, plot **E with P10-P90 whiskers** (backend returns `{E,P10,P90,score}`; Streamlit plots only `score`) + delta-to-winner. |
+| 17 | `EXTEND_STINT` in colour maps (`strategy_card.py:17`, `scenario_chart.py:14`) | DROP | v2 enum = `STAY_OUT｜PIT_NOW｜UNDERCUT｜OVERCUT｜ALERT`. Add ALERT (pulsing danger) + neutral fallback. |
+| 18 | 4 agent sub-tabs, lazy-fetch + cache (`agent_tabs.py`) | KEEP + IMPROVE | Segmented `Tabs`; lazy via TanStack Query `enabled`-on-first-open; cache free via queryKey; each tab gets a micro-chart. Optional 5th Radio tab (§7). |
+| 19 | Per-agent collapsible reasoning (`agent_tabs.py`) | KEEP | Disclosure per tab. |
+| 20 | Result persists (`st.session_state["strategy_result"]`) | KEEP + IMPROVE | Zustand run records; survives route changes; enables run history (§7). |
+| 21 | Purple-border chart CSS injection (`strategy.py:196`) | DROP | `ChartCard` + tokens carry the language. |
+| 22 | Centered "Strategy Advisor" title | KEEP (adapted) | Standard `Header title="Strategy"`. |
+
+## 3. Layout & IA
+
+IA: sticky Scenario Bar → Deliberation (transient) → Decision Brief (hero) → Evidence (scenario scores + timeline + agent tabs). Decision first, evidence below.
+
+```
+┌ Header: "Strategy"                        [⬇ JSON] [🔗 Copy scenario link] ┐
+│ ╔═ SCENARIO BAR (sticky; collapses to a chip row after a run) ═══════════╗ │
+│ ║ (2025 season · chip)                                                   ║ │
+│ ║ [Grand Prix ▾]   [Driver ▾ VER]   [Rival ▾ LEC (optional)]             ║ │
+│ ║ Lap window  ●━━━━━━━━━━● 8–28   → Analysing lap 28                     ║ │
+│ ║ Risk  ●━━━━○  0.55 · Balanced          [▶ Run strategy]                ║ │
+│ ╚════════════════════════════════════════════════════════════════════════╝ │
+│    collapsed after run:  ⟨Hungarian GP⟩ ⟨VER⟩ ⟨vs LEC⟩ ⟨Lap 28⟩ ⟨risk .55⟩ │
+│                                            [Edit scenario] [↻ Re-run]       │
+│ ── RUNNING (replaces zones below) ── Agent Deliberation: StatusStepper +   │
+│    5 pulsing agent chips (Pace·Tire·Pit·SC·Radio) + elapsed + [Cancel]      │
+│ ── COMPLETE ──                                                             │
+│ ┌ SITUATION STRIP: [● MEDIUM][Tyre 14][Gap +2.4s][Lap 78.912][SC 12%]     │
+│ │  duel row w/ rival: VER vs LEC : Δtyre −3, gap +2.4s, LEC HARD 79.1 ────┐│
+│ ┌ DECISION CARD (glow) ──────────────┐ ┌ SCENARIO SCORES ────────────────┐│
+│ │ ⛭ PIT NOW              ◔ 82%       │ │ PIT NOW ▓▓▓▓▓▓ .61 ─┼─          ││
+│ │ BALANCED · PUSH · target 78.450    │ │ STAY OUT ▓▓▓▓ .44  ─┼─          ││
+│ │ Plan: box lap 29 → MEDIUM · under- │ │ (E dot + P10–P90 bar)          ││
+│ │ cut SAI · ▸ Engineer's note        │ ├ STINT TIMELINE ────────────────┤│
+│ │ Key risks: • cliff P10 @ lap 22    │ │ 8══now 28═▒cliff▒═▲box 29 ⌁end │││
+│ │ Playbook: IF SC → PIT NOW (P1) …   │ └────────────────────────────────┘│
+│ │ ▸ ⚖ Regulation context             │                                   │
+│ └────────────────────────────────────┘                                    │
+│ ┌ AGENT BREAKDOWN — segmented Tabs: Pace|Tyres|Situation|Pit ────────────┐│
+│ │  MetricRow/StatCards + one micro-chart + ▸ reasoning disclosure         ││
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**States:** Idle (bar expanded + EmptyState with ghosted preview; progressive gating) · Running (bar locks, deliberation IS the loading state, no fake skeletons) · Complete (deliberation collapses, brief reveals staged, bar collapses to chips) · Error (lap-state 404 → inline pinned to bar; orchestrator 422/500 → error Card + Retry, config preserved; 429 rate-limit 5/min → Toast) · Stale (selector changed after a run → results stay but labelled "scenario has changed" + prominent Re-run).
+
+## 4. Components
+
+Reuse: `Combobox`, `DualRangeSlider`+`Slider`, `StatusStepper` (written for this pipeline), `Card` glow (decision — the one glow), `Card` resting, `Tabs` segmented, `StatCard`/`MetricRow`, `Pill`, `Markdown`, `ChartCard`, `Skeleton`/`EmptyState`/`Toast`/`Tooltip`/`Button`, ECharts+`F1_THEME`+`tireColors`. Lift `features/dashboard/lib/drivers.ts` → `src/lib/` (two features need it).
+
+**New shared primitives (3):** `ActionBadge` (action vocab at hero+sm sizes: STAY_OUT→CircleCheck/success · PIT_NOW→Wrench/danger · UNDERCUT→ArrowDownRight/warning · OVERCUT→ArrowUpRight/blue · ALERT→TriangleAlert/danger pulse · unknown→neutral) · `ConfidenceDial` (SVG radial %, tooltip "LLM self-assessed — qualitative, not calibrated") · `CompoundPill` (tyre chip from `tireColors`).
+
+**Feature-local (`features/strategy/components/`):** `ScenarioBar`, `AgentDeliberation`, `DecisionCard`, `ContingencyList` (playbook: IF trigger → ActionBadge (priority), renders `contingencies[≤4]`), `ScenarioScoresChart` (E bar + P10-P90 whisker + Δ-to-winner), `StintTimeline` (SVG lap axis: now marker, cliff zone from Tyre P10→P90, `pit_lap_target` ▲ + `compound_next` pill, `expected_stint_end`; degrades gracefully), `SituationStrip`+`RivalDuel`, `AgentTabs` (micro-charts per tab: Pace→CI band, Tyres→cliff P10/50/90 3-bar, Situation→2 ConfidenceDials, Pit→stop P05/50/95 range + undercut dial + CompoundPill).
+
+## 5. Interactions & flows
+
+1. **Configure** — progressive disclosure (GP→Driver→sliders+Run); risk slider live-labels zone; analysed-lap chip tracks the range's right thumb; Run disabled-with-reason.
+2. **Deliberate** — on Run, bar locks, deliberation mounts. StatusStepper stages (only 2 real backend boundaries): *Building lap state…* (real GET /lap-state) → *Running agents Pace·Tire·Pit·SC·Radio…* (real POST /recommend; 5 chips pulse 800ms looping, motion-safe) → *Scoring 500 Monte Carlo ×4…* (scripted timer ~60% elapsed) → *Synthesizing…* (until POST resolves). Elapsed mono; Cancel = AbortController; `aria-live=polite`.
+3. **Decide** — stepper→complete, panel collapses, brief enters staged (card fade+rise 250ms → strip → bars animate → timeline draws → tabs), <800ms, motion-safe. Bar collapses to sticky chips.
+4. **Audit** — confidence dial + qualitative tooltip; reasoning one disclosure away (full Markdown, no truncation); agent tabs lazy-fire on first open, cached; regulation disclosure only when non-empty.
+5. **Iterate** — nudge lap/risk → stale notice + Re-run; each run appends to session history → lap-by-lap walk.
+
+## 6. Data & migration notes
+
+Backend (`backend/api/v1/endpoints/strategy.py`, `/api/v1/strategy`): `GET /available-gps?year=2025` (235) · `GET /available-drivers?gp&year` (244) · `GET /lap-range?gp&driver&year` (254) · `GET /lap-state?gp&driver&lap&year` (269) · `POST /recommend {lap_state, gap_ahead_s, pace_delta_s:0, risk_tolerance}` → `{agent:"orchestrator", result: StrategyRecommendation}` (677; **rate-limit 5/min**) · `POST /pace|/tire|/situation|/pit {lap_state}` → typed results (398-614) · `POST /radio`,`GET /radio-*` (optional 5th tab) · `POST /simulate` SSE (899, NOT for #35 — future streaming race-mode seam).
+
+Type in `lib/api/strategy.ts`. Orchestrator v2 schema (`strategy_orchestrator.py:319`): `action` (5-enum incl ALERT), `reasoning`, `confidence`, `pit_lap_target?`, `compound_next?`, `undercut_target?`, `pace_mode`, `target_lap_time_s?`, `risk_posture`, `contingencies[≤4]{trigger,action,priority,rationale}`, `key_risks[≤5]`, `expected_stint_end?`, `scenario_scores: Record<string,{E,P10,P90,score}>`, `regulation_context`. **Every optional field renders conditionally — null-tolerant throughout** (a no-LLM run returns sparse fields).
+
+URL (`features/strategy/search.ts`, same raw↔component boundary as Dashboard): `/strategy?gp=...&driver=NOR&rival=PIA&laps=8-28&risk=0.55`. `laps` encoded "a-b"; `risk` clamped [0,1] default 0.5; `rival` dropped if == driver; year constant 2025. Cascade: gp→clears driver/rival/laps; driver→clears rival/laps. **Deep links reproduce config, NEVER auto-fire the run** (LLM call, rate-limited, non-deterministic) — land on prefilled idle w/ Run highlighted.
+
+State split: TanStack Query staleTime:Infinity for gps/drivers/lap-range/lap-state + the 4 agent POSTs as queries keyed `['strategy','agent',<name>,gp,driver,lap]` `enabled` on first tab open. `useMutation` for POST /recommend (non-deterministic, rate-limited). Zustand `features/strategy/store.ts` (not persisted / sessionStorage): `runs: RunRecord[]{id,config,lapState,result,ranAt}` (cap ~20), `activeRunId`, `pinnedRunId`. Mutation onSuccess appends → history + compare nearly free.
+
+Gotchas: map old→new vocab (EXTEND_STINT gone, ALERT new, risk_level→risk_posture); JSON download serializes full `result` verbatim; `gap_ahead_s` from `lap_state.driver.gap_ahead_s` w/ 2.0 fallback (as Streamlit).
+
+## 7. New features (ranked)
+
+1. **Full v2 decision brief** ⚡ — render pace_mode, target_lap_time_s (radio line `TARGET 78.450 — PUSH`), pit plan (pit_lap_target+compound_next+undercut_target in team colour), risk_posture, key_risks, contingencies. Data already in every response.
+2. **Scenario scores with uncertainty** ⚡ — E + P10-P90 whiskers + Δ-to-winner. Shows how close the call was.
+3. **Run history rail + lap-walk** — session strip of past runs; click restores; confidence-across-laps sparkline. Cheap (store holds records).
+4. **Pin & compare** — two-column diff of two runs.
+5. **Risk sweep** — fire /recommend at risk 0.25/0.5/0.75, show if the action flips. Burns 3/5 rate budget → explicit button, sequential, post-core.
+6. **Radio evidence tab (5th agent)** — POST /radio + radio GETs exist; share components w/ Race Analysis radio.
+7. **Race mode (streaming)** — POST /simulate streams SSE lap-by-lap. Out of scope; build deliberation+card as pure fns of a RunRecord so a streaming producer can drive them later. Note the seam.
+
+## 8. Better than Streamlit
+Whole recommendation not 40% of it (14 vs 6 fields, free) · uncertainty visible (P10-P90 whiskers, CI band) · shareable scenarios (URL=config) · deliberation moment vs spinner · stale-result honesty · untruncated reasoning · iteration as first-class loop · coherent system (shared grammar, no injected CSS/raw-HTML metric blocks).
+
+**Key files:** `frontend/pages/strategy.py` · `frontend/components/strategy/{strategy_card,agent_tabs,scenario_chart}.py` · `backend/api/v1/endpoints/strategy.py` (235-745) · `src/agents/strategy_orchestrator.py:319` (v2 schema, the centerpiece) · grammar `webapp/src/features/dashboard/*` + `webapp/src/components/{Card,StatusStepper,Tabs,Slider,StatCard,Pill}.tsx` + `charts/echartsTheme.ts` + `styles/tokens.css`.


### PR DESCRIPTION
Design-first blueprints for Strategy / Comparison / Race Analysis / Model Lab / Chat+Voice — the plan for building each migrated tab elevated (not a Streamlit port). Each spec inherits the Dashboard grammar and includes KEEP/IMPROVE/DROP, layout, components, flows, data notes, new features and acceptance criteria. Docs only.