### PR TITLE
docs(migration): round-2 dashboard + app-chrome refinement plans

### DIFF
--- a/docs/migration/design-specs/app-chrome-round2.md
+++ b/docs/migration/design-specs/app-chrome-round2.md
@@ -1,0 +1,196 @@
+# App Chrome + Design System — Round 2 Plan
+
+> Execution plan (Fable, 2026-07-14). Refinements to the app SHELL (rail + header) and the design system underneath it: light theme + toggle, rail redesign, a typography/colour rulebook, and a future onboarding sketch. Plan only — build next session, one PR per item, screenshot-verified on the golden session (2023 Monaco R, VER,LEC), dark AND light once item 1 lands.
+
+## 1. Scope, references & key discoveries
+
+Sources of truth audited: `webapp/src/app/{Rail,Header,Shell,providers,router}.tsx`, `webapp/src/styles/tokens.css`, `webapp/src/index.css`, `webapp/src/stores/ui.ts`, `webapp/src/lib/zIndex.ts`, `webapp/src/charts/echartsTheme.ts` + the two brand-convention sites: the **landing** (`~/…/TFG/f1stratlab-web/`: `colors_and_type.css`, `landing.css`, `components/App.jsx`) and the **docs site** (parent repo `docs/styles/{tokens,docs}.css`). Skills applied: `baseline-ui` (`.claude/skills/baseline-ui/SKILL.md`) + `frontend-design`; ui-skills catalogue consulted conceptually (navigation / motion / layout categories) for the rail pattern.
+
+Key discoveries that shape every item below:
+
+1. **Neither the landing nor the docs has a light theme or a theme toggle.** Both are dark-only (`docs/index.html:100-101` pins `theme-color #0c0d14`; the landing has zero `data-theme`/toggle code). "Mirror the landing's light palette" is therefore impossible — **we derive the light palette from the token semantics** and the app becomes the first branded surface with a toggle. The toggle itself is new brand vocabulary, not a port.
+2. **The docs sidebar is the strongest reference for the rail** (`docs/styles/docs.css:301-385`): grouped sections with tiny uppercase titles + a 4px purple dot, active link = purple gradient wash + 2px left bar with glow, mono meta tags. That is the on-brand "premium rail" grammar — the current Rail has none of it.
+3. **The landing centers; the app left-aligns.** `landing.css:309-313` centers `.section-head` by default (marketing grammar, with a `.left` variant). The docs site — the app-like sibling — is left-aligned throughout. The migrated Dashboard's left H1 + left `SectionHeader`s is **correct**; codified in §4.
+4. **A real token bug exists:** brand `--tracking-widest: 0.18em` (`tokens.css:108`) is never mapped into Tailwind's `@theme` (`index.css:9-60` maps colors + fonts only), so every `tracking-widest` utility in the app silently renders Tailwind's default **0.1em**. Two different eyebrow trackings ship today (§4, D1).
+
+---
+
+## 2. Item 1 — Light theme + toggle in the top bar
+
+### Analysis
+
+`tokens.css` is **light-READY but not light-COMPLETE**. Ready: the ramp is fully semantic (`--bg-0..5`, `--fg-1..4`, `--divider/hairline`, shadows, gradients), and `index.css:9` maps it via `@theme inline` so utilities reference the vars — a light theme is a var swap, exactly as the file's own comment promises (`tokens.css:8-10`). Translucent chrome (`bg-bg-2/80` in Rail, `bg-bg-1/80` in Header) also survives the swap: Tailwind v4 renders opacity modifiers on var colors via `color-mix()`, so no component edits needed there.
+
+Not complete — four hard blockers:
+
+| # | Blocker | Where |
+|---|---|---|
+| B1 | `html { color-scheme: dark }` hardcoded | `index.css:63-65` |
+| B2 | Status colors are neon-on-dark: `--success #43ff64`, `--warning #ffbd33` fail contrast on white | `tokens.css:51-54` |
+| B3 | `--tire-hard: #e6e6e6` — white chip on white bg | `tokens.css:59` |
+| B4 | ECharts theme hardcodes resolved dark hex ("a build-time JS module cannot read CSS vars") | `charts/echartsTheme.ts:13-18,29-44` |
+
+No `@media (prefers-color-scheme)` blocks exist anywhere in the webapp today — a clean slate for the interplay rule.
+
+### Plan
+
+**(a) Light token block — `styles/tokens.css`** (append after `:root`, ~35 overrides under `:root[data-theme='light']`):
+
+```css
+:root[data-theme='light'] {
+  color-scheme: light;                            /* resolves B1 declaratively */
+  --bg-0: #f5f5fa;  --bg-1: #eef0f7;  --bg-2: #e9eaf4;   /* page / deep / chrome */
+  --bg-3: #ffffff;  --bg-4: #f7f7fc;  --bg-5: #eceaf9;   /* card / elevated / input */
+  --fg-1: #14121f;                                  /* near-black, purple tint (mirror of bg-1) */
+  --fg-2: rgba(20,18,31,0.75); --fg-3: rgba(20,18,31,0.58);
+  --fg-4: rgba(20,18,31,0.42); --fg-inv: #ffffff;
+  --accent-hover: var(--purple-700);                /* purple-300 fails as text on white */
+  --success: #15803d; --warning: #b45309; --danger: #dc2626; --info: #1d4ed8;  /* B2 */
+  --divider: rgba(20,18,31,0.10); --divider-strong: rgba(20,18,31,0.18);
+  --hairline: rgba(20,18,31,0.06);
+  --grad-hero: radial-gradient(ellipse 120% 80% at 50% 0%,
+    rgba(108,92,231,0.14) 0%, rgba(108,92,231,0.05) 35%, transparent 70%);
+  --shadow-card: 0 2px 10px rgba(20,18,31,0.08);
+  --shadow-elev: 0 12px 40px rgba(20,18,31,0.14);
+  --shadow-glow: 0 0 0 1px rgba(108,92,231,0.30), 0 12px 40px rgba(108,92,231,0.15);
+  --shadow-inset: inset 0 1px 0 rgba(255,255,255,0.6);
+}
+```
+
+Purple ramp, blue ramp and tyre colors stay identical (they are identity colors). **B3** is NOT solved by swapping `--tire-hard` (HARD is white-banded in real F1) — instead every compound chip gets a permanent `border-hairline` (one-line change wherever compound pills render, e.g. `App.tsx:46-53` and the dashboard `CompoundLegend`), which is invisible-ish in dark and load-bearing in light. `::selection` (purple-600 bg + white text) passes in both themes — untouched.
+
+**(b) Theme state — `stores/ui.ts`** (extend the existing persisted store, NOT a new hook file):
+
+```ts
+theme: 'dark' | 'light'          // default 'dark' — brand-first, both sibling sites are dark
+toggleTheme: () => void
+```
+
+Two-state on purpose (no 'system'): both brand surfaces are dark-only, so dark is the identity default, and a two-state toggle keeps CSS single-sourced. If 'system' is ever wanted, it resolves inside the store/subscription — the CSS below never changes.
+
+**(c) DOM stamping + interplay rule.** Single source of truth = the `data-theme` attribute; **no `@media (prefers-color-scheme)` blocks in app CSS, ever** (avoids the two-writers problem). Wiring:
+- `app/providers.tsx`: subscribe once — `useUiStore` selector for `theme`, effect sets `document.documentElement.dataset.theme = theme`. ~6 lines in `Providers`.
+- **FOUC guard** — `webapp/index.html`: 3-line inline script before the module script: `try { const t = JSON.parse(localStorage.getItem('f1sl.ui')).state.theme; if (t) document.documentElement.dataset.theme = t } catch {}` (zustand/persist stores `{state:{...},version}` under `f1sl.ui`, see `stores/ui.ts:21`). Without it, a light-theme user gets one dark frame per load.
+
+**(d) Toggle control — new `components/ThemeToggle.tsx`, mounted inside `app/Header.tsx:22`** (after `{children}`, right cluster) so every routed page gets it for free. lucide `Sun`/`Moon` (lucide-react already a dep, `package.json:40`), ghost `Button` size sm, icon-only with `aria-label="Switch to light/dark theme"` (baseline-ui MUST), icon swap ≤150ms opacity+rotate, `motion-reduce:transition-none`. Note: `/` (temporary theme-preview `App.tsx`) renders no Header — it inherits the toggle when the real Home lands (separate polish PR); acceptable gap.
+
+**(e) ECharts (B4) — the single biggest cost.** Refactor `charts/echartsTheme.ts` to `buildEchartsTheme(mode: 'dark' | 'light')` with two const palettes (light: fg/line/hairline → the rgba(20,18,31,…) family, tooltip bg `#ffffff`, title `#14121f`; series palette unchanged). `charts/registerEcharts.ts:10` registers both `'f1'` and `'f1-light'`. New 4-line `useChartTheme()` (in `charts/registerEcharts.ts`) returns the theme name from the ui store. Update the three consumption sites — `charts/Gauge.tsx:119`, `features/dashboard/components/ChannelChart.tsx:223`, `features/dashboard/components/LapChart.tsx:229` — to `theme={chartTheme} key={chartTheme}` (keyed remount; toggling is rare, remount is fine). `LapChart.tsx:14` also imports the raw `echartsTheme` object — route that through the mode-aware builder.
+
+**(f) Verify.** Contrast spot-checks (fg-3 on bg-3 ≥ 4.5:1; purple-600 as text only ≥ 18px on light, else purple-700) + full-page screenshots of Dashboard in both themes on the golden session.
+
+**Effort: M-L (~1 day).** (a)-(d) ≈ 3h · (e) ≈ 3-4h · (f) ≈ 1-2h. Informed by: `frontend-design` (theme-as-token-swap), token audit above.
+
+---
+
+## 3. Item 2 — Rail redesign (de-slop the sidebar)
+
+### Analysis — why it reads "typical-LLM"
+
+`Rail.tsx` today: a bare flat list starting at the very top of the viewport (no brand block), uniform `gap-1` items, active state = a flat solid `bg-bg-4` pill (`Rail.tsx:16`), ~90 lines of hand-rolled generic 20px SVGs (`Rail.tsx:36-101`), and a full-width centered chevron button at the bottom (`Rail.tsx:250-260`) — the exact default an LLM emits for "sidebar". Zero brand vocabulary, while the docs sidebar (`docs.css:301-385`) and landing nav (`landing.css:35-78`: active = purple-300 + glowing gradient underline; logo = Space Grotesk 600 15px) already define what F1 StratLab navigation looks like.
+
+### Redesign spec
+
+Widths: 232px expanded / 76px collapsed (nudged from 220/72 for the new left indicator + brand block). Width still snaps, never transitions (layout prop — `Rail.tsx:148-151` rationale stands). Acrylic law unchanged: `bg-bg-2/70 backdrop-blur-md`, chrome only.
+
+```
+┌────────────────────────────┐
+│ ◆ F1 StratLab          h-14│  ← brand block, border-b hairline, aligns with Header h-14
+├────────────────────────────┤     → one continuous chrome line across rail + header
+│  Home                      │
+│                            │
+│  TELEMETRY ·               │  ← section label: 10px SG 600 uppercase tracking-widest
+│  ▍Dashboard                │     text-fg-4 + 4px purple-500 dot (docs.css:328-334)
+│   Comparison               │  ← active: grad-purple-soft wash + 2px purple-400 left bar
+│   Lab                      │     w/ soft glow (docs.css:352-364); icon → purple-300
+│                            │
+│  PIT WALL ·                │
+│   Strategy                 │
+│   Race                     │
+│                            │
+│  ASSIST ·                  │
+│   Chat                     │
+│  (flex-1 spacer)           │
+├────────────────────────────┤
+│ v0.9        [⇤]        p-3 │  ← mono version tag (fg-4) + icon-only collapse button
+└────────────────────────────┘
+```
+
+Concrete changes, all in `webapp/src/app/Rail.tsx` (full rewrite, same public surface):
+
+1. **Brand block** (new, top): `h-14 border-b border-hairline px-4 flex items-center gap-2.5`. Mark = 24px `rounded-md` square, `bg-[image:var(--grad-purple)]`, "F1" in mono 700 10px white (pure CSS, no asset). Wordmark "F1 StratLab" `font-display font-semibold text-[15px] tracking-tight` (landing `.logo`, `landing.css:52-58`); hidden when collapsed (mark centers). Links to `/`.
+2. **Grouped nav** (docs-sidebar grammar): Home standalone, then sections **Telemetry** (Dashboard, Comparison, Lab), **Pit wall** (Strategy, Race), **Assist** (Chat). Section label per the diagram; when collapsed, labels swap to a `mx-3 border-t border-hairline` rule so grouping survives at 76px.
+3. **Items**: `h-9 rounded-lg px-3 gap-3 text-sm relative`. Inactive: `text-fg-3` (icon `text-fg-4`) → hover `text-fg-1 bg-fg-1/[0.04]` — **use `fg-1`-based alpha, not `white/…`, so the hover works in both themes** (white in dark, near-black in light). Active: `text-fg-1` + `bg-[image:var(--grad-purple-soft)]` + absolutely-positioned left bar `left-0 inset-y-2 w-0.5 rounded-full bg-purple-400 shadow-[0_0_8px_rgba(108,92,231,0.6)]`, entering via `scale-y` 150ms ease-out (compositor-only, `motion-reduce` guarded). The route-literal typing constraint (`Rail.tsx:8-14`) stays — but rendering a different child per state needs TanStack Link's **children-as-function** form (`{({ isActive }) => …}`) instead of `activeProps` classNames; `to` remains a literal at each call site.
+4. **Icons → lucide-react** (delete `Rail.tsx:36-101`): `House`, `LayoutDashboard`, `ArrowRightLeft` (Comparison — already its icon in `DashboardPage.tsx:117`, keep consistent), `FlaskConical`, `Crosshair` (Strategy), `Flag` (Race), `MessageSquare` (Chat). `size-[18px]`, `strokeWidth={1.75}`, `aria-hidden`. −90 LOC.
+5. **Footer**: replace the full-width centered button (`Rail.tsx:250-260`) with `p-3 border-t border-hairline flex items-center justify-between`: mono `v0.9` tag (`text-[10px] text-fg-4`, hidden collapsed; docs `sidebar-footer` nod, `docs.css:373-385`) + icon-only ghost `Button` `size-8` using lucide `PanelLeftClose`/`PanelLeftOpen`, existing `aria-label`s kept, wrapped in the existing `Tooltip`.
+6. **Motion budget** (baseline-ui): color transitions 150ms + the active-bar scale — nothing else. No width animation, no layout props, ≤200ms everywhere.
+7. **Collapsed state**: icons centered in a `size-9` hit area; active state = wash on that square + left bar retained; `title` tooltip mechanism (`Rail.tsx:132-135`) kept.
+
+Also touch: `app/Rail.test.tsx` (labels, collapse aria, new section labels). No new deps; `useUiStore.railCollapsed` contract unchanged.
+
+**Effort: M (~4h incl. screenshot loop).** Informed by: `baseline-ui` (aria on icon-only buttons, compositor-only motion, fixed z-scale — `Z.rail` unchanged), docs sidebar (`docs.css:301-385`), landing nav (`landing.css:35-78`), ui-skills *navigation* category (grouped rail + brand block + collapse pattern).
+
+---
+
+## 4. Item 3 — Typography + text-colour rulebook
+
+### Audit verdicts
+
+- **Alignment**: landing centers section heads (`landing.css:309-313`) — marketing grammar only. The docs site is left-aligned. **The app left-aligns: the Dashboard's left "Dashboard" H1 (`Header.tsx:21`) + left `SectionHeader`s (`features/dashboard/components/SectionHeader.tsx:11-15`) are correct.** Centered text in-app is reserved for empty/zero states (`EmptyState.tsx:24`) and modal confirmations.
+- **Eyebrow grammar** is the brand's signature type move (landing `colors_and_type.css:195-202`: uppercase, 0.18em, 600): the app reuses it in neutral form (fg-3 + purple tick) — correct, but the tracking is silently wrong app-wide (D1).
+- **Colour**: the landing colours *only* key numbers/words in purple-300 inside neutral prose, separators in fg-4 (`components/App.jsx:216-225`), and uses gradient text exactly once, on the hero H1 (`landing.css:277-282`). The app must keep colour that scarce.
+
+### The rulebook (app-wide, reusable)
+
+1. **Fonts**: Space Grotesk (`font-display`) = titles/headers. Inter (`font-body`) = UI + prose. JetBrains Mono = every number that identifies or measures (lap times, gaps, confidence, versions), always with `tabular-nums`.
+2. **Alignment**: left, always. Exceptions: `EmptyState` bodies and modal confirmations may center. Never center a section title or page H1 in-app.
+3. **In-app scale**: page title 18px SG **600** (Header) · section header 14px SG 500 uppercase eyebrow fg-3 + purple tick (`SectionHeader`) · card title 14px SG 500 fg-1 sentence-case (`ChartCard.tsx:72`) · stat label 12px uppercase eyebrow fg-3 (`StatCard.tsx:39`) · body 14px Inter fg-2 · caption 12px fg-3/fg-4. Rendered-markdown content: 24/20/18 (`Markdown.tsx:13-19`). Hero scale (≥48px) is reserved for the future real Home — one marketing moment per app.
+4. **Eyebrows**: uppercase + brand tracking **0.18em** + font-medium. Neutral variant (fg-3) for section/stat labels; brand variant (purple-300) reserved for hero moments, max one per view (baseline-ui: one accent per view).
+5. **Weights**: SG 600 for titles ≥ 18px, 500 below; 700 only for stat values and hero. Never bold body prose for emphasis — restructure instead.
+6. **Text is neutral by default** (fg-1 → fg-4 by hierarchy). Colour is a signal, never decoration:
+   - **purple** = interactive states + THE one key number/word of a view (landing hero-meta pattern);
+   - **team colours** = driver identity only (names, series, dots — `features/dashboard/lib/drivers.ts`);
+   - **tyre colours** = compounds only; **semantic** (success/warning/danger/info) = state only;
+   - **blue ramp** = neutral data series (first slot of `echartsTheme.ts:29`); **fg-4** = separators (`·`).
+7. **Never gradient text in-app** (the landing hero is the single sanctioned exception; baseline-ui bans it outright).
+8. `text-balance` on headings, `text-pretty` on paragraphs (base layer already balances h1-h3, `index.css:74-79`).
+9. Tracking comes from brand tokens via Tailwind theme — no `tracking-[…]` arbitrary values (see D1).
+
+### Deviations found (fix in this round)
+
+| # | Deviation | Where | Fix |
+|---|---|---|---|
+| D1 | Brand `--tracking-widest` (0.18em, `tokens.css:108`) never mapped into `@theme` → Tailwind default 0.1em ships in every eyebrow; `App.tsx:22,58` hand-rolls `tracking-[0.18em]` — two trackings coexist | `index.css:9-60` (missing map); consumers `SectionHeader.tsx:12`, `SelectorsToolbar.tsx:26`, `StatCard.tsx:39`, `DataTable.tsx:134` | Add `--tracking-wide: var(--tracking-wide); --tracking-widest: var(--tracking-widest);` (+ tight/tighter/tightest) to `@theme inline`; delete arbitrary values in `App.tsx` |
+| D2 | `tracking-wide` on table headers = Tailwind 0.025em vs brand 0.04em | `DataTable.tsx:134` | Covered by D1 |
+| D3 | Page title SG **regular** `text-lg` — under-weighted vs brand h-scale (landing titles are 600) | `Header.tsx:21` | `font-display text-lg font-semibold tracking-tight text-fg-1` |
+| D4 | Temporary Home uses marketing scale in-app | `App.tsx:25` | Dies with the real Home redesign (separate PR) — no action here |
+| D5 | Chart title colour hardcoded white | `echartsTheme.ts:32` | Absorbed by item 1(e) |
+
+**Effort: S (~2h).** D1+D2+D3 are ~10 lines total plus a `tracking-[` sweep; the rulebook lives in this doc and gets linked from the webapp README. Informed by: `baseline-ui` (typography section), landing + docs audit above.
+
+---
+
+## 5. Item 4 — Onboarding (future work, LexFlow-style)
+
+Not built this round — recorded now so keys/mount points don't collide later.
+
+- **Keys** (namespaced like the store, `f1sl.*`): `f1sl.welcomed` (welcome modal seen) · `f1sl.tour.<page>` (per-page coach marks, e.g. `f1sl.tour.dashboard`). Mirrors LexFlow's `lexflow.welcomed` / `onboarded` / `tutorial-completed` gating.
+- **Phase 1 — WelcomeModal (cheap, ship with a polish PR):** built on the existing `components/Modal.tsx`; mounts in `app/Shell.tsx` beside `<Outlet/>`, gated on `!localStorage['f1sl.welcomed']`. Content: brand mark + one-line pitch + three bullets (Dashboard / Strategy / Chat) + primary CTA **"Open a sample session"** deep-linking `/dashboard?year=2023&gp=Monaco&session=R&drivers=VER,LEC` (the golden offline-cached session) + ghost "Skip". Both paths set the key. Effort S (~2h) when scheduled.
+- **Phase 2 — per-page spotlight tour:** anchor registry + Popover-based coach marks (or driver.js — decide then), gated per `f1sl.tour.<page>`, triggered on first visit of each migrated tab. Defer until Strategy/Race/Chat exist — a tour of "coming soon" pages is noise.
+- **Harness note:** the screenshot/E2E scripts must seed these keys in `addInitScript` (the FRONTEND_VISUAL_VERIFICATION pattern) or every capture shows the modal.
+
+**Effort now: 0 (doc only).** Informed by: LexFlow first-run gating pattern.
+
+---
+
+## 6. Build order & effort summary
+
+| Order | Item | PR | Effort | Depends on |
+|---|---|---|---|---|
+| 1 | §4 rulebook fixes (D1-D3) | `fix(webapp): map brand tracking tokens + header weight` | S (~2h) | — |
+| 2 | §3 rail redesign | `feat(webapp): redesign app rail` | M (~4h) | 1 (correct tracking for section labels) |
+| 3 | §2 light theme + toggle | `feat(webapp): light theme + header toggle` | M-L (~1 day) | 2 (rail is tokens-only → theme-proof by construction; style it once) |
+| 4 | §5 onboarding | future sprint | S later | real Home + ≥2 migrated tabs |
+
+Every PR: screenshot-verify on 2023 Monaco R (VER,LEC), dark first, both themes after PR 3; commit explicit paths (never `-A`), no repo-wide prettier (Windows autocrlf gotcha).
+
+**Key files:** `webapp/src/app/{Rail,Header,Shell,providers}.tsx` · `webapp/src/styles/tokens.css` · `webapp/src/index.css` · `webapp/src/stores/ui.ts` · `webapp/src/charts/{echartsTheme,registerEcharts}.ts` + `Gauge.tsx` · `webapp/src/features/dashboard/components/{SectionHeader,SelectorsToolbar,ChannelChart,LapChart}.tsx` · `webapp/src/components/{StatCard,DataTable,Modal}.tsx` · `webapp/index.html` — references `f1stratlab-web/{colors_and_type,landing}.css` + `docs/styles/docs.css:301-385`.

