### PR TITLE
feat(webapp): elevate the dashboard (auto-load, driver colours, icons, restructure)

### DIFF
--- a/webapp/bun.lock
+++ b/webapp/bun.lock
@@ -24,6 +24,7 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.6",
         "eventsource-parser": "^3.1.0",
+        "lucide-react": "^1.24.0",
         "openapi-fetch": "^0.17.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -540,6 +541,8 @@
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lucide-react": ["lucide-react@1.24.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -37,6 +37,7 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.6",
     "eventsource-parser": "^3.1.0",
+    "lucide-react": "^1.24.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -60,6 +60,18 @@ function XIcon({ className }: { className?: string }) {
   )
 }
 
+/** Small colour swatch shown before an option's label when `getOptionAccent`
+ *  is provided (e.g. a driver's team colour in the drivers multi-select). */
+function AccentDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block size-2 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+  )
+}
+
 const PANEL_CLASSNAME = cn(
   'w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl border border-divider bg-bg-4',
   'shadow-[var(--shadow-elev)] outline-none',
@@ -181,13 +193,26 @@ export interface MultiComboboxProps {
   className?: string
   /** Accessible name for the trigger when the visible label lives elsewhere. */
   ariaLabel?: string
+  /** When provided, renders a small colour dot before an option's label (both
+   *  the selected chips and the dropdown items) — e.g. a driver's team colour. */
+  getOptionAccent?: (value: string) => string | undefined
 }
 
 /** Multi-select combobox. Selections render as removable chips in the
  *  trigger; once `max` is reached, remaining options render disabled in the
  *  list instead of silently doing nothing on select. */
 export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(function MultiCombobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, max, className, ariaLabel },
+  {
+    options,
+    value,
+    onChange,
+    placeholder = 'Select...',
+    disabled,
+    max,
+    className,
+    ariaLabel,
+    getOptionAccent,
+  },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -240,26 +265,30 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
           )}
         >
           {selectedOptions.length === 0 && <span className="px-1 text-fg-3">{placeholder}</span>}
-          {selectedOptions.map((option) => (
-            <span
-              key={option.value}
-              className="flex items-center gap-1 rounded-full bg-bg-5 py-0.5 pl-2.5 pr-1 text-fg-1"
-            >
-              {option.label}
-              <button
-                type="button"
-                aria-label={`Remove ${option.label}`}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  removeValue(option.value)
-                }}
-                onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-full p-0.5 text-fg-3 hover:bg-bg-4 hover:text-fg-1"
+          {selectedOptions.map((option) => {
+            const accent = getOptionAccent?.(option.value)
+            return (
+              <span
+                key={option.value}
+                className="flex items-center gap-1 rounded-full bg-bg-5 py-0.5 pl-2.5 pr-1 text-fg-1"
               >
-                <XIcon className="size-3" />
-              </button>
-            </span>
-          ))}
+                {accent && <AccentDot color={accent} />}
+                {option.label}
+                <button
+                  type="button"
+                  aria-label={`Remove ${option.label}`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    removeValue(option.value)
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  className="rounded-full p-0.5 text-fg-3 hover:bg-bg-4 hover:text-fg-1"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </span>
+            )
+          })}
           <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
         </div>
       </Popover.Trigger>
