### PR TITLE
feat(webapp): redesign app rail + fix brand typography tracking

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -19,7 +19,7 @@ export default function App() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-5xl flex-col gap-10 p-8 md:p-16">
       <header className="flex flex-col gap-2">
-        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+        <span className="font-body text-xs font-semibold uppercase tracking-widest text-purple-300">
           Migration epic #25
         </span>
         <h1 className="font-display text-5xl font-bold tracking-tight text-balance md:text-6xl">
@@ -55,7 +55,7 @@ export default function App() {
       </section>
 
       <section className="flex max-w-sm flex-col gap-2 rounded-2xl border border-purple-600/40 bg-bg-3 p-6 shadow-[var(--shadow-glow)]">
-        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+        <span className="font-body text-xs font-semibold uppercase tracking-widest text-purple-300">
           Recommendation
         </span>
         <span className="font-display text-3xl font-bold text-balance">PIT, undercut</span>

--- a/webapp/src/app/Header.tsx
+++ b/webapp/src/app/Header.tsx
@@ -18,7 +18,7 @@ export function Header({ title, children }: HeaderProps) {
       style={{ zIndex: Z.header }}
       className="sticky top-0 flex h-14 items-center justify-between border-b border-divider bg-bg-1/80 px-6 backdrop-blur-md"
     >
-      <h1 className="font-display text-lg text-fg-1">{title}</h1>
+      <h1 className="font-display text-lg font-semibold tracking-tight text-fg-1">{title}</h1>
       {children && <div className="flex items-center gap-2">{children}</div>}
     </header>
   )

--- a/webapp/src/app/Rail.test.tsx
+++ b/webapp/src/app/Rail.test.tsx
@@ -9,6 +9,7 @@ import {
   Outlet,
 } from '@tanstack/react-router'
 import { Rail } from './Rail'
+import { TooltipProvider } from '@/components/Tooltip'
 import { useUiStore } from '@/stores/ui'
 
 // Rail owns the only non-trivial logic in the shell scaffold: toggling
@@ -27,8 +28,27 @@ function renderRail() {
     routeTree: rootRoute.addChildren([indexRoute]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   })
-  return render(<RouterProvider router={router} />)
+  // Rail's collapse button uses <Tooltip>, which throws outside a
+  // TooltipProvider — the real app mounts one in providers.tsx, so the test
+  // supplies its own (same as the router context above).
+  return render(
+    <TooltipProvider>
+      <RouterProvider router={router} />
+    </TooltipProvider>,
+  )
 }
+
+// The 7 nav links the redesigned rail must render, regardless of grouping —
+// name (accessible name of the <Link>) paired with its route.
+const NAV_LINKS: Array<[name: string, href: string]> = [
+  ['Home', '/'],
+  ['Dashboard', '/dashboard'],
+  ['Comparison', '/comparison'],
+  ['Lab', '/lab'],
+  ['Strategy', '/strategy'],
+  ['Race', '/race'],
+  ['Chat', '/chat'],
+]
 
 describe('Rail', () => {
   it('toggles railCollapsed in the UI store on click', async () => {
@@ -39,5 +59,62 @@ describe('Rail', () => {
     fireEvent.click(toggle)
 
     expect(useUiStore.getState().railCollapsed).toBe(true)
+  })
+
+  it('renders the brand block linking home', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    const brandLink = await screen.findByRole('link', { name: /f1 stratlab/i })
+    expect(brandLink).toHaveAttribute('href', '/')
+  })
+
+  it('renders all 7 nav links with their routes', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    for (const [name, href] of NAV_LINKS) {
+      const link = await screen.findByRole('link', { name })
+      expect(link).toHaveAttribute('href', href)
+    }
+  })
+
+  it('groups the nav under the Telemetry, Pit wall and Assist section labels', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    expect(await screen.findByText('Telemetry')).toBeInTheDocument()
+    expect(screen.getByText('Pit wall')).toBeInTheDocument()
+    expect(screen.getByText('Assist')).toBeInTheDocument()
+  })
+
+  it('collapses section labels to a divider instead of rendering the text', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    // Section eyebrows are fully unmounted when collapsed (swapped for a
+    // plain divider rule), not just visually hidden — there's no room at
+    // 76px for the text, so the grouping survives as a rule instead.
+    await screen.findByRole('button', { name: /expand navigation/i })
+    expect(screen.queryByText('Telemetry')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pit wall')).not.toBeInTheDocument()
+    expect(screen.queryByText('Assist')).not.toBeInTheDocument()
+  })
+
+  it('hides text labels but keeps them mounted with a title tooltip when collapsed', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    const dashboardLink = await screen.findByRole('link', { name: 'Dashboard' })
+    expect(dashboardLink).toHaveAttribute('title', 'Dashboard')
+    expect(screen.getByText('Dashboard')).toHaveClass('hidden')
+    expect(screen.getByText('F1 StratLab')).toHaveClass('hidden')
+  })
+
+  it('shows the expand-navigation button when collapsed', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    expect(await screen.findByRole('button', { name: /expand navigation/i })).toBeInTheDocument()
   })
 })

