### PR TITLE
feat(webapp): dashboard round-2 refinements

### DIFF
--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -1,55 +1,34 @@
 import { forwardRef, useEffect, useState, type HTMLAttributes, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
+import { Maximize2, Minimize2, Minus, Plus } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 
 // Titled shell for a single chart: header (title + actions slot + maximize +
-// collapse) and a scroll-contained body. "Maximize" portals the card to a
-// full-viewport overlay so a chart can be inspected without fighting a
-// cramped dashboard grid cell; "collapse" just hides the body in place, for
-// dashboards where a driver wants to fold a chart they aren't using right now.
+// collapse), a scroll-contained body, and an optional footer strip. "Maximize"
+// portals the card to a full-viewport overlay so a chart can be inspected
+// without fighting a cramped dashboard grid cell; "collapse" just hides the
+// body (and footer) in place, for dashboards where a driver wants to fold a
+// chart they aren't using right now.
 //
 // Acrylic-law exception: the overlay backdrop is chrome, not a data plane, so
 // `backdrop-blur` is allowed here even though data surfaces (the Card itself)
 // stay solid `--bg` with a hairline border, per Card.tsx.
-//
-// No icon package is installed yet, so the maximize/restore glyphs are small
-// inline SVGs rather than a new dependency for two icons.
-
-function MaximizeGlyph() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-4" fill="none" aria-hidden="true">
-      <path
-        d="M2 6V2h4M10 2h4v4M14 10v4h-4M6 14H2v-4"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
-
-function RestoreGlyph() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-4" fill="none" aria-hidden="true">
-      <path d="M4 4l8 8M12 4L4 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  )
-}
 
 export interface ChartCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string
   /** Right-aligned header slot, e.g. a range picker or a legend toggle. */
   actions?: ReactNode
   children?: ReactNode
+  /** Optional strip below the body (status / legend). Hidden while collapsed. */
+  footer?: ReactNode
   defaultCollapsed?: boolean
 }
 
 export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function ChartCard(
-  { title, actions, children, defaultCollapsed = false, className, ...props },
+  { title, actions, children, footer, defaultCollapsed = false, className, ...props },
   ref,
 ) {
   const [isMaximized, setIsMaximized] = useState(false)
@@ -68,7 +47,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
   }, [isMaximized])
 
   const header = (
-    <div className="flex shrink-0 items-center justify-between gap-3 border-b border-hairline px-4 py-3">
+    <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-hairline px-4 py-3">
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
@@ -79,7 +58,11 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           onClick={() => setIsCollapsed((value) => !value)}
           className="size-8 px-0 text-fg-3"
         >
-          {isCollapsed ? '+' : '–'}
+          {isCollapsed ? (
+            <Plus className="size-4" aria-hidden="true" />
+          ) : (
+            <Minus className="size-4" aria-hidden="true" />
+          )}
         </Button>
         <Button
           variant="ghost"
@@ -88,13 +71,21 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           onClick={() => setIsMaximized((value) => !value)}
           className="size-8 px-0 text-fg-3"
         >
-          {isMaximized ? <RestoreGlyph /> : <MaximizeGlyph />}
+          {isMaximized ? (
+            <Minimize2 className="size-4" aria-hidden="true" />
+          ) : (
+            <Maximize2 className="size-4" aria-hidden="true" />
+          )}
         </Button>
       </div>
     </div>
   )
 
   const body = isCollapsed ? null : <div className="flex-1 overflow-auto p-4">{children}</div>
+  const footerStrip =
+    isCollapsed || !footer ? null : (
+      <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
+    )
 
   if (isMaximized) {
     return createPortal(
@@ -112,6 +103,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
         >
           {header}
           {body}
+          {footerStrip}
         </Card>
       </div>,
       document.body,
@@ -122,6 +114,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     <Card ref={ref} className={cn('flex flex-col', className)} {...props}>
       {header}
       {body}
+      {footerStrip}
     </Card>
   )
 })

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -65,7 +65,12 @@ function XIcon({ className }: { className?: string }) {
  *  session) — distinguishes "working" from "disabled/unavailable". */
 function SpinnerIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 16 16" fill="none" className={cn('animate-spin', className)} aria-hidden="true">
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn('animate-spin', className)}
+      aria-hidden="true"
+    >
       <circle
         cx="8"
         cy="8"

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -60,6 +60,25 @@ function XIcon({ className }: { className?: string }) {
   )
 }
 
+/** Spinner shown in place of the chevron while a combobox's options are
+ *  still loading (e.g. the drivers roster while the backend parses a FastF1
+ *  session) — distinguishes "working" from "disabled/unavailable". */
+function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className={cn('animate-spin', className)} aria-hidden="true">
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeDasharray="28 10"
+      />
+    </svg>
+  )
+}
+
 /** Small colour swatch shown before an option's label when `getOptionAccent`
  *  is provided (e.g. a driver's team colour in the drivers multi-select). */
 function AccentDot({ color }: { color: string }) {
@@ -125,6 +144,9 @@ export interface ComboboxProps {
   onChange: (value: string) => void
   placeholder?: string
   disabled?: boolean
+  /** Options are being fetched — shows a spinner instead of the chevron and
+   *  suspends interaction, without reading as `disabled` (opacity-50). */
+  loading?: boolean
   className?: string
   /** Accessible name for the trigger when the visible label lives elsewhere. */
   ariaLabel?: string
@@ -132,7 +154,7 @@ export interface ComboboxProps {
 
 /** Single-select typeahead combobox (e.g. "pick a circuit"). */
 export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, className, ariaLabel },
+  { options, value, onChange, placeholder = 'Select...', disabled, loading, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -151,18 +173,24 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Co
           type="button"
           disabled={disabled}
           aria-label={ariaLabel}
+          aria-busy={loading || undefined}
           className={cn(
             'flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-hairline bg-bg-3 px-3 text-sm text-fg-1 transition-colors',
             'hover:bg-bg-4',
             'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0 focus-visible:outline-none',
             'disabled:pointer-events-none disabled:opacity-50',
+            loading && 'pointer-events-none opacity-80',
             className,
           )}
         >
           <span className={cn('truncate', !selectedLabel && 'text-fg-3')}>
             {selectedLabel ?? placeholder}
           </span>
-          <ChevronDownIcon className="size-4 shrink-0 text-fg-3" />
+          {loading ? (
+            <SpinnerIcon className="size-4 shrink-0 text-fg-3" />
+          ) : (
+            <ChevronDownIcon className="size-4 shrink-0 text-fg-3" />
+          )}
         </button>
       </Popover.Trigger>
       <ComboboxPanel>
@@ -188,6 +216,9 @@ export interface MultiComboboxProps {
   onChange: (value: string[]) => void
   placeholder?: string
   disabled?: boolean
+  /** Options are being fetched — shows a spinner instead of the chevron and
+   *  suspends interaction, without reading as `disabled` (opacity-50). */
+  loading?: boolean
   /** Caps how many options can be selected at once (e.g. a 3-driver comparison). */
   max?: number
   className?: string
@@ -208,6 +239,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
     onChange,
     placeholder = 'Select...',
     disabled,
+    loading,
     max,
     className,
     ariaLabel,
@@ -218,13 +250,14 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
   const [open, setOpen] = useState(false)
   const atMax = max !== undefined && value.length >= max
   const selectedOptions = options.filter((option) => value.includes(option.value))
+  const interactive = !disabled && !loading
 
   function handleOpenChange(next: boolean) {
-    if (!disabled) setOpen(next)
+    if (interactive) setOpen(next)
   }
 
   function handleTriggerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (disabled) return
+    if (!interactive) return
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       setOpen((current) => !current)
@@ -245,22 +278,24 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
   }
 
   return (
-    <Popover.Root open={!disabled && open} onOpenChange={handleOpenChange}>
+    <Popover.Root open={interactive && open} onOpenChange={handleOpenChange}>
       <Popover.Trigger asChild>
         <div
           ref={ref}
           role="combobox"
           aria-label={ariaLabel}
-          aria-expanded={!disabled && open}
+          aria-expanded={interactive && open}
           aria-haspopup="listbox"
           aria-disabled={disabled}
-          tabIndex={disabled ? -1 : 0}
+          aria-busy={loading || undefined}
+          tabIndex={interactive ? 0 : -1}
           onKeyDown={handleTriggerKeyDown}
           className={cn(
             'flex min-h-10 w-full flex-wrap items-center gap-1.5 rounded-lg border border-hairline bg-bg-3 px-2 py-1.5 text-sm transition-colors',
             'hover:bg-bg-4',
             'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0 focus-visible:outline-none',
             disabled && 'pointer-events-none opacity-50',
+            loading && !disabled && 'pointer-events-none opacity-80',
             className,
           )}
         >
@@ -289,7 +324,11 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
               </span>
             )
           })}