--- a/docs/migration/design-specs/dashboard-round2.md
+++ b/docs/migration/design-specs/dashboard-round2.md
@@ -1,0 +1,181 @@
+# Dashboard - Round 2 Fixes Plan
+
+> Execution plan (Fable, 2026-07-14). Five refinements to the shipped Dashboard (issue #34 + elevation round 1), designed from the real code and the current screenshot (2023 Monaco R, VER/LEC). This is a build-tomorrow plan, not a design-first spec: each item carries root-cause/analysis, the concrete file:line change plan, and an S/M/L effort tag. All paths relative to `webapp/src/` unless noted. Golden verify session: **2023 Monaco R, VER+LEC** (only offline-cached FastF1 session).
+
+**Scope of files touched:**
+
+| Item | Files |
+|---|---|
+| 1 Click bug | `features/dashboard/components/LapChart.tsx`, `LapChartSection.tsx` |
+| 2 Drivers loading | `components/Combobox.tsx`, `features/dashboard/components/SelectorsToolbar.tsx` (+ backend follow-up issue) |
+| 3 Controls fold-in | `components/ChartCard.tsx`, `features/dashboard/components/{LapChartSection,LapControls,CompoundLegend}.tsx` (+ new `LapChartFooter.tsx`) |
+| 4 8th chart | `features/dashboard/components/{channels.ts,ChannelChart.tsx,TelemetryGrid.tsx}` (+ new `accel.test.ts`) |
+| 5 Drag-to-zoom | `features/dashboard/components/{ChannelChart,LapChart}.tsx` |
+
+---
+
+## 1. BUG - clicking a lap-chart point does nothing (M)
+
+### Root cause
+
+The handler chain is **wired correctly and sound**, verified end to end: `LapChart.tsx:233` binds `onEvents={{ click: handleClick }}` -> `handleClick` (:218-224) -> `extractLapClick` (:184-194) -> `onLapClick`; `LapChartSection.tsx:87` passes `onLapClick={setLap}`; `store.ts:39-40` merges into `selectedLapsPerDriver`; `TelemetryGrid.tsx:98-101` reads it via `useLapTelemetries` (`queries.ts:172-244`), which fires a new `lap-telemetry` query per changed (driver, lap). So the candidates rule out as follows:
+
+- **(c) wrapper interception - RULED OUT.** `role="img"` (`LapChart.tsx:227`) is ARIA-only, it does not affect pointer events; the ChartCard body (`components/ChartCard.tsx:97`, `overflow-auto p-4`) sits behind the canvas, not over it.
+- **(d) echarts-for-react binding - RULED OUT.** v3.0.6 binds `onEvents` at init and only re-binds on a deep-equality miss; `handleClick` is `useCallback`-stable over zustand's stable `setLap`, so `{ click: handleClick }` deep-equals across renders. `notMerge` drives `setOption`, not re-init, so the listener survives option rebuilds.
+- **(a) hit area - PRIMARY CAUSE.** With `tooltip.trigger: 'item'` and default line-series hit-testing, ECharts fires a series `click` only when the pointer hits a drawn graphic. After the round-1 de-bead, symbols are `symbolSize: 5` (`LapChart.tsx:94`); a ~78-lap race across a ~700-900 px grid spaces dots ~9-11 px apart, so the real target is a 5 px dot (`emphasis.scale: 1.6` only grows it *after* hover registers, which is the same tiny target). Clicking the connecting line does not help: `triggerLineEvent` defaults to false, and even when enabled the polyline event carries no per-point `data`, so `extractLapClick` correctly returns `null` through its guards. Most clicks land 3-10 px off a dot and **no event fires at all**.
+- **(b) invisible success - COMPOUNDING CAUSE.** When a click *does* land, there is often nothing to see. The page auto-loads each driver's fastest lap on mount (`DashboardPage.tsx:67-74`), so clicking in the fastest region re-selects the already-loaded lap (a same-value `setLap` merge, zero state change). Clicking a genuinely different lap changes only the small caption (`LapChartSection.tsx:109-128`) and the telemetry grid **below the fold** (see the screenshot's page height). No marker on the chart, no toast, no scroll. Successful clicks read as "nothing happened" too.
+
+So: not a broken handler, a **hit-area + feedback** defect. The fix must work regardless of which factor bit the user on any given click.
+
+### Fix plan (three layers, all land together)
+
+**1a. Nearest-point picking (decouple the hit area from the 5 px dot).** In `LapChart.tsx`:
+
+- Remove the `onEvents` item-click path (:218-224, :233) - one deterministic code path instead of two racing ones.
+- Add `onChartReady={(chart) => bindNearestPointClick(chart, propsRef)}` on the `ReactECharts` (:228-234). New helper `bindNearestPointClick` registers `chart.getZr().on('click', handler)`:
+  - Guard: `if (!chart.containPixel({ gridIndex: 0 }, [e.offsetX, e.offsetY])) return` - legend/axis/title clicks stay inert.
+  - For every plotted point (per visible series), `chart.convertToPixel({ seriesIndex }, value)`, compare squared pixel distance to the click, keep the minimum, accept when within a **20 px radius** (comfortable touch-size target). Max ~240 points (3 drivers x ~80 laps), trivial per click.
+  - Pixel-space nearest (not `convertFromPixel` + data-space nearest) because it matches what the eye considers "the closest dot" when lap times differ wildly on y (the Monaco rain wall in the screenshot).
+- The zr handler binds once per chart instance, so it reads laps/`onLapClick` from a `useRef` updated on every render (`propsRef.current = { laps: plotted per-series data, onLapClick }`).
+- `symbolSize: 5` stays - the de-bead visual is untouched; only the interaction radius grows.
+
+**1b. Visible selected-lap marker.** Pass `selectedLaps: Record<string, number>` into `LapChart` (new prop; `LapChartSection.tsx:60` already reads `selectedLapsPerDriver`, hand it down at :83-88). In `buildDriverSeries` (`LapChart.tsx:90-100`), when `lap.lap_number === selectedLaps[driver]`, emit a per-point override object: `{ value, compound, symbolSize: 11, itemStyle: { borderColor: '#fff', borderWidth: 2 } }`. Each driver's loaded lap renders as a ring; a successful click **visibly moves the ring at the click site**, independent of the below-the-fold grid.
+
+**1c. Click feedback toast.** In `LapChartSection.tsx`, replace the direct `onLapClick={setLap}` (:87) with a local `handleLapClick(driver, lap)`:
+
+- Same lap already loaded -> `toast({ title: "${driver} lap ${lap}", description: 'Already showing this lap.', tone: 'info' })`, no store write.
+- New lap -> `setLap(driver, lap)` + `toast({ title: "${driver} lap ${lap} loaded", description: 'Telemetry updated below.', tone: 'success' })`.
+- `useToast` from `@/components/Toast`; the provider is already mounted app-wide (`app/providers.tsx:21`), nothing to add.
+
+No store or query changes anywhere.
+
+### Browser verification
+
+Backend on :8000, `npm run dev` in `webapp/`, open `/dashboard?year=2023&gp=Monaco Grand Prix&session=R&drivers=VER,LEC`.
+
+1. Click **8-10 px off** any dot -> DevTools Network shows `GET /api/v1/telemetry/lap-telemetry?...&lap_number=N`, the ring jumps to that lap, success toast, caption updates.
+2. Click the already-ringed fastest lap -> "already showing" info toast, **no** refetch.
+3. Click the legend / axis area -> nothing (containPixel guard).
+4. Toggle Outliers/Invalid, click near a filtered-out region -> picker only finds *visible* points (it searches the plotted series data, which is `filterResult.visible`).
+5. After item 5 lands: drag a zoom/pan gesture -> no phantom lap pick (zrender suppresses `click` after a real drag; if a phantom fires, add a mousedown->mouseup delta < 4 px guard in the handler).
+
+Optionally script 1-2 as a Playwright check per the `shot.mjs` harness.
+
+---
+
+## 2. Drivers combobox unusable too long after picking a session (S + backend follow-up)
+
+### Analysis
+
+`useDrivers` (`features/dashboard/queries.ts:69-89`) hits `GET /api/v1/telemetry/drivers` -> `get_drivers` (`backend/api/v1/endpoints/telemetry.py:79`) -> `get_available_drivers` (`backend/services/telemetry/telemetry_service.py:92-105`), which constructs `SessionData` -> `session_cache.get_loaded_session` (`backend/services/telemetry/session_cache.py:51-82`) doing a **full** `load(telemetry=True, laps=True, weather=True)`: 2-15 s warm, 30 s+ on a cold FastF1 download. The prewarm POST (`DashboardPage.tsx:85-87`) fires on the same navigation, so `/drivers` just queues behind the same per-key lock (`session_cache.py:67`) for the whole parse. Meanwhile the combobox renders `disabled={!value.session || driversQuery.isLoading}` (`SelectorsToolbar.tsx:101`) - **visually identical** (`opacity-50`) to "no session picked yet", so 15 s of legitimate work reads as "broken control".
+
+### Fix plan (frontend, this round)
+
+- `components/Combobox.tsx`: add `loading?: boolean` to `ComboboxProps` (:122-131) and `MultiComboboxProps` (:185-199). In both triggers, when loading:
+  - render an inline spinner SVG (`animate-spin`, same hand-rolled-icon pattern as :18-61, no new dep) in place of `ChevronDownIcon` (:165 single / :292 multi);
+  - set `aria-busy="true"` and make the trigger non-interactive (`pointer-events-none`);
+  - do **not** apply the disabled `opacity-50` dim; use a lighter treatment (e.g. `opacity-80`) so *working* is visually distinct from *unavailable*.
+- `SelectorsToolbar.tsx:94-105` (Drivers cell): `disabled={!value.session}`, `loading={driversQuery.isLoading}`, `placeholder={driversQuery.isLoading ? 'Loading drivers…' : 'Select drivers (max 3)'}`.
+- Same `loading` pass on the GP (:79) and Session (:90) comboboxes - those queries are fast, but the consistency is one prop each.
+- Error one-liner: when `driversQuery.isError`, placeholder becomes "Couldn't load drivers - reselect the session" (retry already capped at 1 by `HISTORICAL`, `queries.ts:31`).
+
+### Backend follow-up (file as its own issue, do NOT block this round)
+
+A light roster path so the combobox fills in <1 s while the full parse continues in the background:
+
+- **Option A (preferred):** `GET /drivers` gains a fast path using a laps/telemetry-free FastF1 load (`session.load(laps=False, telemetry=False, weather=False, messages=False)` + `session.results`) behind its own tiny cache; codes + names come from the API results, no parquet parse, no contention on the heavy per-key lock. Must verify `results` populates without laps for 2023-2025.
+- **Option B:** static roster index `(year, gp, session) -> [{code, name}]` generated offline from the featured parquet / HF dataset, served as JSON. Zero FastF1 in the path; costs a build step + a staleness story.
+- Anti-option: the webapp's `features/dashboard/lib/drivers.ts` team-colour map knows season-level codes but **not who ran a given session** - never fake the roster from it.
+
+---
+
+## 3. Controls/legend block mini-redesign (M)
+
+### Analysis
+
+Below the chart card, `LapChartSection.tsx` stacks four loose blocks at section `gap-4` (:76): the `LapControls` row (:92-102), a standalone tip line (:104-107), the "Showing telemetry" caption (:109-128), and `CompoundLegend` with its own "TYRE COMPOUNDS" `SectionHeader` (`CompoundLegend.tsx:71`). Four different vertical rhythms, plus a second section-style header floating right under a card, produce the "un poco raro" reading in the screenshot: the block belongs to the lap chart but doesn't *look* owned by it. All four pieces are dashboard-local (grep: no usages outside `features/dashboard/`), safe to reshape.
+
+### New layout
+
+Everything folds into the Lap Chart `ChartCard`: **controls -> card header** (the `actions` slot already exists, `ChartCard.tsx:44-46` + :74), **status + compounds -> a new card footer strip**.
+
+```
+┌ Lap Chart ————— [⏱ Fastest laps] [👁 Outliers·0] [👁 Invalid·0] · [–] [⛶] ┐
+│                                                                           │
+│                          (chart, 400 px)                                  │
+│                                                                           │
+├───────────────────────────────────────────────────────────────────────────┤
+│ ⚡ VER Lap 23 · LEC Lap 46   · click any point to switch lap               │
+│                     (Medium) VER 53 · LEC 9   (Hard) LEC 42   (Inter) 22  │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+One strip, two clusters: left = telemetry status (team-coloured codes, mono lap numbers) with the click tip demoted to a subdued suffix; right = inline compound micro-legend (pill + per-driver counts). `flex flex-wrap items-center justify-between gap-x-6 gap-y-2`; narrow screens stack the clusters naturally.
+
+### Concrete moves
+
+1. `components/ChartCard.tsx`: add optional `footer?: ReactNode`; render `{footer ? <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div> : null}` after the body in **both** the normal card (:121-126) and the maximized overlay (:99-118) so the strip survives maximize. Hide it while collapsed (same branch as `body`, :97). Shared-primitive change; other charts can adopt later.
+2. `LapChartSection.tsx`: `:77` becomes `<ChartCard title="Lap Chart" actions={<LapControls …/>} footer={footer}>`; delete the standalone blocks :92-130. `footer` renders only when `lapTimes.length > 0` (while loading, the body `Skeleton` :79 is the whole story).
+3. New `components/LapChartFooter.tsx` (feature-local): left cluster = the caption content currently at :109-128 plus the ` · click any point to switch lap` suffix (replaces the whole MousePointerClick tip block :104-107); right cluster = the inline `CompoundLegend`.
+4. `LapControls.tsx`: logic untouched (:64-101); it just renders inside `actions` now. If the header wraps badly under ~480 px, add `flex-wrap` to the ChartCard header row (`ChartCard.tsx:71`), nothing else.
+5. `CompoundLegend.tsx`: reshape from column-per-compound (:70-103) to a single inline row - `[Pill] VER 53 · LEC 9` groups separated by `gap-x-4`; delete the `SectionHeader` (:71), the pills are self-labelling. Keep the invariant that counts come from the FULL unfiltered `lapTimes` (:5-7).
+
+Result: one card = one unit (chart + its controls + its status); the page below returns to clean section-level rhythm (Lap Chart card, Circuit Domination card, Telemetry section). Verify with before/after full-page screenshots (dark only, parity rule).
+
+---
+
+## 4. 8th telemetry chart - fill the DRS gap (M)
+
+### Analysis
+
+The grid is `xl:grid-cols-2` (`TelemetryGrid.tsx:31`) rendering 7 cards in Streamlit order speed/delta/throttle/brake/rpm/gear/drs (:113 + `channels.ts:57-91`); DRS is a short 180 px state band (`ChannelChart.tsx:37`) sitting **alone** in the last row - the emptiest-looking corner of the page.
+
+### The pick: Longitudinal acceleration (g)
+
+Derived entirely from arrays already in every `lap-telemetry` response (`lib/api/telemetry.ts:23-34`): central difference over `speed` + `time`, `a[i] = ((v[i+1] - v[i-1]) / 3.6) / (t[i+1] - t[i-1]) / 9.81`, then a 3-point moving average to tame FastF1's ~4-5 Hz sampling noise.
+
+Why this over the alternatives:
+
+- **Real race-engineering channel.** Braking spikes (-4..-5 g) expose braking points and intensity; traction zones show corner-exit quality; lift-and-coast is directly visible. None of that is readable off the speed trace alone, so it adds information instead of rearranging it.
+- **Works with 1 driver.** A speed-delta channel degenerates exactly like Delta (`ChannelChart.tsx:386-390`, "needs >= 2 drivers"), which would leave 2 of 8 slots dead in single-driver use.
+- **Zero new data / zero backend.** Sector splits have no sector data in the payload; circuit-domination (`lib/api/telemetry.ts:37-42`) is x/y-indexed with no distance mapping, so a dominance strip can't honestly join the distance crosshair.
+- **No duplication.** A throttle+brake "inputs" overlay only pays if it *replaces* the two existing cards (7 -> 6, the opposite of the goal).
+
+### Plan
+
+- `channels.ts`: extend the `key` union (:27) with `'accel'`; add helper `longitudinalAccelG(t: LapTelemetry): number[]` (central diff + 3-point smoothing; guard `dt === 0` on repeated timestamps by carrying the previous value); insert the entry after `gear`, **before** `drs`: `{ key: 'accel', title: 'Longitudinal Accel', yName: 'Long. Accel (g)', transform: longitudinalAccelG }`. Y autoranges via the shared `scale: true` (`ChannelChart.tsx:99-105`). Declared order then yields rows **[Speed · Delta] [Throttle · Brake] [RPM · Gear] [Accel · DRS]** - 8 slots, symmetric, with the two "state-ish" charts sharing the last row.
+- `TelemetryGrid.tsx`: no structural change (:144-154 already maps rest-channels in declared order); update the 7-chart header comment (:1-6). CSS grid stretch already equalizes the last row's card shells; center the 180 px DRS band vertically inside its stretched card (wrap the chart in `flex h-full flex-col justify-center` when `channel.band`, around `ChannelChart.tsx:261-267`) so the short plot doesn't hug the card top.
+- Test: `features/dashboard/components/accel.test.ts` beside `outliers.test.ts` - synthetic constant-accel ramp -> constant g; flat speed -> 0 g; `dt=0` guard.
+- **Fallback** (decision point on real Monaco data during build): if the derivative is too noisy even smoothed, do the grid reflow instead - DRS card spans both columns (`xl:col-span-2`) as a full-width state strip under the 3x2 grid. One-line change, no new channel, still no lonely slot.
+
+---
+
+## 5. Drag-to-zoom on every chart (M)
+
+### Analysis
+
+ECharts 6.1.0 / echarts-for-react 3.0.6 (`webapp/package.json`). The 7 telemetry charts share crosshair group `'telemetry-crosshair'` via `echarts.connect` (`ChannelChart.tsx:48`, :227-230); connected charts **propagate dataZoom actions**, and x = distance on all of them, so a synced x-zoom is meaningful, not cosmetic. `LapChart` is *not* in the group (x = lap number) and gets its own independent zoom. Streamlit/Plotly's native box-zoom is the parity bar.
+
+### Plan
+
+- `ChannelChart.tsx` `baseOption` (:92-144), two additions every telemetry chart inherits:
+  - `dataZoom: [{ type: 'inside', xAxisIndex: 0, filterMode: 'none', zoomOnMouseWheel: 'shift', moveOnMouseMove: true, moveOnMouseWheel: false }]` - drag-pan + Shift+wheel zoom. Plain wheel **must remain page scroll**: 7-8 tall charts with unconditional wheel-capture is a scroll trap. `filterMode: 'none'` keeps each chart's y range stable while panning (no rescale jitter across 8 synced charts).
+  - `toolbox: { right: 8, top: 0, feature: { dataZoom: { yAxisIndex: 'none', filterMode: 'none' }, restore: {} } }` - the toolbox magnifier is the Plotly-style **box zoom** (click, drag a box, x-only via `yAxisIndex: 'none'`); `restore` is the reset. Check icon collision with the centered legend (:114-122) at 2-3 drivers; nudge `right` if needed.
+- **Sync check:** zoom Speed via box-zoom -> Gear/DRS/Accel crosshair AND window follow (connect propagates `dataZoom` + `restore` through the group). The DRS band participates (same x axis).
+- **Reset:** toolbox restore per chart, propagated group-wide. Known caveat: `restore` re-applies the init-time option, and both chart types rebuild options with `notMerge` on data changes (which already resets zoom on driver/filter change - acceptable: zoom is transient inspection state). If restore misfires under echarts-for-react's re-`setOption`, fall back to a small "Reset zoom" action dispatching `{ type: 'dataZoom', start: 0, end: 100 }` - the ChartCard `actions` slot from item 3 is the natural home.
+- `LapChart.tsx` `buildLapChartOption` (:140-175): same `dataZoom` inside + toolbox pair, no group. Keep `zoomOnMouseWheel: 'shift'` for cross-page consistency. Box-zooming into the flat low-1:15 pack (screenshot) is the actual Streamlit-era use case.
+- **Interplay with item 1:** after any pan/box drag on the lap chart, verify the zr nearest-point handler doesn't fire a phantom pick (zrender suppresses `click` after a genuine drag; if not, the delta guard from item 1's verification list covers it). Also re-verify `convertToPixel` picking under an active zoom window - it maps through the current axis scale, so picking zoomed-out (hidden) points is naturally excluded by the 20 px radius, but confirm in browser.
+
+---
+
+## Do-first ordering
+
+| # | Item | Effort | Why this slot |
+|---|---|---|---|
+| 1 | Lap-click bug (item 1) | M | The UI literally says "Click a lap to inspect it" - a broken promise is the highest-pain defect. Everything else is polish on top of a working core loop. |
+| 2 | Drivers loading affordance (item 2) | S | Smallest diff, fully independent files, big perceived-quality win. File the backend roster follow-up issue at the same time. |
+| 3 | Controls fold-in (item 3) | M | Reshapes the strip whose copy item 1 touches (the tip line becomes the footer suffix) - landing 1 first avoids writing that caption twice. Also creates the ChartCard `footer`/`actions` seams item 5's reset fallback may use. |
+| 4 | Drag-to-zoom (item 5) | M | Pure chart-option work; verify the click-vs-drag interplay against item 1's picker while both are fresh in-head. |
+| 5 | 8th chart (item 4) | M | New feature with a data-dependent decision point (accel vs DRS-span reflow); lowest cost to cut or defer if the round runs long. |
+
+Branching: one `feat/` branch per PR to `dev` per project flow; natural split is 1+2 (fix + quick win), 3+5 (layout + interaction), 4 (new channel). Every PR: screenshot-verify on the golden session (dark only at parity), `npm run typecheck && npm run lint && npm run test` in `webapp/`, commit explicit paths (never `-A`, Windows autocrlf gotcha).


### PR DESCRIPTION
Execution plans (Fable) for Víctor's round-2 feedback on the shipped dashboard elevation — ready to build next session. Docs only: dashboard-round2.md (click-to-load fix, drivers-loader, controls redesign, 8th chart, drag-to-zoom) + app-chrome-round2.md (light theme + toggle, sidebar redesign, typography/colour rulebook, onboarding sketch).