--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -1,153 +1,134 @@
 import type { ReactNode } from 'react'
+import {
+  type LucideIcon,
+  ArrowRightLeft,
+  Crosshair,
+  Flag,
+  FlaskConical,
+  House,
+  LayoutDashboard,
+  MessageSquare,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 import { useUiStore } from '@/stores/ui'
 import { Button } from '@/components/Button'
+import { Tooltip } from '@/components/Tooltip'
 
-// Shared Link styling (#33). `to` stays a literal string at each JSX call
-// site below (never threaded through a prop/array field) so TanStack
-// Router's `const TTo` generic can infer the exact route literal instead of
-// widening to `string` — that's what keeps `<Link to="...">` type-checked
-// against the real route tree. `className`'s are concatenated by the router
-// (not merged via cn/twMerge), so LINK_CLASS carries only the parts that
-// never change; color comes from ACTIVE/INACTIVE_PROPS.
-const LINK_CLASS = 'flex items-center gap-3 rounded-lg px-3 py-2.5 font-medium transition-colors'
-const ACTIVE_PROPS = { className: 'bg-bg-4 text-fg-1' }
-const INACTIVE_PROPS = { className: 'text-fg-3 hover:text-fg-1' }
-
-function NavIcon({ children }: { children: ReactNode }) {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-5 shrink-0"
-      aria-hidden="true"
-    >
-      {children}
-    </svg>
+// Shared Link styling (#33, redesigned round 2 per docs/migration/design-specs/
+// app-chrome-round2.md §3 — the docs-sidebar grammar instead of a generic flat
+// list). `to` stays a literal string at each JSX call site below (never
+// threaded through a prop/array field) so TanStack Router's `const TTo`
+// generic can infer the exact route literal instead of widening to `string`
+// — that's what keeps `<Link to="...">` type-checked against the real route
+// tree. `className`s are concatenated by the router (not merged via
+// cn/twMerge), so `itemClass()` carries only the parts that never change;
+// color comes from ACTIVE_PROPS/INACTIVE_PROPS below.
+function itemClass(collapsed: boolean): string {
+  return cn(
+    'relative flex h-9 items-center gap-3 rounded-lg text-sm transition-colors',
+    collapsed ? 'justify-center px-0' : 'px-3',
   )
 }
 
-function HomeIcon() {
-  return (
-    <NavIcon>
-      <path d="M3 9.5 10 4l7 5.5" />
-      <path d="M5 8.5V16h10V8.5" />
-    </NavIcon>
-  )
-}
-
-function DashboardIcon() {
-  return (
-    <NavIcon>
-      <rect x="3" y="3" width="6" height="6" rx="1" />
-      <rect x="11" y="3" width="6" height="6" rx="1" />
-      <rect x="3" y="11" width="6" height="6" rx="1" />
-      <rect x="11" y="11" width="6" height="6" rx="1" />
-    </NavIcon>
-  )
-}
-
-function StrategyIcon() {
-  return (
-    <NavIcon>
-      <circle cx="10" cy="10" r="6.5" />
-      <circle cx="10" cy="10" r="3" />
-      <circle cx="10" cy="10" r="0.5" fill="currentColor" stroke="none" />
-    </NavIcon>
-  )
-}
-
-function RaceIcon() {
-  return (
-    <NavIcon>
-      <path d="M5 3v14" />
-      <path d="M5 4h10l-2.5 3L15 10H5" />
-    </NavIcon>
-  )
-}
-
-function LabIcon() {
-  return (
-    <NavIcon>
-      <path d="M8 3h4" />
-      <path d="M9 3v5.5L4.7 14.8a1.4 1.4 0 0 0 1.2 2.2h8.2a1.4 1.4 0 0 0 1.2-2.2L11 8.5V3" />
-      <path d="M6.7 12.5h6.6" />
-    </NavIcon>
-  )
-}
-
-function ComparisonIcon() {
-  return (
-    <NavIcon>
-      <path d="M6 16V8" />
-      <path d="M14 16V4" />
-      <path d="M3 16h14" />
-    </NavIcon>
-  )
-}
-
-function ChatIcon() {
-  return (
-    <NavIcon>
-      <path d="M3.5 5.5A1.5 1.5 0 0 1 5 4h10a1.5 1.5 0 0 1 1.5 1.5v6A1.5 1.5 0 0 1 15 13H8l-3.5 3v-3H5a1.5 1.5 0 0 1-1.5-1.5v-6Z" />
-    </NavIcon>
-  )
-}
-
-/** Chevron toggle for the collapse button; rotates 180° (transform-only, so
- *  it stays cheap and respects prefers-reduced-motion) to flip meaning from
- *  "collapse" (points in) to "expand" (points out). */
-function CollapseIcon({ collapsed }: { collapsed: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      className={cn(
-        'size-4 transition-transform duration-200 ease-out motion-reduce:transition-none',
-        collapsed && 'rotate-180',
-      )}
-    >
-      <path d="M12.5 4.5 7 10l5.5 5.5" />
-    </svg>
-  )
-}
+const ACTIVE_PROPS = { className: 'text-fg-1 bg-[image:var(--grad-purple-soft)]' }
+const INACTIVE_PROPS = { className: 'text-fg-3 hover:text-fg-1 hover:bg-fg-1/[0.04]' }
 
 interface NavLinkContentProps {
-  icon: ReactNode
+  icon: LucideIcon
   label: string
   collapsed: boolean
+  isActive: boolean
 }
 
-/** Icon + label pair shared by every nav item. When the rail is collapsed the
- *  label is `hidden` (removed from the a11y tree too), so the Link's native
- *  `title` attribute becomes its accessible name and doubles as the hover
- *  tooltip — no Tooltip component needed for this scaffold. */
-function NavLinkContent({ icon, label, collapsed }: NavLinkContentProps) {
+/**
+ * Icon + label + active-indicator triple shared by every nav item. Rendering
+ * a different child per active state needs TanStack Link's children-as-
+ * function form (`{({ isActive }) => ...}`, wired up at each call site below)
+ * rather than `activeProps` classNames, since the left bar and the icon
+ * color both depend on `isActive`.
+ *
+ * The left bar is always mounted (never conditionally rendered) so its
+ * `scale-y` transition actually animates when a route becomes active instead
+ * of popping in — `isActive` only flips the scale, never the DOM presence.
+ *
+ * When the rail is collapsed the label is `hidden` (removed from the a11y
+ * tree too, since `display:none` drops it from the accessibility tree), so
+ * the Link's native `title` attribute becomes the accessible name and
+ * doubles as the hover tooltip — no Tooltip component needed here.
+ */
+function NavLinkContent({ icon: Icon, label, collapsed, isActive }: NavLinkContentProps) {
   return (
     <>
-      <span className="shrink-0">{icon}</span>
-      <span className={cn('truncate text-sm', collapsed && 'hidden')}>{label}</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'absolute inset-y-2 left-0 w-0.5 origin-center scale-y-0 rounded-full bg-purple-400',
+          'shadow-[0_0_8px_rgba(108,92,231,0.6)] transition-transform duration-150 ease-out motion-reduce:transition-none',
+          isActive && 'scale-y-100',
+        )}
+      />
+      <Icon
+        aria-hidden="true"
+        strokeWidth={1.75}
+        className={cn('size-4.5 shrink-0', isActive ? 'text-purple-300' : 'text-fg-4')}
+      />
+      <span className={cn('truncate', collapsed && 'hidden')}>{label}</span>
     </>
   )
 }
 
 /**
- * Acrylic left icon rail: 72px collapsed / 220px expanded, driven by the
- * shared `useUiStore` so the collapsed state survives navigation and reloads
- * (persisted under `f1sl.ui`). Width itself is never transitioned — baseline-ui
- * restricts animation to transform/opacity (cheap, compositor-only); a width
- * change is a layout property, so it snaps instantly instead.
+ * Section eyebrow above a group of nav items (docs-sidebar grammar): a tiny
+ * uppercase label with a purple tick when expanded. When the rail collapses
+ * to icon-only width there's no room for the label, so it swaps to a plain
+ * divider rule instead — the grouping survives the collapse rather than
+ * silently disappearing.
+ */
+function NavSectionLabel({ label, collapsed }: { label: string; collapsed: boolean }) {
+  if (collapsed) {
+    return <div aria-hidden="true" className="mx-3 my-4 border-t border-hairline" />
+  }
+  return (
+    <div className="mt-4 mb-1 flex items-center gap-2 px-3 font-display text-[10px] font-semibold tracking-widest text-fg-4 uppercase">
+      <span aria-hidden="true" className="size-1 shrink-0 rounded-full bg-purple-500" />
+      {label}
+    </div>
+  )
+}
+
+/** One labeled group of nav items (e.g. "Telemetry": Dashboard, Comparison,
+ *  Lab). Pairs the section eyebrow with its `<ul>` so `Rail`'s render reads
+ *  as a flat list of sections instead of repeating the label/list pairing
+ *  three times. */
+function NavSection({
+  label,
+  collapsed,
+  children,
+}: {
+  label: string
+  collapsed: boolean
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <NavSectionLabel label={label} collapsed={collapsed} />
+      <ul className="flex flex-col gap-1">{children}</ul>
+    </div>
+  )
+}
+
+/**
+ * Acrylic left icon rail, redesigned to carry F1 StratLab's brand vocabulary
+ * (docs-sidebar grouping + a brand block) instead of a generic flat list:
+ * 76px collapsed / 232px expanded, driven by the shared `useUiStore` so the
+ * collapsed state survives navigation and reloads (persisted under
+ * `f1sl.ui`). Width itself is never transitioned — baseline-ui restricts
+ * animation to transform/opacity (cheap, compositor-only); a width change is
+ * a layout property, so it snaps instantly instead.
  */
 export function Rail() {
   const railCollapsed = useUiStore((state) => state.railCollapsed)
@@ -158,105 +139,201 @@ export function Rail() {
       aria-label="Primary"
       style={{ zIndex: Z.rail }}
       className={cn(
-        'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/80 backdrop-blur-md',
-        railCollapsed ? 'w-[72px]' : 'w-[220px]',
+        'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/70 backdrop-blur-md',
+        railCollapsed ? 'w-19' : 'w-58',
       )}
     >
-      <ul className="flex flex-1 flex-col gap-1 overflow-y-auto p-3">
-        <li>
-          <Link
-            to="/"
-            activeOptions={{ exact: true }}
-            title={railCollapsed ? 'Home' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<HomeIcon />} label="Home" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/dashboard"
-            title={railCollapsed ? 'Dashboard' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<DashboardIcon />} label="Dashboard" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/strategy"
-            title={railCollapsed ? 'Strategy' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<StrategyIcon />} label="Strategy" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/race"
-            title={railCollapsed ? 'Race' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<RaceIcon />} label="Race" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/lab"
-            title={railCollapsed ? 'Lab' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<LabIcon />} label="Lab" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/comparison"
-            title={railCollapsed ? 'Comparison' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent
-              icon={<ComparisonIcon />}
-              label="Comparison"
-              collapsed={railCollapsed}
-            />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/chat"
-            title={railCollapsed ? 'Chat' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<ChatIcon />} label="Chat" collapsed={railCollapsed} />
-          </Link>
-        </li>
-      </ul>
-
-      <div className="border-t border-divider p-3">
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label={railCollapsed ? 'Expand navigation' : 'Collapse navigation'}
-          onClick={toggleRail}
-          className="w-full justify-center"
+      {/* Brand block. Aligns with Header's h-14 so rail + header form one
+          continuous chrome line across the top of the app. */}
+      <Link
+        to="/"
+        activeOptions={{ exact: true }}
+        className={cn(
+          'flex h-14 shrink-0 items-center gap-2.5 border-b border-hairline',
+          railCollapsed ? 'justify-center px-0' : 'px-4',
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[image:var(--grad-purple)] font-mono text-[10px] font-bold text-white"
         >
-          <CollapseIcon collapsed={railCollapsed} />
-        </Button>
+          F1
+        </span>
+        <span
+          className={cn(
+            'truncate font-display text-[15px] font-semibold tracking-tight text-fg-1',
+            railCollapsed && 'hidden',
+          )}
+        >
+          F1 StratLab
+        </span>
+      </Link>
+
+      <div className="flex flex-1 flex-col overflow-y-auto p-3">
+        <ul className="flex flex-col gap-1">
+          <li>
+            <Link
+              to="/"
+              activeOptions={{ exact: true }}
+              title={railCollapsed ? 'Home' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={House}
+                  label="Home"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </ul>
+
+        <NavSection label="Telemetry" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/dashboard"
+              title={railCollapsed ? 'Dashboard' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={LayoutDashboard}
+                  label="Dashboard"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/comparison"
+              title={railCollapsed ? 'Comparison' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={ArrowRightLeft}
+                  label="Comparison"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/lab"
+              title={railCollapsed ? 'Lab' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={FlaskConical}
+                  label="Lab"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+
+        <NavSection label="Pit wall" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/strategy"
+              title={railCollapsed ? 'Strategy' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={Crosshair}
+                  label="Strategy"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/race"
+              title={railCollapsed ? 'Race' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={Flag}
+                  label="Race"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+
+        <NavSection label="Assist" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/chat"
+              title={railCollapsed ? 'Chat' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={MessageSquare}
+                  label="Chat"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+      </div>
+
+      <div
+        className={cn(
+          'flex items-center border-t border-hairline p-3',
+          railCollapsed ? 'justify-center' : 'justify-between',
+        )}
+      >
+        <span className={cn('font-mono text-[10px] text-fg-4', railCollapsed && 'hidden')}>
+          v0.9
+        </span>
+        <Tooltip content={railCollapsed ? 'Expand navigation' : 'Collapse navigation'} side="right">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={railCollapsed ? 'Expand navigation' : 'Collapse navigation'}
+            onClick={toggleRail}
+            className="size-8 p-0"
+          >
+            {railCollapsed ? (
+              <PanelLeftOpen className="size-4" aria-hidden="true" />
+            ) : (
+              <PanelLeftClose className="size-4" aria-hidden="true" />
+            )}
+          </Button>
+        </Tooltip>
       </div>
     </nav>
   )

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,6 +57,16 @@
   --font-display: var(--font-display);
   --font-body: var(--font-body);
   --font-mono: var(--font-mono);
+
+  /* Brand letter-spacing (tokens.css). Without this map, every `tracking-*`
+     utility silently falls back to Tailwind's defaults (widest 0.1em, wide
+     0.025em) instead of the brand scale — the eyebrow tracking (0.18em) is the
+     one that reads wrong. Keeps `tracking-*` theme-swappable like the colors. */
+  --tracking-tightest: var(--tracking-tightest);
+  --tracking-tighter: var(--tracking-tighter);
+  --tracking-tight: var(--tracking-tight);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-widest: var(--tracking-widest);
 }
 
 @layer base {


### PR DESCRIPTION
App-chrome round-2 (design-first audit in `docs/migration/design-specs/app-chrome-round2.md`, items 2 + 3).

## What
- **Rail redesign.** The old flat-list sidebar (generic-LLM look) is rewritten with the docs-site grammar: a brand block (purple F1 mark + wordmark, aligned to the header's h-14 chrome line), grouped nav (**Telemetry** / **Pit wall** / **Assist**) with uppercase eyebrow labels + purple dots, an active state that's a purple wash + a glowing 2px left bar, lucide icons throughout (−90 lines of hand-rolled SVGs), and a footer with a mono `v0.9` tag + an icon-only collapse button. TanStack Router typing preserved via Link's children-as-function form (`to` stays a literal at each call site).
- **Typography rulebook fixes (D1-D3).** Brand letter-spacing tokens are now mapped into Tailwind's `@theme`, so every `tracking-*` utility uses the brand scale (eyebrows render the intended 0.18em instead of Tailwind's 0.1em default). Page-title header gets its brand weight (`font-semibold tracking-tight`). Removed the two hand-rolled `tracking-[0.18em]` arbitrary values.

## Checks
- tsc -b, oxlint, vitest (43/43, Rail suite expanded), vite build — all green.
- Screenshot-verified on 2023 Monaco R (VER, LEC): new rail grammar, grouped sections, active Dashboard state, correct eyebrow tracking.

## Out of scope (next PR)
- Light theme + header toggle (`app-chrome-round2.md` item 1) — depends on this PR's tokens being correct.
- Onboarding (item 4) — future.