-          <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          {loading ? (
+            <SpinnerIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          ) : (
+            <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          )}
         </div>
       </Popover.Trigger>
       <ComboboxPanel>

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -1,5 +1,5 @@
 // Shared ECharts line chart for the TELEMETRY grid (issue #34, §6.1). One
-// component (`ChannelChart`) covers 6 of the 7 channels via `ChannelConfig`
+// component (`ChannelChart`) covers 7 of the 8 channels via `ChannelConfig`
 // (channels.ts); Delta is cross-driver — it needs a reference lap to diff
 // every other driver against, not a single telemetry array — so it gets its
 // own `DeltaChart` below. Both share `SyncedLineChart`, the thin ECharts
@@ -44,7 +44,9 @@ const NO_LEGEND_GRID_TOP = 16
 
 // Every telemetry ECharts instance joins this group so `echarts.connect`
 // moves every chart's crosshair together when one is scrubbed. That's a
-// meaningful sync, not just a visual one: x is distance on all 7 charts.
+// meaningful sync, not just a visual one: x is distance on all 8 charts —
+// and, since dataZoom lives in `baseOption` below, a zoom/pan on one
+// propagates group-wide too.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
 
 interface LegendEntry {
@@ -82,12 +84,15 @@ function buildTooltipFormatter(year: number | undefined) {
 }
 
 /**
- * Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
- * chart reuses; callers only supply the y-axis and series. Legend entries
- * carry each driver's readable team colour so the driver name shows
+ * Shared option scaffolding (tooltip/legend/grid/x-axis/zoom) every
+ * telemetry chart reuses; callers only supply the y-axis and series. Legend
+ * entries carry each driver's readable team colour so the driver name shows
  * in-colour instead of plain white; with only one driver loaded the legend
  * is dropped entirely (nothing to disambiguate) and the freed strip goes
- * back to the plot via `grid.top`.
+ * back to the plot via `grid.top`. Also wires drag-pan/zoom (`dataZoom`) and
+ * a Plotly-style box-zoom + reset (`toolbox`) — see the inline comments on
+ * each for why the specific settings, and `CROSSHAIR_GROUP` above for how
+ * a zoom on one chart propagates to the rest.
  */
 function baseOption(
   legendEntries: LegendEntry[],
@@ -140,6 +145,33 @@ function baseOption(
       splitLine: { show: false },
     },
     yAxis: yAxisStyled,
+    // Drag-pan + Shift+wheel zoom, inline (no visible slider). Plain wheel
+    // stays page scroll on purpose — 7-8 tall charts stacked in a column
+    // make unconditional wheel-capture a scroll trap. `filterMode: 'none'`
+    // keeps each chart's own y range stable while panning, so 8 charts
+    // synced on the same x don't rescale-jitter against each other.
+    dataZoom: [
+      {
+        type: 'inside',
+        xAxisIndex: 0,
+        filterMode: 'none',
+        zoomOnMouseWheel: 'shift',
+        moveOnMouseMove: true,
+        moveOnMouseWheel: false,
+      },
+    ],
+    // Toolbox box-zoom (x-only, via `yAxisIndex: 'none'`) is the
+    // click-drag-a-box gesture that matches the Streamlit/Plotly original;
+    // `restore` resets it. Both actions propagate through `CROSSHAIR_GROUP`
+    // (echarts.connect), so zooming one chart zooms every synced chart.
+    toolbox: {
+      right: 8,
+      top: 0,
+      feature: {
+        dataZoom: { yAxisIndex: 'none', filterMode: 'none' },
+        restore: {},
+      },
+    },
   }
 }
 
@@ -241,10 +273,10 @@ export interface ChannelChartProps {
   channel: ChannelConfig
 }
 