@@ -267,6 +296,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
         {options.map((option) => {
           const selected = value.includes(option.value)
           const disabledItem = !selected && atMax
+          const accent = getOptionAccent?.(option.value)
           return (
             <Command.Item
               key={option.value}
@@ -275,7 +305,10 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
               onSelect={() => handleSelect(option.value)}
               className={cn(ITEM_CLASSNAME, !disabledItem && 'cursor-pointer')}
             >
-              <span className="truncate">{option.label}</span>
+              <span className="flex min-w-0 items-center gap-2">
+                {accent && <AccentDot color={accent} />}
+                <span className="truncate">{option.label}</span>
+              </span>
               {selected && <CheckIcon className="size-4 shrink-0 text-purple-400" />}
             </Command.Item>
           )

--- a/webapp/src/features/dashboard/DashboardPage.tsx
+++ b/webapp/src/features/dashboard/DashboardPage.tsx
@@ -1,20 +1,27 @@
-// Dashboard page (issue #34) — the telemetry pilot screen, full §6.1 parity.
+// Dashboard page (issue #34 + elevation). The telemetry workspace.
 //
-// This component owns the URL (selector state) and threads it to every section:
-// it reads the validated search, exposes the component-facing array shape, and
-// applies the cascading reset (changing year clears GP/session/drivers, etc.).
-// Sections are dumb consumers of `search` — the lap chart writes loaded laps to
-// the dashboard store, the telemetry grid + circuit map read them.
+// This component owns the URL (selector state), threads it to every section,
+// and runs the workspace-level behaviours: prewarm the FastF1 session on
+// session-select, auto-load each driver's fastest lap when lap-times arrive
+// (so the telemetry charts fall in without a manual click), and reset loaded
+// laps when the session or drivers change. Sections are dumb consumers of
+// `search`; the lap chart writes loaded laps to the store, the telemetry grid
+// and circuit map read them.
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Link, getRouteApi } from '@tanstack/react-router'
+import { ArrowRightLeft, Gauge, TriangleAlert } from 'lucide-react'
 import { Header } from '@/app/Header'
 import { Button } from '@/components/Button'
+import { EmptyState } from '@/components/EmptyState'
+import { cn } from '@/lib/cn'
 import { SelectorsToolbar } from './components/SelectorsToolbar'
 import { LapChartSection } from './components/LapChartSection'
 import { CircuitDominationSection } from './components/CircuitDominationSection'
 import { TelemetryGrid } from './components/TelemetryGrid'
 import { useDashboardStore } from './store'
+import { useLapTimes, prewarmTelemetry } from './queries'
+import { fastestLapPerDriver } from './lib/fastestLap'
 import { fromRaw, toRaw, type DashboardSearch } from './search'
 
 const routeApi = getRouteApi('/dashboard')
@@ -23,32 +30,61 @@ export function DashboardPage() {
   const raw = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
   const search = fromRaw(raw)
+
   const pruneLaps = useDashboardStore((s) => s.pruneLaps)
   const clearLaps = useDashboardStore((s) => s.clearLaps)
+  const setLap = useDashboardStore((s) => s.setLap)
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
 
-  // A loaded lap only means something within one (year, GP, session). If any of
-  // those change — including via a Back/Forward jump or an incoming link that
-  // doesn't go through the selectors — drop every loaded lap, otherwise a stale
-  // driver→lap would be re-fetched against the NEW session's key.
+  const lapTimesQuery = useLapTimes(search)
+  const lapTimes = lapTimesQuery.data
+
+  // A loaded lap only means something within one (year, GP, session). Clear all
+  // loaded laps when the session context CHANGES — but NOT on the first mount,
+  // so navigating away and back (e.g. to Comparison) preserves what was loaded
+  // instead of silently resetting it to the fastest laps.
   const contextKey = `${search.year ?? ''}|${search.gp ?? ''}|${search.session ?? ''}`
+  const contextInitialized = useRef(false)
   useEffect(() => {
+    if (!contextInitialized.current) {
+      contextInitialized.current = true
+      return
+    }
     clearLaps()
   }, [contextKey, clearLaps])
 
-  // Within the same session, removing a driver prunes just their loaded lap
-  // (the other drivers' stay).
+  // Removing a driver prunes just their loaded lap (others stay).
   const driverKey = search.drivers.join(',')
   useEffect(() => {
     pruneLaps(driverKey ? driverKey.split(',') : [])
   }, [driverKey, pruneLaps])
 
+  // Auto-load the fastest lap for every selected driver that doesn't already
+  // have a loaded lap — so the telemetry charts appear without hunting for
+  // "click a point", AND adding a 2nd/3rd driver mid-session loads them too.
+  // MERGE, never replace: a manually-clicked lap (already in the map) is left
+  // untouched.
+  useEffect(() => {
+    if (!lapTimes || lapTimes.length === 0) return
+    const drivers = driverKey ? driverKey.split(',') : []
+    const missing = drivers.filter((driver) => !(driver in selectedLapsPerDriver))
+    if (missing.length === 0) return
+    const fastest = fastestLapPerDriver(lapTimes, missing)
+    for (const [driver, lap] of Object.entries(fastest)) setLap(driver, lap)
+  }, [lapTimes, driverKey, selectedLapsPerDriver, setLap])
+
   /** Patch the URL selection, applying the cascading reset of dependent levels. */
   const handleChange = (patch: Partial<DashboardSearch>) => {
-    // Re-picking the SAME value from a dropdown must not wipe the downstream
-    // selection (the combobox fires onChange even when the value is unchanged).
+    // Re-picking the SAME value must not wipe the downstream selection.
     if ('year' in patch && patch.year === search.year) return
     if ('gp' in patch && patch.gp === search.gp) return
     if ('session' in patch && patch.session === search.session) return
+
+    // Warm the session cache the moment a session is chosen — the parse runs
+    // while the user picks drivers, so the charts don't hang afterwards.
+    if ('session' in patch && patch.session && search.year != null && search.gp) {
+      prewarmTelemetry(search.year, search.gp, patch.session)
+    }
 
     const next: DashboardSearch = { ...search, ...patch }
     if ('year' in patch) {
@@ -64,21 +100,74 @@ export function DashboardPage() {
     void navigate({ search: toRaw(next) })
   }
 
+  const hasDrivers = search.drivers.length > 0
+  // Drivers are chosen but lap-times settled with no data (backend down, or no
+  // laps for these drivers this session): show ONE clear notice instead of a
+  // lap-chart banner contradicting seven telemetry loaders that never resolve.
+  const lapTimesFailed =
+    hasDrivers &&
+    !lapTimesQuery.isLoading &&
+    (lapTimesQuery.isError || (lapTimes?.length ?? 0) === 0)
+
   return (
     <>
       <Header title="Dashboard">
         <Link to="/comparison" search={toRaw(search)}>
           <Button variant="ghost" size="sm">
-            ⚖️ Go to comparison
+            <ArrowRightLeft className="size-4" aria-hidden="true" />
+            Go to comparison
           </Button>
         </Link>
       </Header>
 
-      <div className="flex flex-col gap-8">
-        <SelectorsToolbar value={search} onChange={handleChange} />
-        <LapChartSection search={search} />
-        <CircuitDominationSection search={search} />
-        <TelemetryGrid search={search} />
+      <div className="flex flex-col gap-6">
+        {/* Selector context bar — sticky under the header so the session you're
+            looking at stays visible while you scroll the charts. */}
+        <div
+          className={cn(
+            'sticky top-14 z-20 -mx-6 border-b border-hairline bg-bg-1/85 px-6 py-3 backdrop-blur',
+          )}
+        >
+          <SelectorsToolbar value={search} onChange={handleChange} />
+        </div>
+
+        {!hasDrivers ? (
+          <EmptyState
+            icon={<Gauge className="size-8 text-fg-3" aria-hidden="true" />}
+            title="Pick a session and up to three drivers"
+            description={
+              search.session
+                ? 'Choose up to three drivers above to load their lap times and telemetry.'
+                : 'Choose a year, Grand Prix and session above, then up to three drivers.'
+            }
+          />
+        ) : lapTimesFailed ? (
+          <div
+            role="status"
+            className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
+          >
+            <TriangleAlert className="size-5 shrink-0 text-warning" aria-hidden="true" />
+            <span>
+              No lap data for this selection. The backend may be unavailable, or these drivers set
+              no timed laps in this session — try another session or driver.
+            </span>
+          </div>
+        ) : (
+          <>
+            {/* Zone 1 — Session: lap chart (hero) beside the circuit map. */}
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+              <div className="min-w-0 xl:col-span-2">
+                <LapChartSection search={search} />
+              </div>
+              <div className="min-w-0 xl:col-span-1">
+                <CircuitDominationSection search={search} />
+              </div>
+            </div>
+
+            {/* Zone 2 — Lap inspector: the 7 telemetry channels. */}
+            <TelemetryGrid search={search} />
+          </>
+        )}
       </div>
     </>
   )

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -10,15 +10,21 @@
 // `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
 // scrubbing any one chart shows every driver's value at that distance.
 
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import type { EChartsOption, LineSeriesOption } from 'echarts'
+import type {
+  DefaultLabelFormatterCallbackParams,
+  EChartsOption,
+  LineSeriesOption,
+  TooltipComponentFormatterCallbackParams,
+} from 'echarts'
 import * as echarts from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
 import { F1_THEME } from '@/charts/echartsTheme'
 import type { LapTelemetry } from '@/lib/api/telemetry'
-import { getDriverColor } from '../lib/drivers'
+import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
+import { TelemetryLoader } from './TelemetryLoader'
 
 // Register the token theme at module load, before any chart's init runs
 // (echarts-for-react inits with the `theme` prop in componentDidMount, which
@@ -26,20 +32,69 @@ import type { ChannelConfig } from './channels'
 registerF1Theme()
 
 const CHART_HEIGHT = 320
+// DRS renders as a state band, not a full telemetry trace — a shorter card
+// keeps it from claiming as much vertical rhythm as Speed/RPM/etc.
+const BAND_CHART_HEIGHT = 180
+
+// Legend only earns its keep once there's something to disambiguate between —
+// a lone "— VER" floating atop a single-driver chart is noise, not
+// information. Hiding it frees the strip `grid.top` reserved for it.
+const LEGEND_GRID_TOP = 44
+const NO_LEGEND_GRID_TOP = 16
 
 // Every telemetry ECharts instance joins this group so `echarts.connect`
 // moves every chart's crosshair together when one is scrubbed. That's a
 // meaningful sync, not just a visual one: x is distance on all 7 charts.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
 
-const AXIS_TOOLTIP: EChartsOption['tooltip'] = { trigger: 'axis', axisPointer: { type: 'line' } }
+interface LegendEntry {
+  name: string
+  color: string
+}
 
-/** Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
- *  chart reuses; callers only supply the y-axis and series. The y-axis name is
- *  anchored to the left of the axis line (`align: 'left'`) so a label like
- *  "Throttle (%)" extends into the plot instead of half of it clipping off the
- *  container's left edge. */
-function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): EChartsOption {
+/**
+ * One tooltip row per hovered series: the driver code in its (readable) team
+ * colour, the value right-aligned in mono — turns ECharts' default
+ * left-aligned wall of numbers into something closer to a timing scoreboard.
+ * Shared by every telemetry chart (baseOption below), so drivers read the
+ * same way whether it's Speed, Delta, or the DRS band.
+ */
+function buildTooltipFormatter(year: number | undefined) {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
+    return items
+      .map(({ seriesName, value }) => {
+        if (!seriesName) return ''
+        const raw = Array.isArray(value) ? value[value.length - 1] : value
+        const display =
+          typeof raw === 'number'
+            ? Number.isInteger(raw)
+              ? String(raw) // gear / DRS are integers — no ".0"
+              : raw.toFixed(1)
+            : String(raw ?? '')
+        return `<div style="display:flex;justify-content:space-between;gap:20px;">
+  <span style="color:${getDriverTextColor(seriesName, year)}">${seriesName}</span>
+  <span style="font-family:'JetBrains Mono Variable',monospace">${display}</span>
+</div>`
+      })
+      .join('')
+  }
+}
+
+/**
+ * Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
+ * chart reuses; callers only supply the y-axis and series. Legend entries
+ * carry each driver's readable team colour so the driver name shows
+ * in-colour instead of plain white; with only one driver loaded the legend
+ * is dropped entirely (nothing to disambiguate) and the freed strip goes
+ * back to the plot via `grid.top`.
+ */
+function baseOption(
+  legendEntries: LegendEntry[],
+  yAxis: EChartsOption['yAxis'],
+  year: number | undefined,
+): EChartsOption {
+  const showLegend = legendEntries.length > 1
   const yAxisStyled = {
     // `scale: true` autoranges around the data instead of forcing a 0 baseline
     // (Plotly's default in the Streamlit original) — RPM/Speed/Delta would
@@ -47,16 +102,43 @@ function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): E
     // (throttle 0-100, gear, DRS) override this, so it only affects the
     // free-ranged ones.
     scale: true,
-    nameLocation: 'end' as const,
-    nameGap: 12,
-    nameTextStyle: { align: 'left' as const },
     ...(yAxis as object),
   }
   return {
-    tooltip: AXIS_TOOLTIP,
-    legend: { data: driversWithData, top: 0 },
-    grid: { top: 44, left: 8, right: 20, bottom: 8, containLabel: true },
-    xAxis: { type: 'value', name: 'Distance (m)', nameLocation: 'middle', nameGap: 28 },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      extraCssText: 'border-radius:12px;padding:10px 12px',
+      formatter: buildTooltipFormatter(year),
+    },
+    legend: showLegend
+      ? {
+          data: legendEntries.map(({ name, color }) => ({ name, textStyle: { color } })),
+          icon: 'roundRect',
+          itemWidth: 10,
+          itemHeight: 3,
+          top: 0,
+        }
+      : { show: false },
+    grid: {
+      top: showLegend ? LEGEND_GRID_TOP : NO_LEGEND_GRID_TOP,
+      left: 8,
+      right: 20,
+      bottom: 8,
+      containLabel: true,
+    },
+    // The y-axis drops its own `name` — each card's header already carries
+    // the channel's unit-bearing title (e.g. "Speed (km/h)"), so a second
+    // axis label would just repeat it a third time alongside the legend.
+    // `splitLine` is off too: dense multi-driver traces over a full grid
+    // read as moiré noise: a hairline axis alone is quieter.
+    xAxis: {
+      type: 'value',
+      name: 'Distance (m)',
+      nameLocation: 'middle',
+      nameGap: 28,
+      splitLine: { show: false },
+    },
     yAxis: yAxisStyled,
   }
 }
@@ -65,11 +147,15 @@ function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): E
  * One ECharts line series per loaded driver, coloured by team. `points`
  * returns a driver's [distance, value] pairs — the only thing that differs
  * between a plain channel (read one array) and Delta (diff two arrays).
+ * `band` fills the trace down to the axis at ~35% of the driver colour —
+ * used only by the DRS state chart, where a filled band reads as "engaged"
+ * more clearly than a thin stepped line does.
  */
 function buildDriverSeries(
   drivers: string[],
   year: number | undefined,
   stepped: boolean | undefined,
+  band: boolean | undefined,
   points: (driver: string) => Array<[number, number]>,
 ): LineSeriesOption[] {
   return drivers.map((driver) => ({
@@ -79,6 +165,7 @@ function buildDriverSeries(
     step: stepped ? 'end' : undefined,
     lineStyle: { width: 2, color: getDriverColor(driver, year) },
     itemStyle: { color: getDriverColor(driver, year) },
+    areaStyle: band ? { opacity: 0.35 } : undefined,
     data: points(driver),
   }))
 }
@@ -90,21 +177,28 @@ function buildChannelOption(
   channel: ChannelConfig,
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
-  const series = buildDriverSeries(loaded, year, channel.stepped, (driver) => {
+  const legendEntries = loaded.map((driver) => ({
+    name: driver,
+    color: getDriverTextColor(driver, year),
+  }))
+  const series = buildDriverSeries(loaded, year, channel.stepped, channel.band, (driver) => {
     const telemetry = byDriver[driver]
     const values = channel.transform(telemetry)
     return telemetry.distance.map((distance, i): [number, number] => [distance, values[i]])
   })
 
   return {
-    ...baseOption(loaded, {
-      type: 'value',
-      name: channel.yName,
-      min: channel.yAxis?.min,
-      max: channel.yAxis?.max,
-      interval: channel.yAxis?.interval,
-      axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
-    }),
+    ...baseOption(
+      legendEntries,
+      {
+        type: 'value',
+        min: channel.yAxis?.min,
+        max: channel.yAxis?.max,
+        interval: channel.yAxis?.interval,
+        axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
+      },
+      year,
+    ),
     series,
   }
 }
@@ -114,13 +208,21 @@ function buildChannelOption(
  * line chart and joins the crosshair group so scrubbing one channel moves
  * the vertical guide on all the others at the same distance.
  */
-function SyncedLineChart({ option, ariaLabel }: { option: EChartsOption; ariaLabel: string }) {
+function SyncedLineChart({
+  option,
+  ariaLabel,
+  height = CHART_HEIGHT,
+}: {
+  option: EChartsOption
+  ariaLabel: string
+  height?: number
+}) {
   return (
     <div role="img" aria-label={ariaLabel}>
       <ReactECharts
         theme={F1_THEME}
         option={option}
-        style={{ height: CHART_HEIGHT }}
+        style={{ height }}
         notMerge
         onChartReady={(instance) => {
           instance.group = CROSSHAIR_GROUP
@@ -140,14 +242,30 @@ export interface ChannelChartProps {
 }
 
 /** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
- *  ECharts line per loaded driver, x = distance in meters. */
-export function ChannelChart({ title, byDriver, drivers, year, channel }: ChannelChartProps) {
+ *  ECharts line per loaded driver, x = distance in meters. DRS renders as a
+ *  shorter, filled state band instead of the standard line height (see
+ *  `channel.band` in channels.ts). Memoized: 6 of these mount per grid, and
+ *  most re-renders (layout toggle, an unrelated driver's data settling)
+ *  don't change this channel's own `byDriver`/`drivers`/`year`. */
+export const ChannelChart = memo(function ChannelChart({
+  title,
+  byDriver,
+  drivers,
+  year,
+  channel,
+}: ChannelChartProps) {
   const option = useMemo(
     () => buildChannelOption(byDriver, drivers, year, channel),
     [byDriver, drivers, year, channel],
   )
-  return <SyncedLineChart option={option} ariaLabel={`${title} telemetry chart`} />
-}
+  return (
+    <SyncedLineChart
+      option={option}
+      ariaLabel={`${title} telemetry chart`}
+      height={channel.band ? BAND_CHART_HEIGHT : CHART_HEIGHT}
+    />
+  )
+})
 
 // ---- Delta: cross-driver, needs its own data prep --------------------------
 
@@ -205,10 +323,14 @@ function buildDeltaOption(
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const reference = findReferenceDriver(byDriver, loaded)
-  if (!reference) return baseOption([], { type: 'value', name: 'Delta (s)' })
+  if (!reference) return baseOption([], { type: 'value' }, year)
 
   const refTelemetry = byDriver[reference]
-  const series = buildDriverSeries(loaded, year, false, (driver) => {
+  const legendEntries = loaded.map((driver) => ({
+    name: driver,
+    color: getDriverTextColor(driver, year),
+  }))
+  const series = buildDriverSeries(loaded, year, false, false, (driver) => {
     const telemetry = byDriver[driver]
     return telemetry.distance.map((distance, i): [number, number] => {
       const refTime = interp(distance, refTelemetry.distance, refTelemetry.time)
@@ -230,27 +352,43 @@ function buildDeltaOption(
     }
   }
 
-  return { ...baseOption(loaded, { type: 'value', name: 'Delta (s)' }), series }
+  return { ...baseOption(legendEntries, { type: 'value' }, year), series }
 }
 
 export interface DeltaChartProps {
   byDriver: Record<string, LapTelemetry>
   drivers: string[]
   year: number | undefined
+  /** True while at least one selected lap is still loading (from
+   *  `useLapTelemetries`). Distinguishes "still fetching the 2nd driver"
+   *  from "nobody picked a 2nd driver yet" — without it, a 2-driver
+   *  selection mid-fetch shows the same "needs ≥2 drivers" note as the true
+   *  empty state, which reads as broken rather than in progress. */
+  isLoading: boolean
 }
 
 /**
  * Time delta vs. the fastest loaded driver, interpolated onto their distance
  * grid. Needs >=2 loaded drivers to have anyone to compare against —
- * `delta_graph.py` shows an `st.info` notice in the same case.
+ * `delta_graph.py` shows an `st.info` notice in the same case, unless a 2nd+
+ * driver is still loading, in which case the shared loader plays instead of
+ * a note that looks like a bug.
  */
-export function DeltaChart({ byDriver, drivers, year }: DeltaChartProps) {
+export const DeltaChart = memo(function DeltaChart({
+  byDriver,
+  drivers,
+  year,
+  isLoading,
+}: DeltaChartProps) {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
 
   if (loaded.length < MIN_DELTA_DRIVERS) {
+    if (drivers.length >= MIN_DELTA_DRIVERS && isLoading) {
+      return <TelemetryLoader />
+    }
     return <p className="px-2 py-12 text-center text-sm text-fg-3">Delta needs ≥2 drivers</p>
   }
 
   return <SyncedLineChart option={option} ariaLabel="Delta telemetry chart" />
-}
+})

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -10,9 +10,11 @@ import type { DashboardSearch } from '../search'
 import { useCircuitDomination } from '../queries'
 import type { CircuitDomination } from '@/lib/api/telemetry'
 import { TelemetryLoader } from './TelemetryLoader'
+import { SectionHeader } from './SectionHeader'
 import { Card } from '@/components/Card'
 import { cn } from '@/lib/cn'
-import { computeBounds, computeViewBox, buildSegments } from './circuitDraw'
+import { getDriverTextColor } from '../lib/drivers'
+import { computeBounds, computeViewBox, buildSegments, buildOutlinePath } from './circuitDraw'
 
 export interface CircuitDominationSectionProps {
   search: DashboardSearch
@@ -31,8 +33,10 @@ const MAP_HEIGHT_PX = 360
  *  metres, others a few hundred). */
 const SEGMENT_STROKE_PX = 5
 
-const SECTION_TITLE_CLASSNAME =
-  'text-center text-lg font-display font-medium uppercase tracking-wide text-fg-2'
+/** Faint continuous underlay tracing the whole track, drawn once beneath the
+ *  coloured microsector segments so the gaps between them don't read as a
+ *  broken circuit. */
+const OUTLINE_STROKE_COLOR = 'rgba(255,255,255,0.08)'
 
 /**
  * CIRCUIT DOMINATION: a track outline coloured by whichever driver was
@@ -47,12 +51,13 @@ export function CircuitDominationSection({ search }: CircuitDominationSectionPro
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className={SECTION_TITLE_CLASSNAME}>Circuit Domination</h2>
+      <SectionHeader title="Circuit Domination" />
       <CircuitDominationBody
         hasSelection={hasSelection}
         hasEnoughDrivers={hasEnoughDrivers}
         isLoading={query.isLoading}
         data={query.data ?? null}
+        year={search.year}
       />
     </section>
   )
@@ -63,6 +68,7 @@ interface CircuitDominationBodyProps {
   hasEnoughDrivers: boolean
   isLoading: boolean
   data: CircuitDomination | null
+  year: DashboardSearch['year']
 }
 
 /** Picks which of the four states to render: no selection yet, selection but
@@ -73,6 +79,7 @@ function CircuitDominationBody({
   hasEnoughDrivers,
   isLoading,
   data,
+  year,
 }: CircuitDominationBodyProps) {
   if (!hasSelection) {
     return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
@@ -94,19 +101,21 @@ function CircuitDominationBody({
       </p>
     )
   }
-  return <CircuitMap data={data} />
+  return <CircuitMap data={data} year={year} />
 }
 
 interface CircuitMapProps {
   data: CircuitDomination
+  year: DashboardSearch['year']
 }
 
 /** The track SVG plus its driver legend, centered in a narrower column so it
  *  reads as a focal shape rather than stretching full-bleed (Streamlit
  *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
-function CircuitMap({ data }: CircuitMapProps) {
+function CircuitMap({ data, year }: CircuitMapProps) {
   const bounds = computeBounds(data.x, data.y)
   const viewBox = computeViewBox(bounds)
+  const outlinePoints = buildOutlinePath(data.x, data.y)
   const segments = buildSegments(data.x, data.y, data.colors)
 
   return (
@@ -117,6 +126,15 @@ function CircuitMap({ data }: CircuitMapProps) {
         style={{ height: MAP_HEIGHT_PX }}
       >
         <svg viewBox={viewBox} width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+          <polyline
+            points={outlinePoints}
+            fill="none"
+            stroke={OUTLINE_STROKE_COLOR}
+            strokeWidth={SEGMENT_STROKE_PX}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
           {segments.map((segment, index) => (
             <line
               key={index}
@@ -132,18 +150,22 @@ function CircuitMap({ data }: CircuitMapProps) {
           ))}
         </svg>
       </div>
-      <CircuitLegend drivers={data.drivers} />
+      <CircuitLegend drivers={data.drivers} year={year} />
     </Card>
   )
 }
 
 interface CircuitLegendProps {
   drivers: { driver: string; color: string }[]
+  year: DashboardSearch['year']
 }
 
 /** Colour-dot legend, one swatch per driver — the SVG equivalent of the
- *  Streamlit figure's Plotly legend (invisible line traces named per driver). */
-function CircuitLegend({ drivers }: CircuitLegendProps) {
+ *  Streamlit figure's Plotly legend (invisible line traces named per driver).
+ *  The dot keeps the data-driven `entry.color` (which may already carry
+ *  contrast handling from the backend); the driver NAME is team-coloured via
+ *  `getDriverTextColor` so it stays legible against the dark UI. */
+function CircuitLegend({ drivers, year }: CircuitLegendProps) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
       {drivers.map((entry) => (
@@ -153,7 +175,12 @@ function CircuitLegend({ drivers }: CircuitLegendProps) {
             className="inline-block size-3 rounded-full"
             style={{ backgroundColor: entry.color }}
           />
-          <span className="font-mono text-xs tracking-wide text-fg-2">{entry.driver}</span>
+          <span
+            className="font-mono text-xs tracking-wide"
+            style={{ color: getDriverTextColor(entry.driver, year) }}
+          >
+            {entry.driver}
+          </span>
         </div>
       ))}
     </div>

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -9,6 +9,8 @@
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
+import { getDriverTextColor } from '../lib/drivers'
+import { SectionHeader } from './SectionHeader'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -36,25 +38,29 @@ function orderedCompounds(counts: Map<string, Map<string, number>>): string[] {
   })
 }
 
-/** "VER: 12 laps · LEC: 8 laps" for the drivers who ran this compound, in
- *  selection order, singular "lap" for a count of exactly one. */
-function driverLapSummary(driverCounts: Map<string, number>, drivers: string[]): string {
+/** Drivers who ran this compound with their lap counts, in selection order
+ *  (skips drivers who ran zero laps on it). */
+function driversWithCounts(
+  driverCounts: Map<string, number>,
+  drivers: string[],
+): { driver: string; count: number }[] {
   return drivers
     .map((driver) => ({ driver, count: driverCounts.get(driver) ?? 0 }))
     .filter(({ count }) => count > 0)
-    .map(({ driver, count }) => `${driver}: ${count} lap${count === 1 ? '' : 's'}`)
-    .join(' · ')
 }
 
 export interface CompoundLegendProps {
   /** FULL (unfiltered) lap times. */
   lapTimes: LapTime[]
   drivers: string[]
+  /** Season year — team colours changed lineups across seasons (`getDriverTextColor`). */
+  year?: number
 }
 
-/** Per-compound Pill row with each driver's lap count on that tyre. Renders
- *  nothing when no laps are loaded yet (matches the Streamlit early-return). */
-export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
+/** Per-compound Pill row with each driver's lap count on that tyre, the
+ *  driver code team-coloured. Renders nothing when no laps are loaded yet
+ *  (matches the Streamlit early-return). */
+export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
 
@@ -62,13 +68,11 @@ export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="font-display text-sm uppercase tracking-wide text-fg-2">
-        🏎️ Tyre Compounds Used
-      </h3>
+      <SectionHeader title="Tyre compounds" />
       <div className="flex flex-wrap gap-4">
         {compounds.map((compound) => {
           const variant = compoundVariant(compound)
-          const summary = driverLapSummary(counts.get(compound) ?? new Map(), drivers)
+          const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
           return (
             <div key={compound} className="flex flex-col items-start gap-1">
               {variant ? (
@@ -76,7 +80,22 @@ export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
               ) : (
                 <Pill tone="neutral">{compoundLabel(compound)}</Pill>
               )}
-              {summary ? <span className="text-xs text-fg-3">{summary}</span> : null}
+              {driverCounts.length > 0 ? (
+                <span className="text-xs text-fg-3">
+                  {driverCounts.map(({ driver, count }, index) => (
+                    <span key={driver}>
+                      {index > 0 ? ' · ' : ''}
+                      <span
+                        className="font-mono tabular-nums"
+                        style={{ color: getDriverTextColor(driver, year) }}
+                      >
+                        {driver}
+                      </span>{' '}
+                      {count}
+                    </span>
+                  ))}
+                </span>
+              ) : null}
             </div>
           )
         })}

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -11,10 +11,10 @@ import { useCallback, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { EChartsOption } from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
-import { echartsTheme, F1_THEME } from '@/charts/echartsTheme'
+import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverColor } from '../lib/drivers'
-import { compoundEmoji, compoundLabel } from '../lib/compounds'
+import { getDriverColor, getDriverTextColor } from '../lib/drivers'
+import { compoundLabel, compoundVariant } from '../lib/compounds'
 import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
 
 // Register the token theme at module load, before any chart's init runs
@@ -45,9 +45,18 @@ interface DriverSeriesOption {
   name: string
   type: 'line'
   symbolSize: number
-  lineStyle: { color: string }
+  lineStyle: { color: string; width: number }
   itemStyle: { color: string }
+  emphasis: { scale: number }
   data: LapPoint[]
+}
+
+/** One legend entry, team-coloured via `textStyle` — a bare string legend
+ *  entry shares ONE colour for every driver, so each entry needs its own
+ *  `DataItem` object instead (icon/size stay on the shared `legend` option). */
+interface LegendEntry {
+  name: string
+  textStyle: { color: string }
 }
 
 /** Runtime narrowing for whatever `unknown` an ECharts callback hands back. */
@@ -74,32 +83,73 @@ function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
   return byDriver
 }
 
-/** Build one driver's line+marker series, coloured by TEAM colour. */
+/** Build one driver's line+marker series, coloured by TEAM colour. Markers
+ *  stay small (`symbolSize: 5`) and the line thin (`width: 1.5`) so a dense
+ *  multi-driver plot doesn't bead into a wall of dots; `emphasis.scale` grows
+ *  the hovered point back up so it's still an obvious click target. */
 function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
   return {
     name: driver,
     type: 'line',
-    symbolSize: 7,
-    lineStyle: { color },
+    symbolSize: 5,
+    lineStyle: { color, width: 1.5 },
     itemStyle: { color },
+    emphasis: { scale: 1.6 },
     data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
   }
 }
 
-/** Tooltip text: `<emoji> DRIVER — Lap N — M:SS.mmm — Compound`. */
-function formatLapTooltip(raw: unknown): string {
-  if (!raw || typeof raw !== 'object') return ''
-  const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
-  if (!isLapPoint(data)) return ''
-  const [lapNumber, lapTime] = data.value
-  return `${compoundEmoji(data.compound)} ${seriesName ?? ''} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundLabel(data.compound)}`
+/** Legend entries, each carrying its own driver-team text colour (the shared
+ *  `legend.icon`/`itemWidth`/`itemHeight` options keep every swatch the same
+ *  shape/size — only the colour differs per driver). */
+function buildLegendData(
+  seriesList: DriverSeriesOption[],
+  year: number | undefined,
+): LegendEntry[] {
+  return seriesList.map((series) => ({
+    name: series.name,
+    textStyle: { color: getDriverTextColor(series.name, year) },
+  }))
+}
+
+/** 8px rounded compound-colour swatch for the tooltip, replacing the old emoji
+ *  marker. An unknown compound gets a neutral grey — NOT the medium yellow,
+ *  which would falsely read as a real tyre. */
+function compoundDotHtml(compound: string): string {
+  const variant = compoundVariant(compound)
+  const hex = variant ? tireColors[variant] : '#6b7280'
+  return `<span style="display:inline-block;width:8px;height:8px;border-radius:9999px;background:${hex};margin-right:4px;"></span>`
+}
+
+/** Tooltip HTML: team-coloured driver name — Lap N — M:SS.mmm — compound dot + label. */
+function formatLapTooltip(year: number | undefined) {
+  return (raw: unknown): string => {
+    if (!raw || typeof raw !== 'object') return ''
+    const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
+    if (!isLapPoint(data)) return ''
+    const [lapNumber, lapTime] = data.value
+    const driverName = seriesName ?? ''
+    const driverHtml = seriesName
+      ? `<b style="color:${getDriverTextColor(seriesName, year)}">${driverName}</b>`
+      : `<b>${driverName}</b>`
+    return `${driverHtml} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundDotHtml(data.compound)}${compoundLabel(data.compound)}`
+  }
 }
 
 /** Build the full chart option from the per-driver series list. */
-function buildLapChartOption(seriesList: DriverSeriesOption[]): EChartsOption {
+function buildLapChartOption(
+  seriesList: DriverSeriesOption[],
+  year: number | undefined,
+): EChartsOption {
   return {
-    tooltip: { trigger: 'item', formatter: formatLapTooltip },
-    legend: { data: seriesList.map((series) => series.name), top: 0 },
+    tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
+    legend: {
+      data: buildLegendData(seriesList, year),
+      icon: 'roundRect',
+      itemWidth: 10,
+      itemHeight: 3,
+      top: 0,
+    },
     grid: { top: 44, left: 56, right: 24, bottom: 44, containLabel: true },
     xAxis: {
       type: 'value',
@@ -162,7 +212,7 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
       .map((driver) =>
         buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
       )
-    return buildLapChartOption(seriesList)
+    return buildLapChartOption(seriesList, year)
   }, [laps, drivers, year])
 
   const handleClick = useCallback(
@@ -174,12 +224,14 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
   )
 
   return (
-    <ReactECharts
-      theme={F1_THEME}
-      option={option}
-      style={{ height: 400 }}
-      notMerge
-      onEvents={{ click: handleClick }}
-    />
+    <div role="img" aria-label="Lap times by lap, per driver">
+      <ReactECharts
+        theme={F1_THEME}
+        option={option}
+        style={{ height: 400 }}
+        notMerge
+        onEvents={{ click: handleClick }}
+      />
+    </div>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -9,11 +9,14 @@
 // "what's plotted" and "what's counted".
 
 import { useMemo } from 'react'
+import { Activity, Info, MousePointerClick } from 'lucide-react'
 import type { DashboardSearch } from '../search'
 import { useLapTimes } from '../queries'
 import { useDashboardStore } from '../store'
 import { applyLapFilters } from '../lib/outliers'
+import { getDriverTextColor } from '../lib/drivers'
 import { Skeleton } from '@/components/Skeleton'
+import { ChartCard } from '@/components/ChartCard'
 import { LapChart } from './LapChart'
 import { LapControls } from './LapControls'
 import { CompoundLegend } from './CompoundLegend'
@@ -22,15 +25,17 @@ export interface LapChartSectionProps {
   search: DashboardSearch
 }
 
-/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`. */
+/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`.
+ *  Only reachable once drivers ARE selected but their lap-times came back empty;
+ *  the "no drivers yet" case is handled by the page-level `EmptyState`. */
 function NoLapDataBanner() {
   return (
     <div
       role="status"
       className="flex items-center gap-3 rounded-xl border border-hairline border-l-4 border-l-info bg-bg-3 px-4 py-3 text-sm text-fg-2"
     >
-      <span aria-hidden="true">ℹ️</span>
-      <span>No lap data available. Select drivers and ensure backend is running.</span>
+      <Info className="size-4 shrink-0 text-info" aria-hidden="true" />
+      <span>No laps to plot for this selection.</span>
     </div>
   )
 }
@@ -61,27 +66,28 @@ export function LapChartSection({ search }: LapChartSectionProps) {
     [lapTimes, showOutliers, showInvalidLaps],
   )
 
-  const isEmpty = search.drivers.length === 0 || lapTimes.length === 0
+  // Drivers are always present by the time this section renders (the page
+  // shows its own EmptyState otherwise) — this only guards the in-between
+  // moment where lap-times came back empty for the current selection.
+  const isEmpty = lapTimes.length === 0
   const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className="text-center font-display text-lg uppercase tracking-wide text-fg-2">
-        Lap Chart
-      </h2>
-
-      {lapTimesQuery.isLoading ? (
-        <Skeleton className="h-100 w-full" />
-      ) : isEmpty ? (
-        <NoLapDataBanner />
-      ) : (
-        <LapChart
-          laps={filterResult.visible}
-          drivers={search.drivers}
-          year={search.year}
-          onLapClick={setLap}
-        />
-      )}
+      <ChartCard title="Lap Chart">
+        {lapTimesQuery.isLoading ? (
+          <Skeleton className="h-100 w-full" />
+        ) : isEmpty ? (
+          <NoLapDataBanner />
+        ) : (
+          <LapChart
+            laps={filterResult.visible}
+            drivers={search.drivers}
+            year={search.year}
+            onLapClick={setLap}
+          />
+        )}
+      </ChartCard>
 
       <LapControls
         lapTimes={lapTimes}
@@ -95,23 +101,33 @@ export function LapChartSection({ search }: LapChartSectionProps) {
         onToggleInvalidLaps={toggleInvalidLaps}
       />
 
-      <p className="text-sm text-fg-3">
-        💡 Tip: Click on any point in the LAP CHART above to load that lap's telemetry
+      <p className="flex items-center gap-2 text-sm text-fg-3">
+        <MousePointerClick className="size-4 shrink-0" aria-hidden="true" />
+        Click a lap to inspect it — fastest laps load automatically.
       </p>
 
       {captionParts.length > 0 ? (
-        <p className="text-sm text-fg-2">
-          📊 Showing telemetry:{' '}
-          {captionParts.map((part, index) => (
-            <span key={part.driver}>
-              {index > 0 ? ', ' : ''}
-              <strong className="font-semibold text-fg-1">{part.driver}</strong> (Lap {part.lap})
-            </span>
-          ))}
+        <p className="flex items-center gap-2 text-sm text-fg-2">
+          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
+          <span>
+            Showing telemetry:{' '}
+            {captionParts.map((part, index) => (
+              <span key={part.driver}>
+                {index > 0 ? ', ' : ''}
+                <strong
+                  className="font-semibold"
+                  style={{ color: getDriverTextColor(part.driver, search.year) }}
+                >
+                  {part.driver}
+                </strong>{' '}
+                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
+              </span>
+            ))}
+          </span>
         </p>
       ) : null}
 
-      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} />
+      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} year={search.year} />
     </section>
   )
 }

--- a/webapp/src/features/dashboard/components/LapControls.tsx
+++ b/webapp/src/features/dashboard/components/LapControls.tsx
@@ -2,47 +2,47 @@
 // `frontend/components/dashboard/lap_graph.py::render_control_buttons` /
 // `_display_filter_status`.
 //
-// Pure presentational + one pure computation (fastest lap per driver); all
+// Pure presentational; the fastest-lap computation is the shared
+// `../lib/fastestLap` helper (also used by the page's auto-load effect). All
 // store writes happen in the caller (`LapChartSection`) so this component
 // never touches Zustand directly.
 
+import { Eye, EyeOff, Timer } from 'lucide-react'
 import { Button } from '@/components/Button'
+import { cn } from '@/lib/cn'
 import type { LapTime } from '@/lib/api/telemetry'
+import { fastestLapPerDriver } from '../lib/fastestLap'
 
-/** Each driver's fastest lap (by `lap_time`), computed from the FULL
- *  (unfiltered) lap times — the outlier/invalid toggles must not hide a
- *  driver's genuine fastest lap from this shortcut. */
-function fastestLapPerDriver(lapTimes: LapTime[], drivers: string[]): Record<string, number> {
-  const fastest: Record<string, number> = {}
-  for (const driver of drivers) {
-    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
-    if (driverLaps.length === 0) continue
-    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
-    fastest[driver] = quickest.lap_number
-  }
-  return fastest
-}
-
-/** "Showing/Hiding N outlier laps | Hiding N invalid laps" status line,
- *  matching `_display_filter_status`'s message assembly exactly. */
-function buildFilterStatus(
-  outlierCount: number,
-  invalidCount: number,
-  showOutliers: boolean,
-  showInvalidLaps: boolean,
-): string {
-  const parts: string[] = []
-  if (outlierCount > 0) {
-    parts.push(
-      showOutliers
-        ? `📊 Showing ${outlierCount} outlier laps`
-        : `🚫 Hiding ${outlierCount} outlier laps`,
-    )
-  }
-  if (invalidCount > 0 && !showInvalidLaps) {
-    parts.push(`🚫 Hiding ${invalidCount} invalid laps`)
-  }
-  return parts.join(' | ')
+/** Pressed/unpressed toggle chip for a lap-visibility filter, with the
+ *  affected lap count embedded in the label — replaces the old standalone
+ *  filter-status line, which duplicated these same counts as plain text. */
+function FilterChip({
+  label,
+  count,
+  pressed,
+  onToggle,
+}: {
+  label: string
+  count: number
+  pressed: boolean
+  onToggle: () => void
+}) {
+  const Icon = pressed ? Eye : EyeOff
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onToggle}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0',
+        pressed ? 'bg-bg-4 text-fg-1' : 'text-fg-3 hover:bg-bg-4 hover:text-fg-2',
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+      {label} · {count}
+    </button>
+  )
 }
 
 export interface LapControlsProps {
@@ -58,8 +58,9 @@ export interface LapControlsProps {
   onToggleInvalidLaps: () => void
 }
 
-/** Fastest-laps shortcut + outlier/invalid visibility toggles, plus the
- *  resulting filter-status line. */
+/** Fastest-laps shortcut + outlier/invalid visibility toggle chips, in a
+ *  left-aligned auto-width row (not a full-width grid — these are compact
+ *  controls, not equal-weight destinations). */
 export function LapControls({
   lapTimes,
   drivers,
@@ -71,8 +72,6 @@ export function LapControls({
   onToggleOutliers,
   onToggleInvalidLaps,
 }: LapControlsProps) {
-  const filterStatus = buildFilterStatus(outlierCount, invalidCount, showOutliers, showInvalidLaps)
-
   /** Load each driver's fastest lap — no-op when there are no laps yet, so the
    *  button can't wipe the current selection with an empty map. */
   const handleSelectFastest = () => {
@@ -81,19 +80,23 @@ export function LapControls({
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <Button variant="ghost" onClick={handleSelectFastest}>
-          🏁 SELECT FASTEST LAPS
-        </Button>
-        <Button variant="ghost" onClick={onToggleOutliers}>
-          {showOutliers ? 'HIDE OUTLIERS' : 'SHOW OUTLIERS'}
-        </Button>
-        <Button variant="ghost" onClick={onToggleInvalidLaps}>
-          {showInvalidLaps ? 'HIDE INVALID LAPS' : 'SHOW INVALID LAPS'}
-        </Button>
-      </div>
-      {filterStatus ? <p className="text-sm text-fg-3">{filterStatus}</p> : null}
+    <div className="flex flex-wrap items-center gap-2">
+      <Button variant="ghost" size="sm" onClick={handleSelectFastest}>
+        <Timer className="size-4" aria-hidden="true" />
+        Select fastest laps
+      </Button>
+      <FilterChip
+        label="Outliers"
+        count={outlierCount}
+        pressed={showOutliers}
+        onToggle={onToggleOutliers}
+      />
+      <FilterChip
+        label="Invalid"
+        count={invalidCount}
+        pressed={showInvalidLaps}
+        onToggle={onToggleInvalidLaps}
+      />
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/SectionHeader.tsx
+++ b/webapp/src/features/dashboard/components/SectionHeader.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+/**
+ * One consistent section header for the whole Dashboard: left-aligned, uppercase
+ * eyebrow with a brand-purple tick, and an optional right slot for section-level
+ * controls (e.g. the grid/stack toggle). Replaces the mix of centered/left
+ * titles the migrated sections started with.
+ */
+export function SectionHeader({ title, children }: { title: string; children?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <h2 className="flex items-center gap-2 font-display text-sm font-medium uppercase tracking-widest text-fg-3">
+        <span aria-hidden="true" className="inline-block h-4 w-0.5 rounded-full bg-purple-600" />
+        {title}
+      </h2>
+      {children ? <div className="flex items-center gap-2">{children}</div> : null}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react'
 import type { DashboardSearch } from '../search'
 import { MAX_DRIVERS } from '../search'
 import { useGps, useSessions, useDrivers } from '../queries'
+import { getDriverColor } from '../lib/drivers'
 import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
 import { cn } from '@/lib/cn'
 
@@ -99,6 +100,7 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           placeholder="Select drivers (max 3)"
           disabled={!value.session || driversQuery.isLoading}
           max={MAX_DRIVERS}
+          getOptionAccent={(code) => getDriverColor(code, value.year)}
         />
       </SelectorField>
     </div>

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -11,12 +11,14 @@
 // instead of a chart — Víctor's hard requirement, see TelemetryLoader.tsx.
 
 import type { ReactNode } from 'react'
+import { TriangleAlert } from 'lucide-react'
 import { ChartCard } from '@/components/ChartCard'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import type { DashboardSearch } from '../search'
 import { useLapTelemetries } from '../queries'
 import { useDashboardStore, type ChartLayout } from '../store'
+import { SectionHeader } from './SectionHeader'
 import { TelemetryLoader } from './TelemetryLoader'
 import { ChannelChart, DeltaChart } from './ChannelChart'
 import { CHANNELS, DELTA_TITLE } from './channels'
@@ -61,7 +63,7 @@ function NoTelemetryNotice({ failedDrivers }: { failedDrivers: string[] }) {
       role="status"
       className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
     >
-      <span aria-hidden="true">⚠️</span>
+      <TriangleAlert className="size-5 shrink-0 text-warning" aria-hidden="true" />
       <span>{noTelemetryMessage(failedDrivers)}</span>
     </div>
   )
@@ -112,10 +114,9 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="font-display text-lg tracking-wide text-fg-2 uppercase">Telemetry</h2>
+      <SectionHeader title="Telemetry">
         <LayoutToggle layout={chartLayout} onToggle={toggleChartLayout} />
-      </div>
+      </SectionHeader>
 
       {settledEmpty ? (
         <NoTelemetryNotice failedDrivers={failedDrivers} />
@@ -126,7 +127,7 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
           ) : null}
 
           <div className={cn(LAYOUT_CLASSNAMES[chartLayout])}>
-            <TelemetryCard title={speedChannel.title} hasAny={hasAny}>
+            <TelemetryCard title={speedChannel.yName} hasAny={hasAny}>
               <ChannelChart
                 title={speedChannel.title}
                 byDriver={byDriver}
@@ -137,11 +138,11 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
             </TelemetryCard>
 
             <TelemetryCard title={DELTA_TITLE} hasAny={hasAny}>
-              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} />
+              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} isLoading={isLoading} />
             </TelemetryCard>
 
             {restChannels.map((channel) => (
-              <TelemetryCard key={channel.key} title={channel.title} hasAny={hasAny}>
+              <TelemetryCard key={channel.key} title={channel.yName} hasAny={hasAny}>
                 <ChannelChart
                   title={channel.title}
                   byDriver={byDriver}

--- a/webapp/src/features/dashboard/components/TelemetryLoader.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryLoader.tsx
@@ -2,6 +2,27 @@
 // ScaleLoader — 5 purple bars pulsing on a staggered delay). Shown by the
 // telemetry charts and the circuit map before a lap's telemetry is loaded.
 // Víctor's hard requirement: preserve this loading state before charts render.
+//
+// The `@keyframes` are injected ONCE at module load (guarded by a DOM id, not
+// just a JS boolean, so a Vite HMR re-evaluation of this module can't leave a
+// duplicate behind) rather than per mount — up to 7 TelemetryGrid cards can
+// render this loader at the same time while laps are still loading, and a
+// `<style>` tag per instance would mean 7 copies of the same rule.
+
+const KEYFRAMES_ID = 'f1-telemetry-loader-keyframes'
+
+function ensureKeyframesInjected(): void {
+  if (typeof document === 'undefined' || document.getElementById(KEYFRAMES_ID)) return
+  const style = document.createElement('style')
+  style.id = KEYFRAMES_ID
+  style.textContent = `@keyframes f1-scaleloader {
+    0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
+    20% { transform: scaleY(1); opacity: 1; }
+  }`
+  document.head.appendChild(style)
+}
+
+ensureKeyframesInjected()
 
 interface TelemetryLoaderProps {
   /** Message under the bars. Defaults to the Streamlit copy. */
@@ -10,7 +31,7 @@ interface TelemetryLoaderProps {
   minHeight?: number
 }
 
-const BAR_COLOR = '#a78bfa'
+const BAR_COLOR = 'var(--purple-300)'
 const BAR_COUNT = 5
 
 export function TelemetryLoader({
@@ -26,25 +47,25 @@ export function TelemetryLoader({
     >
       <div className="flex items-end gap-1.5" aria-hidden="true">
         {Array.from({ length: BAR_COUNT }).map((_, i) => (
+          // The animation itself lives in a class (not inline style) so
+          // `motion-reduce:animate-none` can win outright — a static bar,
+          // not just a faster one — for anyone with reduced-motion set.
+          // Only the per-bar stagger (`animationDelay`) needs to stay inline.
           <span
             key={i}
+            className="animate-[f1-scaleloader_1s_ease-in-out_infinite] motion-reduce:animate-none"
             style={{
               display: 'inline-block',
               width: 6,
               height: 35,
               background: BAR_COLOR,
               borderRadius: 2,
-              animation: 'f1-scaleloader 1s ease-in-out infinite',
               animationDelay: `${i * 0.1}s`,
             }}
           />
         ))}
       </div>
       <p className="text-sm text-fg-2">{label}</p>
-      <style>{`@keyframes f1-scaleloader {
-        0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
-        20% { transform: scaleY(1); opacity: 1; }
-      }`}</style>
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -33,6 +33,11 @@ export interface ChannelConfig {
    *  gear and DRS are discrete states (gear_graph.py / drs_graph.py both use
    *  a step shape for this reason), not continuous quantities. */
   stepped?: boolean
+  /** Renders as a filled state band (shorter chart, ~35%-opacity area under
+   *  the line) instead of the standard telemetry line — DRS is really an
+   *  on/off state, not a quantity to trace, so a band reads more like
+   *  "engaged" than a thin 0/1 line does. */
+  band?: boolean
   yAxis?: ChannelYAxis
   /** Extracts the plotted series from a driver's telemetry. */
   transform: (telemetry: LapTelemetry) => number[]
@@ -74,6 +79,7 @@ export const CHANNELS: ChannelConfig[] = [
     title: 'DRS',
     yName: 'DRS',
     stepped: true,
+    band: true,
     yAxis: {
       min: 0,
       max: 1,

--- a/webapp/src/features/dashboard/components/circuitDraw.ts
+++ b/webapp/src/features/dashboard/components/circuitDraw.ts
@@ -83,6 +83,23 @@ export function computeViewBox(bounds: Bounds): string {
 }
 
 /**
+ * Builds the SVG `points` attribute for a `<polyline>` tracing every track
+ * coordinate in order (y-flipped, same convention as `buildSegments`). Drawn
+ * once as a faint continuous outline underneath the coloured microsector
+ * segments, so gaps between segments (there is no line between the last
+ * point of one microsector and the first of the next) don't read as a
+ * broken track.
+ */
+export function buildOutlinePath(x: number[], y: number[]): string {
+  const pointCount = Math.min(x.length, y.length)
+  const points: string[] = []
+  for (let i = 0; i < pointCount; i++) {
+    points.push(`${x[i]},${flipY(y[i])}`)
+  }
+  return points.join(' ')
+}
+
+/**
  * Builds one line segment per consecutive coordinate pair, each carrying the
  * colour of the driver who dominated that microsector. `colors[i]` paints
  * the segment from `point[i]` to `point[i+1]` (so `colors.length === x.length - 1`

--- a/webapp/src/features/dashboard/lib/drivers.ts
+++ b/webapp/src/features/dashboard/lib/drivers.ts
@@ -119,6 +119,44 @@ export function getDriverColor(code: string, year?: number): string {
   return DRIVER_COLORS_FLAT[key] ?? DEFAULT_DRIVER_COLOR
 }
 
+// --- Legibility floor ---------------------------------------------------------
+// Some real team colours are near-black on the dark UI (Williams #041E42, the
+// Red Bull #2 #1B3D8E): fine as a thick chart line, invisible as text or a thin
+// swatch. `getDriverTextColor` brightens only those below a luminance threshold,
+// so driver NAMES stay team-coloured AND readable. This deviates from strict
+// Streamlit parity on purpose (a designed improvement).
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '')
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+
+/** WCAG relative luminance (0 = black, 1 = white). */
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (c: number) => {
+    const s = c / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+function mixToward([r, g, b]: [number, number, number], target: number, amount: number): string {
+  const mix = (c: number) => Math.round(c + (target - c) * amount)
+  const toHex = (c: number) => mix(c).toString(16).padStart(2, '0')
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+// Below this luminance a colour is too dark to read as text on the dark UI.
+const TEXT_LUMINANCE_FLOOR = 0.16
+
+/** Team colour for a driver, brightened toward white when too dark to read as text. */
+export function getDriverTextColor(code: string, year?: number): string {
+  const base = getDriverColor(code, year)
+  const rgb = hexToRgb(base)
+  if (relativeLuminance(rgb) >= TEXT_LUMINANCE_FLOOR) return base
+  return mixToward(rgb, 255, 0.5)
+}
+
 /** Build a `{ driver: colour }` map for the selected drivers. */
 export function driverColorMap(drivers: string[], year?: number): Record<string, string> {
   const map: Record<string, string> = {}

--- a/webapp/src/features/dashboard/lib/fastestLap.ts
+++ b/webapp/src/features/dashboard/lib/fastestLap.ts
@@ -1,0 +1,21 @@
+import type { LapTime } from '@/lib/api/telemetry'
+
+/**
+ * Each driver's fastest lap NUMBER (by `lap_time`), computed from the full
+ * (unfiltered) lap set — the outlier/invalid toggles must not hide a driver's
+ * genuine fastest lap. Drives both the SELECT FASTEST LAPS button and the
+ * auto-load-on-selection behaviour.
+ */
+export function fastestLapPerDriver(
+  lapTimes: LapTime[],
+  drivers: string[],
+): Record<string, number> {
+  const fastest: Record<string, number> = {}
+  for (const driver of drivers) {
+    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
+    if (driverLaps.length === 0) continue
+    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
+    fastest[driver] = quickest.lap_number
+  }
+  return fastest
+}

--- a/webapp/src/features/dashboard/queries.ts
+++ b/webapp/src/features/dashboard/queries.ts
@@ -8,6 +8,7 @@
 // `{ driver: telemetry }` record, so click-to-load / fastest-laps are just
 // store writes and the charts fetch reactively.
 
+import { useMemo } from 'react'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/client'
 import { queryKeys } from '@/lib/queryKeys'
@@ -24,7 +25,10 @@ import {
 } from '@/lib/api/telemetry'
 import type { DashboardSearch } from './search'
 
-const HISTORICAL = { staleTime: Infinity, gcTime: Infinity } as const
+// Historical data never changes: cache forever, and cap retries at 1 so a
+// downed backend fails fast instead of spinning through the default 3-retry
+// exponential backoff (which, on 10s+ FastF1 calls, means minutes of spinner).
+const HISTORICAL = { staleTime: Infinity, gcTime: Infinity, retry: 1 } as const
 
 /** Available GPs for a season. */
 export function useGps(year: number | undefined) {
@@ -85,6 +89,21 @@ export function useDrivers(
 }
 
 const ready = (s: DashboardSearch) => s.year != null && !!s.gp && !!s.session
+
+/**
+ * Fire-and-forget: ask the backend to warm the FastF1 session cache for this
+ * (year, gp, session). Called when the user picks a session so the ~2-15s parse
+ * starts while they choose drivers — by the time lap-times fires, it's warm.
+ * Untyped raw fetch (same-origin via the dev proxy / nginx); errors are ignored.
+ */
+export function prewarmTelemetry(year: number, gp: string, session: string): void {
+  // Same base as the typed client (client.ts) so it works split-origin too.
+  const base = import.meta.env.VITE_API_BASE ?? ''
+  const query = new URLSearchParams({ year: String(year), gp, session })
+  void fetch(`${base}/api/v1/telemetry/prewarm?${query.toString()}`, { method: 'POST' }).catch(
+    () => {},
+  )
+}
 
 /** Lap-time series for the selected drivers (feeds the lap chart). */
 export function useLapTimes(search: DashboardSearch) {
@@ -175,30 +194,51 @@ export function useLapTelemetries(
     })),
   })
 
-  const byDriver: Record<string, LapTelemetry> = {}
-  const failedDrivers: string[] = []
-  let anyLoading = false
-  results.forEach((r, i) => {
-    if (!canFetch) return
-    const driver = entries[i][0]
-    if (r.isLoading) {
-      anyLoading = true
-      return
-    }
-    if (r.data) {
-      byDriver[driver] = r.data
-      return
-    }
-    // Settled (success with a `{}` body → null, or error after retries) but no
-    // telemetry: a pit/out/incomplete lap or a failed fetch.
-    if (r.isError || r.isSuccess) failedDrivers.push(driver)
-  })
+  // Memoize the combined result on a content signature so `byDriver` keeps a
+  // STABLE identity across unrelated re-renders (outlier/layout toggles, hovers)
+  // — without this the 7 telemetry charts' option `useMemo`s recompute thousands
+  // of points every render. The signature must capture EVERY input to `byDriver`:
+  // the session context (so navigating between sessions can't return the prior
+  // session's cached telemetry for one frame), each query's driver:lap:status,
+  // and `dataUpdatedAt` (so a refetch that keeps `status: 'success'` still busts
+  // the memo). `year`/`gp`/`session`/`canFetch` are already in scope above.
+  const signature =
+    `${canFetch}|${year ?? ''}|${gp ?? ''}|${session ?? ''}|` +
+    results
+      .map((r, i) => `${entries[i]?.[0]}:${entries[i]?.[1]}:${r.status}:${r.dataUpdatedAt}`)
+      .join('|')
 
-  return {
-    byDriver,
-    isLoading: anyLoading,
-    hasAny: Object.keys(byDriver).length > 0,
-    hasSelection: entries.length > 0,
-    failedDrivers,
-  }
+  return useMemo<LapTelemetriesResult>(
+    () => {
+      const byDriver: Record<string, LapTelemetry> = {}
+      const failedDrivers: string[] = []
+      let anyLoading = false
+      results.forEach((r, i) => {
+        if (!canFetch) return
+        const driver = entries[i][0]
+        if (r.isLoading) {
+          anyLoading = true
+          return
+        }
+        if (r.data) {
+          byDriver[driver] = r.data
+          return
+        }
+        // Settled (success with a `{}` body → null, or error after retries) but
+        // no telemetry: a pit/out/incomplete lap or a failed fetch.
+        if (r.isError || r.isSuccess) failedDrivers.push(driver)
+      })
+      return {
+        byDriver,
+        isLoading: anyLoading,
+        hasAny: Object.keys(byDriver).length > 0,
+        hasSelection: entries.length > 0,
+        failedDrivers,
+      }
+    },
+    // Keyed on the content signature above; `results`/`entries`/`canFetch` are
+    // read inside but only matter when the signature changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [signature],
+  )
 }

--- a/webapp/src/features/dashboard/search.ts
+++ b/webapp/src/features/dashboard/search.ts
@@ -55,12 +55,15 @@ function capDriversCsv(raw: unknown): string | undefined {
   return capped.length > 0 ? capped.join(',') : undefined
 }
 
-/** `validateSearch` for the /dashboard route: coerce raw router search. */
+/** `validateSearch` for the /dashboard route: coerce raw router search AND
+ *  enforce the cascade (drivers need a session, session needs a GP, GP needs a
+ *  year). A hand-truncated link like `?drivers=VER,LEC` therefore drops the
+ *  orphan drivers instead of rendering the page in a broken half-selected state. */
 export function validateDashboardSearch(raw: Record<string, unknown>): RawDashboardSearch {
   const year = coerceYear(raw.year)
-  const gp = coerceStr(raw.gp)
-  const session = coerceStr(raw.session)
-  const drivers = capDriversCsv(raw.drivers)
+  const gp = year != null ? coerceStr(raw.gp) : undefined
+  const session = gp ? coerceStr(raw.session) : undefined
+  const drivers = session ? capDriversCsv(raw.drivers) : undefined
   return {
     ...(year != null ? { year } : {}),
     ...(gp ? { gp } : {}),


### PR DESCRIPTION
Elevates the migrated Dashboard from feature-parity to a polished analysis product (polish plan STEP 2). Builds on the backend perf PR #91.

**Biggest wins (Víctor's complaints):**
- **Auto-load**: selecting drivers now loads each one's fastest lap automatically — the telemetry charts appear without hunting for click-to-load. Clicking a lap still inspects another. + prewarm on session-select.
- **Driver colours painted everywhere** (legends, tooltips, compound counts, caption, circuit legend) with a luminance floor so dark teams (Williams) stay readable.
- **Emojis → lucide icons** across the board.
- **Real empty state** (one card) replaces the 8 infinite loaders that looked broken.

**Restructure (design-first):** sticky selector bar, 2-zone layout (lap chart + circuit side by side, then the 7-channel grid), consistent section headers, the lap chart carded off the hero gradient.

**Chart polish:** kill triple-labelling, hide single-driver legends, DRS as a state band, quieter grid, de-beaded lap chart, scoreboard tooltips; controls as toggle chips.

**Verification:** local pipeline green (typecheck / lint / 33 tests / build); screenshot-verified (empty + real Monaco auto-load, dark). Adversarial Fable review (SOUND-WITH-FIXES, no P0) — fixed before this PR: infinite-loaders-on-failed-lap-times, added-driver-doesn't-auto-load + Delta-lies, incomplete telemetry memo signature (stale-across-nav), prewarm split-origin base, comparison-round-trip wipe, truncated-URL renders broken, unknown-compound dot, integer tooltips.

**Out of scope (queued):** Home redesign, keyboard click-to-load (WCAG), light theme — all in the polish/design plan.

Built by an Opus-frozen foundation + 3 parallel Sonnet workers + central verify + Fable.