-/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
- *  ECharts line per loaded driver, x = distance in meters. DRS renders as a
- *  shorter, filled state band instead of the standard line height (see
- *  `channel.band` in channels.ts). Memoized: 6 of these mount per grid, and
+/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/accel/drs)
+ *  as an ECharts line per loaded driver, x = distance in meters. DRS renders
+ *  as a shorter, filled state band instead of the standard line height (see
+ *  `channel.band` in channels.ts). Memoized: 7 of these mount per grid, and
  *  most re-renders (layout toggle, an unrelated driver's data settling)
  *  don't change this channel's own `byDriver`/`drivers`/`year`. */
 export const ChannelChart = memo(function ChannelChart({
@@ -258,13 +290,19 @@ export const ChannelChart = memo(function ChannelChart({
     () => buildChannelOption(byDriver, drivers, year, channel),
     [byDriver, drivers, year, channel],
   )
-  return (
+  const chart = (
     <SyncedLineChart
       option={option}
       ariaLabel={`${title} telemetry chart`}
       height={channel.band ? BAND_CHART_HEIGHT : CHART_HEIGHT}
     />
   )
+  if (!channel.band) return chart
+  // The DRS band is a fixed 180px chart inside a grid-stretched card shell
+  // (its row-mate is the full-height Accel line chart) — without this
+  // wrapper it hugs the card's top edge instead of sitting centered in the
+  // extra space the taller row-mate creates.
+  return <div className="flex h-full flex-col justify-center">{chart}</div>
 })
 
 // ---- Delta: cross-driver, needs its own data prep --------------------------

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -4,13 +4,15 @@
 // One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
 // each annotated with per-driver lap counts. Counts always come from the
 // FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
-// chart, not "how many laps did each driver run on this tyre".
+// chart, not "how many laps did each driver run on this tyre". Renders as a
+// single inline row (round-2 fix #3) — it lives in the Lap Chart card's
+// footer now, not as its own titled block, so the pills self-label and don't
+// need a `SectionHeader` above them.
 
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
 import { getDriverTextColor } from '../lib/drivers'
-import { SectionHeader } from './SectionHeader'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -57,9 +59,9 @@ export interface CompoundLegendProps {
   year?: number
 }
 
-/** Per-compound Pill row with each driver's lap count on that tyre, the
- *  driver code team-coloured. Renders nothing when no laps are loaded yet
- *  (matches the Streamlit early-return). */
+/** Inline compound-Pill row, each pill followed by its per-driver lap counts
+ *  on the same line — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
+ *  laps are loaded yet (matches the Streamlit early-return). */
 export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
@@ -67,39 +69,36 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
   if (compounds.length === 0) return null
 
   return (
-    <div className="flex flex-col gap-3">
-      <SectionHeader title="Tyre compounds" />
-      <div className="flex flex-wrap gap-4">
-        {compounds.map((compound) => {
-          const variant = compoundVariant(compound)
-          const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
-          return (
-            <div key={compound} className="flex flex-col items-start gap-1">
-              {variant ? (
-                <Pill compound={variant}>{compoundLabel(compound)}</Pill>
-              ) : (
-                <Pill tone="neutral">{compoundLabel(compound)}</Pill>
-              )}
-              {driverCounts.length > 0 ? (
-                <span className="text-xs text-fg-3">
-                  {driverCounts.map(({ driver, count }, index) => (
-                    <span key={driver}>
-                      {index > 0 ? ' · ' : ''}
-                      <span
-                        className="font-mono tabular-nums"
-                        style={{ color: getDriverTextColor(driver, year) }}
-                      >
-                        {driver}
-                      </span>{' '}
-                      {count}
-                    </span>
-                  ))}
-                </span>
-              ) : null}
-            </div>
-          )
-        })}
-      </div>
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+      {compounds.map((compound) => {
+        const variant = compoundVariant(compound)
+        const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
+        return (
+          <div key={compound} className="flex items-center gap-1.5">
+            {variant ? (
+              <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+            ) : (
+              <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+            )}
+            {driverCounts.length > 0 ? (
+              <span className="text-xs text-fg-3">
+                {driverCounts.map(({ driver, count }, index) => (
+                  <span key={driver}>
+                    {index > 0 ? ' · ' : ''}
+                    <span
+                      className="font-mono tabular-nums"
+                      style={{ color: getDriverTextColor(driver, year) }}
+                    >
+                      {driver}
+                    </span>{' '}
+                    {count}
+                  </span>
+                ))}
+              </span>
+            ) : null}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -6,10 +6,16 @@
 // that lap's telemetry via `onLapClick`, which the section wires to the
 // dashboard store's `setLap` (click-to-load; this component never fetches
 // telemetry itself).
+//
+// Click picking runs on zrender directly (`bindNearestPointClick`), not
+// ECharts' `onEvents.click` — the plotted symbols are a de-cluttered 5px dot
+// (see `buildDriverSeries`), too small a hit target on a ~80-lap race. The
+// picker instead accepts any click within a 20px radius of the nearest
+// plotted point (round-2 fix, see `docs/migration/design-specs/dashboard-round2.md#1`).
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
-import type { EChartsOption } from 'echarts'
+import type { ECharts, EChartsOption } from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
 import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
@@ -31,11 +37,28 @@ const AXIS_NAME_STYLE = {
 }
 
 /** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
- *  alongside so the tooltip can show tyre info without a second lookup. */
+ *  alongside so the tooltip can show tyre info without a second lookup.
+ *  `symbolSize`/`itemStyle` are per-point overrides — only set on the
+ *  driver's currently-selected lap, to draw it as a visible ring (see
+ *  `SELECTED_LAP_SYMBOL_SIZE`). ECharts merges a per-data `itemStyle` on top
+ *  of the series-level one, so the ring keeps the driver's fill colour and
+ *  only adds the border. */
 interface LapPoint {
   value: [number, number]
   compound: string
+  symbolSize?: number
+  itemStyle?: { borderColor: string; borderWidth: number }
 }
+
+// Selected-lap ring: bigger symbol + white border, independent of the driver
+// colour underneath — a white ring reads on every team colour on the dark UI.
+const SELECTED_LAP_SYMBOL_SIZE = 11
+const SELECTED_LAP_RING_STYLE = { borderColor: '#fff', borderWidth: 2 }
+
+// Nearest-point click picking (item 1) — see the module docblock.
+const NEAREST_POINT_RADIUS_PX = 20
+// A real drag (pan/box-zoom, item 5) must not also register as a lap pick.
+const DRAG_CLICK_GUARD_PX = 4
 
 /** A single driver's series — kept as our own shape (not `echarts`'
  *  `LineSeriesOption`) so the extra `compound` field on each point never
@@ -83,11 +106,32 @@ function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
   return byDriver
 }
 
+/** One lap turned into a plotted point; the driver's currently-selected lap
+ *  (loaded telemetry) gets the ring override so it's visible on the chart
+ *  itself, not just in the footer caption below. */
+function buildLapPoint(lap: LapTime, selectedLap: number | undefined): LapPoint {
+  const isSelected = lap.lap_number === selectedLap
+  return {
+    value: [lap.lap_number, lap.lap_time],
+    compound: lap.compound,
+    ...(isSelected
+      ? { symbolSize: SELECTED_LAP_SYMBOL_SIZE, itemStyle: SELECTED_LAP_RING_STYLE }
+      : {}),
+  }
+}
+
 /** Build one driver's line+marker series, coloured by TEAM colour. Markers
  *  stay small (`symbolSize: 5`) and the line thin (`width: 1.5`) so a dense
  *  multi-driver plot doesn't bead into a wall of dots; `emphasis.scale` grows
- *  the hovered point back up so it's still an obvious click target. */
-function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
+ *  the hovered point back up so it's still an obvious click target. The hit
+ *  target for clicking, though, is decoupled from this visual size — see
+ *  `findNearestPoint`. */
+function buildDriverSeries(
+  driver: string,
+  laps: LapTime[],
+  color: string,
+  selectedLap: number | undefined,
+): DriverSeriesOption {
   return {
     name: driver,
     type: 'line',
@@ -95,7 +139,7 @@ function buildDriverSeries(driver: string, laps: LapTime[], color: string): Driv
     lineStyle: { color, width: 1.5 },
     itemStyle: { color },
     emphasis: { scale: 1.6 },
-    data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
+    data: laps.map((lap) => buildLapPoint(lap, selectedLap)),
   }
 }
 
@@ -171,26 +215,141 @@ function buildLapChartOption(
       scale: true,
     },
     series: seriesList,
+    // Drag-to-zoom (item 5): inside = click-drag pan + Shift+wheel zoom;
+    // plain wheel stays page scroll. `filterMode: 'none'` keeps zoom/pan from
+    // rescaling the y-axis. `x = lap number` here (unlike the telemetry
+    // charts' `x = distance`), so this chart is NOT joined to their
+    // `echarts.connect` crosshair group — its zoom stays independent.
+    dataZoom: [
+      {
+        type: 'inside',
+        xAxisIndex: 0,
+        filterMode: 'none',
+        zoomOnMouseWheel: 'shift',
+        moveOnMouseMove: true,
+        moveOnMouseWheel: false,
+      },
+    ],
+    // Toolbox box-zoom (Plotly-style, x-only via `yAxisIndex: 'none'`) + a
+    // reset button — the discoverable alternative to the shift-drag gesture.
+    toolbox: {
+      right: 8,
+      top: 0,
+      feature: {
+        dataZoom: { yAxisIndex: 'none', filterMode: 'none' },
+        restore: {},
+      },
+    },
   }
 }
 
-/** A driver code + lap number pulled off a click event, or null when the
- *  click missed a data point (background/axis click). */
-interface LapClickTarget {
+/** One driver's plotted points, exactly as handed to its ECharts series —
+ *  `seriesIndex` in the picker below is this array's index, since it's built
+ *  in lockstep with `option.series`. */
+interface PickerSeries {
   driver: string
-  lapNumber: number
+  points: LapPoint[]
 }
 
-function extractLapClick(raw: unknown): LapClickTarget | null {
-  if (!raw || typeof raw !== 'object') return null
-  const params = raw as { seriesName?: string; data?: unknown; value?: unknown }
-  const driver = params.seriesName
-  const fromData = isLapPoint(params.data) ? params.data.value[0] : undefined
-  const fromValue =
-    Array.isArray(params.value) && typeof params.value[0] === 'number' ? params.value[0] : undefined
-  const lapNumber = fromData ?? fromValue
-  if (!driver || lapNumber == null) return null
-  return { driver, lapNumber }
+/** What the zrender click handler reads on every click: the currently
+ *  plotted series (post-filter, so a filtered-out lap can't be picked) and
+ *  the latest `onLapClick` callback. Mirrored into a ref (see `LapChart`)
+ *  because the handler itself is bound once, in `onChartReady`. */
+interface PickerRefValue {
+  series: PickerSeries[]
+  onLapClick: (driver: string, lapNumber: number) => void
+}
+
+/** Minimal shape read off zrender's raw pointer events — the real event
+ *  (`ElementEvent`) carries plenty more, this is all the picker needs. */
+interface ZrPointerEvent {
+  offsetX: number
+  offsetY: number
+}
+
+/** One plotted point, resolved to its on-screen pixel position. */
+interface PixelPoint {
+  driver: string
+  lapNumber: number
+  px: number
+  py: number
+}
+
+/** Every plotted point across all series, converted once to pixel space via
+ *  `convertToPixel` — cheap even for a full ~80-lap x 3-driver grid (max
+ *  ~240 points per click). */
+function toPixelPoints(chart: ECharts, series: PickerSeries[]): PixelPoint[] {
+  const pixelPoints: PixelPoint[] = []
+  series.forEach((driverSeries, seriesIndex) => {
+    for (const point of driverSeries.points) {
+      const [px, py] = chart.convertToPixel({ seriesIndex }, point.value)
+      pixelPoints.push({ driver: driverSeries.driver, lapNumber: point.value[0], px, py })
+    }
+  })
+  return pixelPoints
+}
+
+function squaredPixelDistance(point: PixelPoint, clickX: number, clickY: number): number {
+  return (point.px - clickX) ** 2 + (point.py - clickY) ** 2
+}
+
+/** Nearest plotted point to a click, in PIXEL space (not data space) — pixel
+ *  distance is what a viewer actually judges as "the closest dot", which can
+ *  differ from data-space nearest when the y-axis spans wildly different lap
+ *  times (e.g. a rain-affected race). Returns null when nothing plotted is
+ *  within `NEAREST_POINT_RADIUS_PX`, so legend/axis-adjacent clicks stay
+ *  inert instead of snapping to a far-away point. */
+function findNearestPoint(
+  chart: ECharts,
+  series: PickerSeries[],
+  clickX: number,
+  clickY: number,
+): { driver: string; lapNumber: number } | null {
+  let nearest: PixelPoint | null = null
+  let nearestDistanceSq = Infinity
+
+  for (const point of toPixelPoints(chart, series)) {
+    const distanceSq = squaredPixelDistance(point, clickX, clickY)
+    if (distanceSq < nearestDistanceSq) {
+      nearestDistanceSq = distanceSq
+      nearest = point
+    }
+  }
+
+  if (!nearest || nearestDistanceSq > NEAREST_POINT_RADIUS_PX ** 2) return null
+  return { driver: nearest.driver, lapNumber: nearest.lapNumber }
+}
+
+/** Registers the nearest-point click picker directly on zrender, once per
+ *  chart instance (called from `onChartReady`, which — unlike `onEvents` —
+ *  only fires on mount, so this never double-binds across the option
+ *  rebuilds `notMerge` triggers on every data change).
+ *
+ *  Three guards, in order: (1) a real mousedown→click drag (pan or the
+ *  toolbox box-zoom, item 5) is ignored via the pixel-delta check, so
+ *  dragging never fires a phantom lap pick; (2) `containPixel` rejects
+ *  clicks outside the plot area (legend, axis, toolbox icons); (3)
+ *  `findNearestPoint`'s radius rejects clicks too far from any plotted dot. */
+function bindNearestPointClick(chart: ECharts, pickerRef: { current: PickerRefValue }): void {
+  const zr = chart.getZr()
+  let downPoint: { x: number; y: number } | null = null
+
+  zr.on('mousedown', (e: ZrPointerEvent) => {
+    downPoint = { x: e.offsetX, y: e.offsetY }
+  })
+
+  zr.on('click', (e: ZrPointerEvent) => {
+    const dragged =
+      downPoint != null &&
+      Math.hypot(e.offsetX - downPoint.x, e.offsetY - downPoint.y) >= DRAG_CLICK_GUARD_PX
+    downPoint = null
+    if (dragged) return
+    if (!chart.containPixel({ gridIndex: 0 }, [e.offsetX, e.offsetY])) return
+
+    const { series, onLapClick } = pickerRef.current
+    const nearest = findNearestPoint(chart, series, e.offsetX, e.offsetY)
+    if (nearest) onLapClick(nearest.driver, nearest.lapNumber)
+  })
 }
 
 export interface LapChartProps {
@@ -200,28 +359,41 @@ export interface LapChartProps {
   drivers: string[]
   year: number | undefined
   onLapClick: (driver: string, lapNumber: number) => void
+  /** driver code -> the lap number whose telemetry is currently loaded, so
+   *  that lap's point can be drawn as a visible ring on the chart. */
+  selectedLaps: Record<string, number>
 }
 
 /** Lap-time chart: one coloured-by-driver line per selected driver, with
- *  click-to-load and a compound-aware tooltip. */
-export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
-  const option = useMemo(() => {
+ *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
+export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
+  const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
       .filter((driver) => byDriver.has(driver))
       .map((driver) =>
-        buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
+        buildDriverSeries(
+          driver,
+          byDriver.get(driver) ?? [],
+          getDriverColor(driver, year),
+          selectedLaps[driver],
+        ),
       )
-    return buildLapChartOption(seriesList, year)
-  }, [laps, drivers, year])
+    return {
+      option: buildLapChartOption(seriesList, year),
+      pickerSeries: seriesList.map((series) => ({ driver: series.name, points: series.data })),
+    }
+  }, [laps, drivers, year, selectedLaps])
 
-  const handleClick = useCallback(
-    (raw: unknown) => {
-      const click = extractLapClick(raw)
-      if (click) onLapClick(click.driver, click.lapNumber)
-    },
-    [onLapClick],
-  )
+  // Latest-ref mirror: the zrender click handler is registered once (see
+  // `handleChartReady` below) and reads through this ref on every click, so
+  // it always sees the current laps/onLapClick without re-binding.
+  const pickerRef = useRef<PickerRefValue>({ series: pickerSeries, onLapClick })
+  pickerRef.current = { series: pickerSeries, onLapClick }
+
+  const handleChartReady = useCallback((chart: ECharts) => {
+    bindNearestPointClick(chart, pickerRef)
+  }, [])
 
   return (
     <div role="img" aria-label="Lap times by lap, per driver">
@@ -230,7 +402,7 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
         option={option}
         style={{ height: 400 }}
         notMerge
-        onEvents={{ click: handleClick }}
+        onChartReady={handleChartReady}
       />
     </div>
   )

--- a/webapp/src/features/dashboard/components/LapChartFooter.tsx
+++ b/webapp/src/features/dashboard/components/LapChartFooter.tsx
@@ -1,0 +1,68 @@
+// Lap Chart card footer strip: telemetry-selection status (left) + tyre
+// compound legend (right), folded into the `ChartCard`'s `footer` slot so the
+// card reads as one unit — chart, controls, status — instead of a stack of
+// loose blocks below it (round-2 fix #3, see
+// `docs/migration/design-specs/dashboard-round2.md#3`). `LapChartSection`
+// only renders this once `lapTimes` is non-empty; both clusters are cheap to
+// compute off data it already has in hand.
+
+import { Activity } from 'lucide-react'
+import type { LapTime } from '@/lib/api/telemetry'
+import { getDriverTextColor } from '../lib/drivers'
+import { CompoundLegend } from './CompoundLegend'
+
+/** `{ driver, lap }` pairs for the telemetry-status caption, in the store
+ *  map's insertion order (click order / fastest-laps batch order). */
+function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
+  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
+}
+
+export interface LapChartFooterProps {
+  /** driver code -> the lap number whose telemetry is currently loaded. */
+  selectedLapsPerDriver: Record<string, number>
+  /** FULL (unfiltered) lap times — the compound legend's counts ignore the
+   *  outlier/invalid toggles, matching `LapControls`. */
+  lapTimes: LapTime[]
+  drivers: string[]
+  year: number | undefined
+}
+
+/** Left cluster: which lap's telemetry is loaded per driver, plus the
+ *  click-to-switch hint (demoted here from its old standalone tip line).
+ *  Right cluster: the inline tyre-compound legend. `flex-wrap` lets narrow
+ *  cards stack the two clusters instead of overflowing. */
+export function LapChartFooter({
+  selectedLapsPerDriver,
+  lapTimes,
+  drivers,
+  year,
+}: LapChartFooterProps) {
+  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+      {captionParts.length > 0 ? (
+        <p className="flex items-center gap-2 text-sm text-fg-2">
+          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
+          <span>
+            Showing telemetry:{' '}
+            {captionParts.map((part, index) => (
+              <span key={part.driver}>
+                {index > 0 ? ', ' : ''}
+                <strong
+                  className="font-semibold"
+                  style={{ color: getDriverTextColor(part.driver, year) }}
+                >
+                  {part.driver}
+                </strong>{' '}
+                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
+              </span>
+            ))}
+            <span className="text-fg-3"> · click any point to switch lap</span>
+          </span>
+        </p>
+      ) : null}
+      <CompoundLegend lapTimes={lapTimes} drivers={drivers} year={year} />
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -1,25 +1,31 @@
 // LAP CHART section. Streamlit parity: `frontend/components/dashboard/lap_graph.py`.
 //
-// Owns the data fetch (`useLapTimes`) and the store reads/writes; the three
-// sub-components (`LapChart`, `LapControls`, `CompoundLegend`) are dumb
-// renderers of whatever slice they're handed. The outlier/invalid filters are
-// applied here (client-side, no refetch — `applyLapFilters`) and only the
-// resulting `visible` laps are plotted; buttons and the legend keep working
-// off the FULL `lapTimes`, matching the Streamlit source's split between
-// "what's plotted" and "what's counted".
+// Owns the data fetch (`useLapTimes`) and the store reads/writes; `LapChart`,
+// `LapControls`, and `LapChartFooter` are dumb renderers of whatever slice
+// they're handed. The outlier/invalid filters are applied here (client-side,
+// no refetch — `applyLapFilters`) and only the resulting `visible` laps are
+// plotted; the controls and footer keep working off the FULL `lapTimes`,
+// matching the Streamlit source's split between "what's plotted" and "what's
+// counted".
+//
+// Everything the chart owns — controls, telemetry status, compound legend —
+// folds into the ONE `ChartCard`: controls sit in the header `actions` slot,
+// status + legend in the `footer` strip, so the card reads as a single unit
+// instead of a chart plus a stack of loose blocks below it (round-2 fix #3,
+// see `docs/migration/design-specs/dashboard-round2.md#3`).
 
 import { useMemo } from 'react'
-import { Activity, Info, MousePointerClick } from 'lucide-react'
+import { Info } from 'lucide-react'
 import type { DashboardSearch } from '../search'
 import { useLapTimes } from '../queries'
 import { useDashboardStore } from '../store'
 import { applyLapFilters } from '../lib/outliers'
-import { getDriverTextColor } from '../lib/drivers'
+import { useToast } from '@/components/Toast'
 import { Skeleton } from '@/components/Skeleton'
 import { ChartCard } from '@/components/ChartCard'
 import { LapChart } from './LapChart'
 import { LapControls } from './LapControls'
-import { CompoundLegend } from './CompoundLegend'
+import { LapChartFooter } from './LapChartFooter'
 
 export interface LapChartSectionProps {
   search: DashboardSearch
@@ -40,18 +46,13 @@ function NoLapDataBanner() {
   )
 }
 
-/** `{ driver, lap }` pairs for the "Showing telemetry" caption, in the
- *  store map's insertion order (click order / fastest-laps batch order). */
-function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
-  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
-}
-
-/** LAP CHART section: chart (or its loading/empty state), control buttons,
- *  a click-to-load tip, the current telemetry-selection caption, and the
- *  tyre compound legend, in that order. */
+/** LAP CHART section: one `ChartCard` — the chart body (or its loading/empty
+ *  state), the fastest-laps/outlier/invalid controls in the header, and the
+ *  telemetry-status + compound-legend strip in the footer. */
 export function LapChartSection({ search }: LapChartSectionProps) {
   const lapTimesQuery = useLapTimes(search)
   const lapTimes = useMemo(() => lapTimesQuery.data ?? [], [lapTimesQuery.data])
+  const { toast } = useToast()
 
   const showOutliers = useDashboardStore((s) => s.showOutliers)
   const showInvalidLaps = useDashboardStore((s) => s.showInvalidLaps)
@@ -70,11 +71,53 @@ export function LapChartSection({ search }: LapChartSectionProps) {
   // shows its own EmptyState otherwise) — this only guards the in-between
   // moment where lap-times came back empty for the current selection.
   const isEmpty = lapTimes.length === 0
-  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  /** Click-to-load, with feedback that the click actually landed: an
+   *  already-loaded lap gets an info toast (no store write, no refetch); a
+   *  new lap gets a success toast once the fetch is queued. Compensates for
+   *  the chart's ring marker (see `LapChart`) being easy to miss when the
+   *  telemetry grid it feeds is below the fold. */
+  function handleLapClick(driver: string, lap: number) {
+    if (selectedLapsPerDriver[driver] === lap) {
+      toast({ title: `${driver} lap ${lap}`, description: 'Already showing this lap.', tone: 'info' })
+      return
+    }
+    setLap(driver, lap)
+    toast({
+      title: `${driver} lap ${lap} loaded`,
+      description: 'Telemetry updated below.',
+      tone: 'success',
+    })
+  }
 
   return (
     <section className="flex flex-col gap-4">
-      <ChartCard title="Lap Chart">
+      <ChartCard
+        title="Lap Chart"
+        actions={
+          <LapControls
+            lapTimes={lapTimes}
+            drivers={search.drivers}
+            showOutliers={showOutliers}
+            showInvalidLaps={showInvalidLaps}
+            outlierCount={filterResult.outlierCount}
+            invalidCount={filterResult.invalidCount}
+            onSelectFastestLaps={setFastestLaps}
+            onToggleOutliers={toggleOutliers}
+            onToggleInvalidLaps={toggleInvalidLaps}
+          />
+        }
+        footer={
+          lapTimes.length > 0 ? (
+            <LapChartFooter
+              selectedLapsPerDriver={selectedLapsPerDriver}
+              lapTimes={lapTimes}
+              drivers={search.drivers}
+              year={search.year}
+            />
+          ) : undefined
+        }
+      >
         {lapTimesQuery.isLoading ? (
           <Skeleton className="h-100 w-full" />
         ) : isEmpty ? (
@@ -84,50 +127,11 @@ export function LapChartSection({ search }: LapChartSectionProps) {
             laps={filterResult.visible}
             drivers={search.drivers}
             year={search.year}
-            onLapClick={setLap}
+            selectedLaps={selectedLapsPerDriver}
+            onLapClick={handleLapClick}
           />
         )}
       </ChartCard>
-
-      <LapControls
-        lapTimes={lapTimes}
-        drivers={search.drivers}
-        showOutliers={showOutliers}
-        showInvalidLaps={showInvalidLaps}
-        outlierCount={filterResult.outlierCount}
-        invalidCount={filterResult.invalidCount}
-        onSelectFastestLaps={setFastestLaps}
-        onToggleOutliers={toggleOutliers}
-        onToggleInvalidLaps={toggleInvalidLaps}
-      />
-
-      <p className="flex items-center gap-2 text-sm text-fg-3">
-        <MousePointerClick className="size-4 shrink-0" aria-hidden="true" />
-        Click a lap to inspect it — fastest laps load automatically.
-      </p>
-
-      {captionParts.length > 0 ? (
-        <p className="flex items-center gap-2 text-sm text-fg-2">
-          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
-          <span>
-            Showing telemetry:{' '}
-            {captionParts.map((part, index) => (
-              <span key={part.driver}>
-                {index > 0 ? ', ' : ''}
-                <strong
-                  className="font-semibold"
-                  style={{ color: getDriverTextColor(part.driver, search.year) }}
-                >
-                  {part.driver}
-                </strong>{' '}
-                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
-              </span>
-            ))}
-          </span>
-        </p>
-      ) : null}
-
-      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} year={search.year} />
     </section>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -79,7 +79,11 @@ export function LapChartSection({ search }: LapChartSectionProps) {
    *  telemetry grid it feeds is below the fold. */
   function handleLapClick(driver: string, lap: number) {
     if (selectedLapsPerDriver[driver] === lap) {
-      toast({ title: `${driver} lap ${lap}`, description: 'Already showing this lap.', tone: 'info' })
+      toast({
+        title: `${driver} lap ${lap}`,
+        description: 'Already showing this lap.',
+        tone: 'info',
+      })
       return
     }
     setLap(driver, lap)

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -76,7 +76,8 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           value={value.gp}
           onChange={(gp) => onChange({ gp })}
           placeholder="Select GP"
-          disabled={value.year == null || gpsQuery.isLoading}
+          disabled={value.year == null}
+          loading={gpsQuery.isLoading}
         />
       </SelectorField>
 
@@ -87,7 +88,8 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           value={value.session}
           onChange={(session) => onChange({ session })}
           placeholder="Select session"
-          disabled={!value.gp || sessionsQuery.isLoading}
+          disabled={!value.gp}
+          loading={sessionsQuery.isLoading}
         />
       </SelectorField>
 
@@ -97,8 +99,15 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           options={driverOptions}
           value={value.drivers}
           onChange={(drivers) => onChange({ drivers })}
-          placeholder="Select drivers (max 3)"
-          disabled={!value.session || driversQuery.isLoading}
+          placeholder={
+            driversQuery.isLoading
+              ? 'Loading drivers…'
+              : driversQuery.isError
+                ? "Couldn't load drivers — reselect the session"
+                : 'Select drivers (max 3)'
+          }
+          disabled={!value.session}
+          loading={driversQuery.isLoading}
           max={MAX_DRIVERS}
           getOptionAccent={(code) => getDriverColor(code, value.year)}
         />

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -1,9 +1,12 @@
-// TELEMETRY section (issue #34, §6.1): 7 per-channel charts — Speed, Delta,
-// Throttle, Brake, RPM, Gear, DRS, matching the render order in
-// frontend/pages/dashboard.py — in a grid<->stack layout, each plotting one
-// line per loaded driver against distance. Delta is cross-driver (needs a
-// reference lap) so it renders through the dedicated `DeltaChart`; the other
-// 6 channels share the generic `ChannelChart`, driven by `channels.ts`.
+// TELEMETRY section (issue #34, §6.1; round 2 adds Accel): 8 per-channel
+// charts — Speed, Delta, Throttle, Brake, RPM, Gear, Accel, DRS — in a
+// grid<->stack layout, each plotting one line per loaded driver against
+// distance. The first 7 (everything but Accel) match the render order in
+// frontend/pages/dashboard.py; Accel has no Streamlit precedent, inserted
+// between Gear and DRS (channels.ts) to fill the grid's lonely last-row DRS
+// slot. Delta is cross-driver (needs a reference lap) so it renders through
+// the dedicated `DeltaChart`; the other 7 channels share the generic
+// `ChannelChart`, driven by `channels.ts`.
 //
 // Data comes from `useLapTelemetries`, keyed by the store's
 // `selectedLapsPerDriver` (the lap chart writes to it on click-to-load).
@@ -109,7 +112,9 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
 
   // Speed leads, Delta is hardcoded second (cross-driver, not part of
   // CHANNELS), then the rest of CHANNELS in their declared order — matches
-  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs).
+  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs)
+  // with Accel (round 2) inserted before drs, yielding 8 grid slots:
+  // [Speed·Delta] [Throttle·Brake] [RPM·Gear] [Accel·DRS].
   const [speedChannel, ...restChannels] = CHANNELS
 
   return (

--- a/webapp/src/features/dashboard/components/accel.test.ts
+++ b/webapp/src/features/dashboard/components/accel.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { longitudinalAccelG } from './channels'
+import type { LapTelemetry } from '@/lib/api/telemetry'
+
+/** Builds a minimal `LapTelemetry` fixture — `longitudinalAccelG` only reads
+ *  `speed`/`time`, the other channels are filled with zeros to satisfy the
+ *  interface. */
+function telemetry(speed: number[], time: number[]): LapTelemetry {
+  return {
+    driver: 'VER',
+    lap_number: 1,
+    distance: speed.map((_, i) => i),
+    time,
+    speed,
+    throttle: speed.map(() => 0),
+    brake: speed.map(() => 0),
+    rpm: speed.map(() => 0),
+    gear: speed.map(() => 0),
+    drs: speed.map(() => 0),
+  }
+}
+
+describe('longitudinalAccelG', () => {
+  it('reads ~1g on a constant-acceleration ramp', () => {
+    // 5 Hz-ish sampling (dt = 0.2s), speed climbing at exactly 1g the whole way.
+    const dt = 0.2
+    const accelStepKmh = 9.81 * 3.6 * dt // km/h gained per sample at 1g
+    const time = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    const speed = time.map((_, i) => i * accelStepKmh)
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    expect(g).toHaveLength(6)
+    for (const value of g) {
+      expect(value).toBeCloseTo(1, 5)
+    }
+  })
+
+  it('reads ~0g on a flat speed trace', () => {
+    const time = [0, 0.2, 0.4, 0.6, 0.8]
+    const speed = time.map(() => 220)
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    for (const value of g) {
+      expect(value).toBeCloseTo(0, 5)
+    }
+  })
+
+  it('carries the previous value through a repeated timestamp instead of NaN/Infinity', () => {
+    // time[3] === time[1] makes the central-difference dt at i=2 zero.
+    const time = [0, 0.2, 0.2, 0.2, 0.4]
+    const speed = [100, 110, 112, 115, 120]
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    expect(g).toHaveLength(5)
+    for (const value of g) {
+      expect(Number.isFinite(value)).toBe(true)
+      expect(Number.isNaN(value)).toBe(false)
+    }
+  })
+
+  it('returns an empty array for empty telemetry', () => {
+    expect(longitudinalAccelG(telemetry([], []))).toEqual([])
+  })
+})

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -1,15 +1,19 @@
-// Channel configs for the TELEMETRY grid (issue #34, §6.1). Six of the seven
-// charts (everything but Delta) are pure "plot this array against distance"
-// jobs and share the generic `ChannelChart` component — this file is that
-// shared data. Delta is cross-driver (it diffs every loaded lap against a
-// reference lap's interpolated time, not a single telemetry array) so it
-// gets its own `DeltaChart` component in ChannelChart.tsx instead of an
-// entry here; `DELTA_TITLE` is exported so its ChartCard heading still lives
-// next to the other six.
+// Channel configs for the TELEMETRY grid (issue #34, §6.1). Seven of the
+// eight charts (everything but Delta) are pure "plot this array against
+// distance" jobs and share the generic `ChannelChart` component — this file
+// is that shared data. Delta is cross-driver (it diffs every loaded lap
+// against a reference lap's interpolated time, not a single telemetry
+// array) so it gets its own `DeltaChart` component in ChannelChart.tsx
+// instead of an entry here; `DELTA_TITLE` is exported so its ChartCard
+// heading still lives next to the other seven.
 //
 // Streamlit parity: frontend/components/telemetry/{speed,throttle,brake,rpm,
 // gear,drs}_graph.py. `transform` mirrors each module's data-prep step (only
 // DRS transforms its raw values; the rest plot the FastF1 array as-is).
+// `accel` (round 2, issue #34 follow-up) has no Streamlit precedent — it's
+// derived client-side from `speed`/`time`, added to fill the grid's lonely
+// last-row DRS slot with a real race-engineering channel instead of dead
+// space.
 
 import type { LapTelemetry } from '@/lib/api/telemetry'
 
@@ -24,7 +28,7 @@ export interface ChannelYAxis {
 }
 
 export interface ChannelConfig {
-  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'drs'
+  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'accel' | 'drs'
   /** ChartCard header + chart title. */
   title: string
   /** Y-axis name shown on the chart. */
@@ -41,6 +45,63 @@ export interface ChannelConfig {
   yAxis?: ChannelYAxis
   /** Extracts the plotted series from a driver's telemetry. */
   transform: (telemetry: LapTelemetry) => number[]
+}
+
+const GRAVITY_MS2 = 9.81
+const KMH_PER_MS = 3.6
+
+/**
+ * Longitudinal acceleration in g, derived from the `speed`/`time` arrays
+ * already present on every `lap-telemetry` response — no new backend field.
+ * Central difference over the interior samples (`a[i] = ((v[i+1]-v[i-1]) /
+ * 3.6) / (t[i+1]-t[i-1]) / 9.81`, km/h -> m/s -> g), one-sided at the two
+ * endpoints (nothing to average with past the edge), then a 3-point moving
+ * average (`movingAverage3`) to tame FastF1's ~4-5 Hz sampling noise:
+ * differentiating a sampled-and-quantized speed signal amplifies its own
+ * noise, so the raw central difference would jitter point-to-point instead
+ * of tracing the clean braking/traction zones this channel exists to show.
+ *
+ * A repeated timestamp (`dt === 0`, seen in FastF1's telemetry
+ * interpolation) would otherwise divide by zero; that sample instead
+ * carries the previous point's value forward so the trace stays finite
+ * (no NaN/Infinity) rather than poisoning the whole line.
+ */
+export function longitudinalAccelG(telemetry: LapTelemetry): number[] {
+  const { speed, time } = telemetry
+  const sampleCount = speed.length
+  if (sampleCount === 0) return []
+
+  const raw: number[] = new Array(sampleCount)
+  for (let i = 0; i < sampleCount; i++) {
+    const lo = i === 0 ? 0 : i - 1
+    const hi = i === sampleCount - 1 ? sampleCount - 1 : i + 1
+    const dt = time[hi] - time[lo]
+    if (dt === 0) {
+      raw[i] = i === 0 ? 0 : raw[i - 1]
+      continue
+    }
+    const deltaSpeedMs = (speed[hi] - speed[lo]) / KMH_PER_MS
+    raw[i] = deltaSpeedMs / dt / GRAVITY_MS2
+  }
+
+  return movingAverage3(raw)
+}
+
+/**
+ * Boundary-aware 3-point moving average: a 2-point average at the two
+ * endpoints (no data past the edge to average with), a 3-point average
+ * everywhere else. Used to smooth `longitudinalAccelG`'s central-difference
+ * noise without losing the endpoint samples.
+ */
+function movingAverage3(values: number[]): number[] {
+  const n = values.length
+  return values.map((_, i) => {
+    const lo = Math.max(0, i - 1)
+    const hi = Math.min(n - 1, i + 1)
+    let sum = 0
+    for (let j = lo; j <= hi; j++) sum += values[j]
+    return sum / (hi - lo + 1)
+  })
 }
 
 /**
@@ -73,6 +134,14 @@ export const CHANNELS: ChannelConfig[] = [
     // min 0 so neutral (nGear=0, seen at launch / in the pits) isn't clipped.
     yAxis: { min: 0, max: 8, interval: 1 },
     transform: (t) => t.gear,
+  },
+  {
+    key: 'accel',
+    title: 'Longitudinal Accel',
+    yName: 'Long. Accel (g)',
+    // No explicit yAxis: `scale: true` (baseOption's default) autoranges
+    // around the data, same as Speed/RPM/Delta.
+    transform: longitudinalAccelG,
   },
   {
     key: 'drs',


### PR DESCRIPTION
Round-2 refinements to the migrated Dashboard, from Víctor's review of the shipped elevation (design-first audit in `docs/migration/design-specs/dashboard-round2.md`).

## What
- **Lap-chart click fixed.** Clicking a point now loads that lap's telemetry via a nearest-point picker on zrender (20px radius) instead of the too-small 5px symbol hit-target. Guards: mousedown->click drag detection (so pan/box-zoom never fires a pick), `containPixel` (ignore legend/axis/toolbox), and the radius. The currently-loaded lap gets a visible white ring, and a toast confirms switch vs already-loaded.
- **Drivers picker shows it's working.** Comboboxes gain a `loading` state (spinner + `aria-busy`, `opacity-80` not the disabled dim) so the drivers selector reads as busy — not broken — during the 2-15s FastF1 session parse. Placeholder reads "Loading drivers…".
- **Controls block folded in.** The loose fastest-laps / outliers / invalid / caption / compound-legend stack below the lap chart is now the ChartCard's header actions + a footer strip (`LapChartFooter`), fixing the "raro" loose text.
- **8th telemetry chart.** New Longitudinal Acceleration (g) channel, derived client-side from the existing speed/time arrays (central difference + 3-point smoothing, dt=0 guard) — fills the lonely DRS slot so the grid is a symmetric 4x2.
- **Drag-to-zoom.** ECharts `dataZoom` (inside pan + Shift-wheel) + a toolbox box-zoom/restore on the lap and telemetry charts (Plotly/Streamlit parity). Telemetry charts share the existing crosshair-connect group so a zoom syncs across all 8.

## Checks
- tsc -b, oxlint, vitest (37/37, incl. new `accel.test.ts`), vite build — all green.
- Screenshot-verified on 2023 Monaco R (VER, LEC): 9 canvases auto-load, symmetric grid, folded footer, selected-lap ring.

## Out of scope (separate PRs)
- Light theme + rail redesign + typography (app-chrome-round2.md).
- A faster `/drivers` path (backend roster index) — filed separately.