### PR TITLE
feat(webapp): light theme with header toggle

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -5,6 +5,15 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>F1 StratLab</title>
+    <script>
+      // FOUC guard: stamp the persisted theme before React mounts, so a
+      // light-theme user never sees one dark frame. zustand/persist stores
+      // { state: { theme, ... }, version } under the `f1sl.ui` key.
+      try {
+        var t = JSON.parse(localStorage.getItem('f1sl.ui')).state.theme
+        if (t) document.documentElement.dataset.theme = t
+      } catch (e) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -46,7 +46,12 @@ export default function App() {
           {TYRES.map(([label, bg]) => (
             <span
               key={label}
-              className={cn('rounded-full px-3 py-1 font-mono text-xs font-semibold text-bg-0', bg)}
+              // border-hairline (B3): keeps HARD's near-white chip visible
+              // against a white card once the light theme lands.
+              className={cn(
+                'rounded-full border border-hairline px-3 py-1 font-mono text-xs font-semibold text-bg-0',
+                bg,
+              )}
             >
               {label}
             </span>

--- a/webapp/src/app/Header.tsx
+++ b/webapp/src/app/Header.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Z } from '@/lib/zIndex'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 export interface HeaderProps {
   title: string
@@ -11,6 +12,10 @@ export interface HeaderProps {
  * chips differ per screen — filters, driver pickers, export buttons), so
  * Shell does not mount this itself. Acrylic chrome: translucent + blurred,
  * per the acrylic law data surfaces (Card.tsx) never get this treatment.
+ *
+ * `ThemeToggle` always renders at the far right of the cluster, after the
+ * page's own `children`, so every routed page gets it for free even when it
+ * passes no children of its own (app-chrome-round2.md §2d).
  */
 export function Header({ title, children }: HeaderProps) {
   return (
@@ -19,7 +24,10 @@ export function Header({ title, children }: HeaderProps) {
       className="sticky top-0 flex h-14 items-center justify-between border-b border-divider bg-bg-1/80 px-6 backdrop-blur-md"
     >
       <h1 className="font-display text-lg font-semibold tracking-tight text-fg-1">{title}</h1>
-      {children && <div className="flex items-center gap-2">{children}</div>}
+      <div className="flex items-center gap-2">
+        {children}
+        <ThemeToggle />
+      </div>
     </header>
   )
 }

--- a/webapp/src/app/providers.tsx
+++ b/webapp/src/app/providers.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from './router'
 import { TooltipProvider } from '@/components/Tooltip'
 import { ToastProvider } from '@/components/Toast'
+import { useUiStore } from '@/stores/ui'
 
 // App-wide providers: TanStack Query (server-state cache) wraps TanStack Router
 // (typed routing). Race telemetry is immutable/historical, so a generous default
@@ -15,6 +17,15 @@ const queryClient = new QueryClient({
 })
 
 export function Providers() {
+  // Single source of truth for the active theme: mirror the persisted store
+  // onto <html data-theme>, which every token reads via :root[data-theme].
+  // The FOUC guard in index.html sets this before React mounts; this effect
+  // keeps it in sync on toggle.
+  const theme = useUiStore((state) => state.theme)
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+  }, [theme])
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>

--- a/webapp/src/charts/Gauge.tsx
+++ b/webapp/src/charts/Gauge.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { EChartsOption } from 'echarts'
-import { registerF1Theme } from './registerEcharts'
-import { F1_THEME } from './echartsTheme'
+import { registerF1Theme, useChartTheme } from './registerEcharts'
+import { F1_LIGHT_THEME } from './echartsTheme'
 
 // Register the token theme at module load — before any chart's init runs.
 // (echarts-for-react inits with the `theme` prop in componentDidMount, which
@@ -15,10 +15,30 @@ registerF1Theme()
 // touch a raw ECharts option for this shape: pass a value, get a token-themed
 // arc back. Progress-only design (no needle) reads cleanly at small sizes.
 
-const PURPLE_600 = '#6c5ce7'
-const HAIRLINE = 'rgba(255,255,255,0.10)'
-const FG_1 = '#ffffff'
-const FG_3 = 'rgba(255,255,255,0.52)'
+// The gauge's track/detail/title colors are set per-series (ECharts merges a
+// series-level `itemStyle`/`color` over the registered theme's defaults), so
+// swapping the registered `theme` prop alone does not re-color them — they
+// need their own light/dark palette here, mirroring echartsTheme.ts's swap.
+const PURPLE_600 = '#6c5ce7' // identity color — same accent in both themes
+
+interface GaugePalette {
+  hairline: string
+  fg1: string
+  fg3: string
+}
+
+const DARK_GAUGE_PALETTE: GaugePalette = {
+  hairline: 'rgba(255,255,255,0.10)',
+  fg1: '#ffffff',
+  fg3: 'rgba(255,255,255,0.52)',
+}
+
+const LIGHT_GAUGE_PALETTE: GaugePalette = {
+  hairline: 'rgba(20,18,31,0.10)',
+  fg1: '#14121f',
+  fg3: 'rgba(20,18,31,0.58)',
+}
+
 const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 const DISPLAY = "'Space Grotesk Variable', system-ui, sans-serif"
 
@@ -36,13 +56,20 @@ interface GaugeOptionInput {
   max: number
   label: string | undefined
   formatValue: (value: number) => string
+  palette: GaugePalette
 }
 
 /** Build the ECharts gauge option: hairline full-circle track, purple
  *  progress arc, no pointer/anchor, and a mono center readout formatted via
  *  `formatValue`. Pulled out of the component so the option shape is easy to
  *  read independent of the render/effect wiring. */
-function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput): EChartsOption {
+function buildGaugeOption({
+  value,
+  max,
+  label,
+  formatValue,
+  palette,
+}: GaugeOptionInput): EChartsOption {
   return {
     series: [
       {
@@ -61,7 +88,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         axisLine: {
           lineStyle: {
             width: 10,
-            color: [[1, HAIRLINE]],
+            color: [[1, palette.hairline]],
           },
         },
         axisTick: { show: false },
@@ -71,7 +98,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         detail: {
           valueAnimation: true,
           formatter: (detailValue: number) => formatValue(detailValue),
-          color: FG_1,
+          color: palette.fg1,
           fontFamily: MONO,
           fontSize: 24,
           fontWeight: 600,
@@ -80,7 +107,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         title: {
           show: Boolean(label),
           offsetCenter: [0, '35%'],
-          color: FG_3,
+          color: palette.fg3,
           fontFamily: DISPLAY,
           fontSize: 12,
         },
@@ -111,10 +138,14 @@ export function Gauge({
   formatValue = defaultFormatValue,
   height = DEFAULT_HEIGHT_PX,
 }: GaugeProps) {
+  const chartTheme = useChartTheme()
+  const palette = chartTheme === F1_LIGHT_THEME ? LIGHT_GAUGE_PALETTE : DARK_GAUGE_PALETTE
   const option = useMemo(
-    () => buildGaugeOption({ value, max, label, formatValue }),
-    [value, max, label, formatValue],
+    () => buildGaugeOption({ value, max, label, formatValue, palette }),
+    [value, max, label, formatValue, palette],
   )
 
-  return <ReactECharts theme={F1_THEME} option={option} style={{ height }} notMerge />
+  return (
+    <ReactECharts theme={chartTheme} key={chartTheme} option={option} style={{ height }} notMerge />
+  )
 }

--- a/webapp/src/charts/echartsTheme.ts
+++ b/webapp/src/charts/echartsTheme.ts
@@ -1,49 +1,106 @@
 // ECharts theme built from the F1 StratLab brand tokens. Registered once when
-// the first chart mounts (issue #34): `echarts.registerTheme(F1_THEME, echartsTheme)`.
-// Kept as a plain object so #32 does not pull the heavy echarts dep into the
+// the first chart mounts (issue #34): `echarts.registerTheme(F1_THEME, ...)`.
+// Kept as plain objects so #32 does not pull the heavy echarts dep into the
 // bundle; #34 imports echarts and this together.
 //
 // Design: transparent background (charts sit on solid --bg cards), hairline
 // grid, blue data ramp + purple accent, JetBrains Mono axis labels, tabular
-// figures. Colors are the resolved token hex (a build-time JS module cannot read
-// CSS vars); keep them in sync with styles/tokens.css.
+// figures. Colors are the resolved token hex (a build-time JS module cannot
+// read CSS vars); keep them in sync with styles/tokens.css.
+//
+// Light theme (app-chrome-round2.md item 1(e)): a build-time module can't
+// react to the `data-theme` attribute the way CSS vars do, so instead of one
+// static theme object we build the theme per mode from two hardcoded
+// palettes (dark/light) that mirror tokens.css's `--fg-2/3`, `--divider`,
+// `--hairline` swap. The categorical series palette and tyre colors are
+// identity colors — unchanged across modes.
 
 export const F1_THEME = 'f1'
+export const F1_LIGHT_THEME = 'f1-light'
 
-const FG_2 = 'rgba(255,255,255,0.72)'
-const FG_3 = 'rgba(255,255,255,0.52)'
-const LINE = 'rgba(255,255,255,0.18)'
-const HAIRLINE = 'rgba(255,255,255,0.06)'
 const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 const DISPLAY = "'Space Grotesk Variable', system-ui, sans-serif"
 
-const axis = {
-  axisLine: { lineStyle: { color: LINE } },
-  axisTick: { lineStyle: { color: LINE } },
-  axisLabel: { color: FG_3, fontFamily: MONO },
-  splitLine: { lineStyle: { color: HAIRLINE } },
+// Categorical palette: blue (data) first, then purple accent, then
+// compound-ish greens/ambers. Identity colors — same in both themes.
+const SERIES_COLORS = ['#3385ff', '#6c5ce7', '#2dd47a', '#ffbd33', '#ff5733', '#60a5fa', '#a29bfe']
+
+interface ThemePalette {
+  /** Body/legend text (mirrors tokens.css `--fg-2`). */
+  fg2: string
+  /** Axis label text (mirrors `--fg-3`). */
+  fg3: string
+  /** Axis line/tick color (mirrors `--divider`). */
+  line: string
+  /** Split-line / grid border color (mirrors `--hairline`). */
+  hairline: string
+  titleColor: string
+  tooltipBg: string
+  tooltipBorder: string
+  tooltipText: string
 }
 
-export const echartsTheme = {
-  // Categorical palette: blue (data) first, then purple accent, then compound-ish greens/ambers.
-  color: ['#3385ff', '#6c5ce7', '#2dd47a', '#ffbd33', '#ff5733', '#60a5fa', '#a29bfe'],
-  backgroundColor: 'transparent',
-  textStyle: { fontFamily: MONO, color: FG_2 },
-  title: { textStyle: { color: '#ffffff', fontFamily: DISPLAY, fontWeight: 600 } },
-  legend: { textStyle: { color: FG_2, fontFamily: MONO } },
-  grid: { borderColor: HAIRLINE, containLabel: true },
-  categoryAxis: axis,
-  valueAxis: axis,
-  timeAxis: axis,
-  logAxis: axis,
-  tooltip: {
-    backgroundColor: '#17192b',
-    borderColor: 'rgba(255,255,255,0.10)',
-    textStyle: { color: '#ffffff', fontFamily: MONO },
-  },
+const DARK_PALETTE: ThemePalette = {
+  fg2: 'rgba(255,255,255,0.72)',
+  fg3: 'rgba(255,255,255,0.52)',
+  line: 'rgba(255,255,255,0.18)',
+  hairline: 'rgba(255,255,255,0.06)',
+  titleColor: '#ffffff',
+  tooltipBg: '#17192b',
+  tooltipBorder: 'rgba(255,255,255,0.10)',
+  tooltipText: '#ffffff',
+}
+
+const LIGHT_PALETTE: ThemePalette = {
+  fg2: 'rgba(20,18,31,0.75)',
+  fg3: 'rgba(20,18,31,0.58)',
+  line: 'rgba(20,18,31,0.18)',
+  hairline: 'rgba(20,18,31,0.06)',
+  titleColor: '#14121f',
+  tooltipBg: '#ffffff',
+  tooltipBorder: 'rgba(20,18,31,0.10)',
+  tooltipText: '#14121f',
+}
+
+/** Shared axis look (category/value/time/log all render the same way here)
+ *  for one palette — hairline line/tick, faint split line, mono labels. */
+function buildAxisStyle(palette: ThemePalette) {
+  return {
+    axisLine: { lineStyle: { color: palette.line } },
+    axisTick: { lineStyle: { color: palette.line } },
+    axisLabel: { color: palette.fg3, fontFamily: MONO },
+    splitLine: { lineStyle: { color: palette.hairline } },
+  }
+}
+
+/** Builds the full ECharts theme object for one app theme mode. A build-time
+ *  JS module can't read the `data-theme` CSS variable swap, so this is
+ *  called once per mode up front and both results are registered
+ *  (`registerEcharts.ts`) — the chart picks one by name via `useChartTheme()`. */
+export function buildEchartsTheme(mode: 'dark' | 'light') {
+  const palette = mode === 'light' ? LIGHT_PALETTE : DARK_PALETTE
+  const axis = buildAxisStyle(palette)
+  return {
+    color: SERIES_COLORS,
+    backgroundColor: 'transparent',
+    textStyle: { fontFamily: MONO, color: palette.fg2 },
+    title: { textStyle: { color: palette.titleColor, fontFamily: DISPLAY, fontWeight: 600 } },
+    legend: { textStyle: { color: palette.fg2, fontFamily: MONO } },
+    grid: { borderColor: palette.hairline, containLabel: true },
+    categoryAxis: axis,
+    valueAxis: axis,
+    timeAxis: axis,
+    logAxis: axis,
+    tooltip: {
+      backgroundColor: palette.tooltipBg,
+      borderColor: palette.tooltipBorder,
+      textStyle: { color: palette.tooltipText, fontFamily: MONO },
+    },
+  }
 }
 
 // F1 tyre-compound colors for series that encode compound (from tokens).
+// Identity colors — unchanged across themes.
 export const tireColors: Record<string, string> = {
   SOFT: '#ff2d3a',
   MEDIUM: '#ffcf2d',

--- a/webapp/src/charts/registerEcharts.ts
+++ b/webapp/src/charts/registerEcharts.ts
@@ -1,12 +1,24 @@
 import * as echarts from 'echarts'
-import { echartsTheme, F1_THEME } from './echartsTheme'
+import { useUiStore } from '@/stores/ui'
+import { buildEchartsTheme, F1_LIGHT_THEME, F1_THEME } from './echartsTheme'
 
 let registered = false
 
-/** Register the F1 ECharts theme once (idempotent). Call before mounting the
- *  first chart so every chart inherits the token theme. */
+/** Register both F1 ECharts themes once (idempotent) — dark (`F1_THEME`) and
+ *  light (`F1_LIGHT_THEME`). Call before mounting the first chart so every
+ *  chart can pick either theme by name (see `useChartTheme`). */
 export function registerF1Theme(): void {
   if (registered) return
-  echarts.registerTheme(F1_THEME, echartsTheme)
+  echarts.registerTheme(F1_THEME, buildEchartsTheme('dark'))
+  echarts.registerTheme(F1_LIGHT_THEME, buildEchartsTheme('light'))
   registered = true
+}
+
+/** The registered ECharts theme name matching the app's current light/dark
+ *  theme (`stores/ui.ts`), so every chart follows the header toggle. Callers
+ *  key their `<ReactECharts>` on this value to force a remount on toggle —
+ *  ECharts doesn't hot-swap a theme on an already-mounted instance. */
+export function useChartTheme(): string {
+  const theme = useUiStore((state) => state.theme)
+  return theme === 'light' ? F1_LIGHT_THEME : F1_THEME
 }

--- a/webapp/src/components/ThemeToggle.tsx
+++ b/webapp/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { Moon, Sun } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { useUiStore } from '@/stores/ui'
+
+// Icon-only theme toggle, mounted in `app/Header.tsx`'s right cluster so
+// every routed page gets it for free. This component only flips the
+// two-state `theme` in `stores/ui.ts` — the `<html data-theme>` DOM stamping
+// and the FOUC guard already live in `providers.tsx` / `index.html`
+// (app-chrome-round2.md §2b-c), so ThemeToggle never touches the DOM
+// directly, it just reads/writes the store.
+
+/**
+ * Sun/Moon icon-only button. The icon always depicts the theme you're about
+ * to switch TO, not the one you're currently in — Sun while dark ("go
+ * light"), Moon while light ("go dark") — so the control reads as an action
+ * rather than a status indicator.
+ */
+export function ThemeToggle() {
+  const theme = useUiStore((state) => state.theme)
+  const toggleTheme = useUiStore((state) => state.toggleTheme)
+  const Icon = theme === 'dark' ? Sun : Moon
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+      onClick={toggleTheme}
+      className="size-8 px-0"
+    >
+      <Icon
+        aria-hidden="true"
+        className="size-4 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none"
+      />
+    </Button>
+  )
+}

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -19,8 +19,8 @@ import type {
   TooltipComponentFormatterCallbackParams,
 } from 'echarts'
 import * as echarts from 'echarts'
-import { registerF1Theme } from '@/charts/registerEcharts'
-import { F1_THEME } from '@/charts/echartsTheme'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
 import type { LapTelemetry } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
@@ -48,6 +48,12 @@ const NO_LEGEND_GRID_TOP = 16
 // and, since dataZoom lives in `baseOption` below, a zoom/pan on one
 // propagates group-wide too.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
+
+// Delta's y=0 reference markLine (see buildDeltaOption) is a per-series
+// style, not governed by the registered ECharts theme — it needs its own
+// light/dark swap, mirroring echartsTheme.ts's fg/hairline palettes.
+const MARK_LINE_COLOR_DARK = 'rgba(255,255,255,0.35)'
+const MARK_LINE_COLOR_LIGHT = 'rgba(20,18,31,0.35)'
 
 interface LegendEntry {
   name: string
@@ -249,10 +255,12 @@ function SyncedLineChart({
   ariaLabel: string
   height?: number
 }) {
+  const chartTheme = useChartTheme()
   return (
     <div role="img" aria-label={ariaLabel}>
       <ReactECharts
-        theme={F1_THEME}
+        theme={chartTheme}
+        key={chartTheme}
         option={option}
         style={{ height }}
         notMerge
@@ -358,6 +366,7 @@ function buildDeltaOption(
   byDriver: Record<string, LapTelemetry>,
   drivers: string[],
   year: number | undefined,
+  markLineColor: string,
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const reference = findReferenceDriver(byDriver, loaded)
@@ -379,13 +388,15 @@ function buildDeltaOption(
   // Dashed y=0 reference guide — the reference driver's own delta line hugs
   // it. ECharts attaches markLine per-series (no chart-level equivalent), so
   // it rides on the first series (mutating in place; `firstSeries` is the
-  // same object as `series[0]`).
+  // same object as `series[0]`). markLine styles aren't governed by the
+  // registered theme either (same reasoning as Gauge.tsx), so its color is
+  // threaded in per active theme mode.
   const firstSeries = series[0]
   if (firstSeries) {
     firstSeries.markLine = {
       symbol: 'none',
       silent: true,
-      lineStyle: { type: 'dashed', color: 'rgba(255,255,255,0.35)' },
+      lineStyle: { type: 'dashed', color: markLineColor },
       data: [{ yAxis: 0 }],
     }
   }
@@ -419,7 +430,12 @@ export const DeltaChart = memo(function DeltaChart({
   isLoading,
 }: DeltaChartProps) {
   const loaded = drivers.filter((driver) => byDriver[driver])
-  const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
+  const chartTheme = useChartTheme()
+  const markLineColor = chartTheme === F1_LIGHT_THEME ? MARK_LINE_COLOR_LIGHT : MARK_LINE_COLOR_DARK
+  const option = useMemo(
+    () => buildDeltaOption(byDriver, drivers, year, markLineColor),
+    [byDriver, drivers, year, markLineColor],
+  )
 
   if (loaded.length < MIN_DELTA_DRIVERS) {
     if (drivers.length >= MIN_DELTA_DRIVERS && isLoading) {

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -76,7 +76,12 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
         return (
           <div key={compound} className="flex items-center gap-1.5">
             {variant ? (
-              <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+              // Permanent hairline border (B3): HARD is a near-white chip
+              // that vanishes on a white card in the light theme; the border
+              // is near-invisible in dark and load-bearing in light.
+              <Pill compound={variant} className="border border-hairline">
+                {compoundLabel(compound)}
+              </Pill>
             ) : (
               <Pill tone="neutral">{compoundLabel(compound)}</Pill>
             )}

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -16,8 +16,8 @@
 import { useCallback, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ECharts, EChartsOption } from 'echarts'
-import { registerF1Theme } from '@/charts/registerEcharts'
-import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import { compoundLabel, compoundVariant } from '../lib/compounds'
@@ -28,12 +28,15 @@ import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
 // in componentDidMount, which can fire before an effect-time registration).
 registerF1Theme()
 
-// Reuse the shared theme's axis-label color/font for axis NAMES ("Lap
-// Number", "Lap Time") so they read consistently with the tick labels
-// without duplicating the theme's magic color values here.
-const AXIS_NAME_STYLE = {
-  color: echartsTheme.valueAxis.axisLabel.color,
-  fontFamily: echartsTheme.valueAxis.axisLabel.fontFamily,
+/** Axis NAME style ("Lap Number", "Lap Time"), reusing the mode-aware theme's
+ *  axis-label color/font so the names read consistently with the tick labels
+ *  in both light and dark, without duplicating the theme's color values here. */
+function buildAxisNameStyle(mode: 'dark' | 'light') {
+  const theme = buildEchartsTheme(mode)
+  return {
+    color: theme.valueAxis.axisLabel.color,
+    fontFamily: theme.valueAxis.axisLabel.fontFamily,
+  }
 }
 
 /** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
@@ -184,6 +187,7 @@ function formatLapTooltip(year: number | undefined) {
 function buildLapChartOption(
   seriesList: DriverSeriesOption[],
   year: number | undefined,
+  axisNameStyle: { color: string; fontFamily: string },
 ): EChartsOption {
   return {
     tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
@@ -200,7 +204,7 @@ function buildLapChartOption(
       name: 'Lap Number',
       nameLocation: 'middle',
       nameGap: 26,
-      nameTextStyle: AXIS_NAME_STYLE,
+      nameTextStyle: axisNameStyle,
       scale: true,
     },
     yAxis: {
@@ -208,7 +212,7 @@ function buildLapChartOption(
       name: 'Lap Time',
       nameLocation: 'middle',
       nameGap: 48,
-      nameTextStyle: AXIS_NAME_STYLE,
+      nameTextStyle: axisNameStyle,
       axisLabel: { formatter: formatLapTimeAxis },
       // Autorange around the lap times (~78-95 s) instead of forcing a 0:00
       // baseline, which would squash every line into the top of the plot.
@@ -367,6 +371,7 @@ export interface LapChartProps {
 /** Lap-time chart: one coloured-by-driver line per selected driver, with
  *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
 export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
+  const chartTheme = useChartTheme()
   const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
@@ -379,11 +384,12 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
           selectedLaps[driver],
         ),
       )
+    const mode = chartTheme === F1_LIGHT_THEME ? 'light' : 'dark'
     return {
-      option: buildLapChartOption(seriesList, year),
+      option: buildLapChartOption(seriesList, year, buildAxisNameStyle(mode)),
       pickerSeries: seriesList.map((series) => ({ driver: series.name, points: series.data })),
     }
-  }, [laps, drivers, year, selectedLaps])
+  }, [laps, drivers, year, selectedLaps, chartTheme])
 
   // Latest-ref mirror: the zrender click handler is registered once (see
   // `handleChartReady` below) and reads through this ref on every click, so
@@ -398,7 +404,8 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
   return (
     <div role="img" aria-label="Lap times by lap, per driver">
       <ReactECharts
-        theme={F1_THEME}
+        theme={chartTheme}
+        key={chartTheme}
         option={option}
         style={{ height: 400 }}
         notMerge

--- a/webapp/src/stores/ui.ts
+++ b/webapp/src/stores/ui.ts
@@ -5,10 +5,18 @@ import { persist } from 'zustand/middleware'
 // namespace per the state-model plan (A5-1). Server data lives in TanStack Query
 // and selector state in the URL; this store is only for what the user *did* to
 // the UI. Feature slices (chat, voice, replay) arrive with their features.
+// Two-state theme (no 'system'): both sibling brand surfaces (landing, docs) are
+// dark-only, so dark is the identity default and a binary toggle keeps the CSS
+// single-sourced on the `data-theme` attribute. If 'system' is ever wanted it
+// resolves here, not in the CSS.
+export type Theme = 'dark' | 'light'
+
 interface UiState {
   railCollapsed: boolean
   toggleRail: () => void
   setRailCollapsed: (collapsed: boolean) => void
+  theme: Theme
+  toggleTheme: () => void
 }
 
 export const useUiStore = create<UiState>()(
@@ -17,6 +25,8 @@ export const useUiStore = create<UiState>()(
       railCollapsed: false,
       toggleRail: () => set((state) => ({ railCollapsed: !state.railCollapsed })),
       setRailCollapsed: (collapsed) => set({ railCollapsed: collapsed }),
+      theme: 'dark',
+      toggleTheme: () => set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
     }),
     { name: 'f1sl.ui' },
   ),

--- a/webapp/src/styles/tokens.css
+++ b/webapp/src/styles/tokens.css
@@ -107,3 +107,56 @@
   --tracking-wide: 0.04em;
   --tracking-widest: 0.18em;
 }
+
+/* =========================================================
+   LIGHT THEME (E1) — a token swap, stamped via data-theme='light' on
+   <html> (see app/providers.tsx + the FOUC guard in index.html). Only the
+   *semantic* ramp flips: the background/foreground ladders, dividers, shadows
+   and the hero gradient. Identity colours (purple, blue, tyre compounds) and
+   chrome gradients stay put — they read on both themes. This block is more
+   specific than `html { color-scheme: dark }`, so `color-scheme: light` wins
+   here declaratively (no @media, single source of truth = the attribute).
+
+   Not solved by a var swap: HARD's white chip (--tire-hard) would vanish on a
+   light card — instead every compound pill carries a permanent border-hairline
+   (invisible-ish in dark, load-bearing in light). Status colours are darkened
+   to pass contrast on white. */
+:root[data-theme='light'] {
+  color-scheme: light;
+
+  --bg-0: #f5f5fa; /* page */
+  --bg-1: #eef0f7; /* deep surface (hero) */
+  --bg-2: #e9eaf4; /* sidebar / chrome */
+  --bg-3: #ffffff; /* card resting */
+  --bg-4: #f7f7fc; /* card hovered / elevated */
+  --bg-5: #eceaf9; /* input bg */
+
+  --fg-1: #14121f; /* near-black, purple tint (mirror of dark --bg-1) */
+  --fg-2: rgba(20, 18, 31, 0.75);
+  --fg-3: rgba(20, 18, 31, 0.58);
+  --fg-4: rgba(20, 18, 31, 0.42);
+  --fg-inv: #ffffff;
+
+  --accent-hover: var(--purple-700); /* purple-300 fails as text on white */
+
+  --success: #15803d;
+  --warning: #b45309;
+  --danger: #dc2626;
+  --info: #1d4ed8;
+
+  --divider: rgba(20, 18, 31, 0.1);
+  --divider-strong: rgba(20, 18, 31, 0.18);
+  --hairline: rgba(20, 18, 31, 0.06);
+
+  --grad-hero: radial-gradient(
+    ellipse 120% 80% at 50% 0%,
+    rgba(108, 92, 231, 0.14) 0%,
+    rgba(108, 92, 231, 0.05) 35%,
+    transparent 70%
+  );
+
+  --shadow-card: 0 2px 10px rgba(20, 18, 31, 0.08);
+  --shadow-elev: 0 12px 40px rgba(20, 18, 31, 0.14);
+  --shadow-glow: 0 0 0 1px rgba(108, 92, 231, 0.3), 0 12px 40px rgba(108, 92, 231, 0.15);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}


### PR DESCRIPTION
App-chrome round-2 (design-first audit in `docs/migration/design-specs/app-chrome-round2.md`, item 1). The app becomes the first branded surface with a light/dark toggle.

## What
- **Light token block.** `:root[data-theme='light']` flips only the *semantic* ramp (bg/fg ladders, dividers, shadows, hero gradient). Identity colours (purple, blue, tyre compounds) and chrome gradients stay — they read on both themes. `color-scheme: light` wins declaratively over the base `html { color-scheme: dark }` (more specific), so no `@media` two-writers problem: the `data-theme` attribute is the single source of truth.
- **Theme state + stamping.** Two-state `theme` (`dark`|`light`, default dark) added to the persisted `f1sl.ui` store; `providers.tsx` mirrors it onto `<html data-theme>`, and a 6-line inline script in `index.html` stamps it before React mounts (FOUC guard — no dark flash for a light user).
- **Toggle.** A Sun/Moon `ThemeToggle` in the header, present on every routed page.
- **Charts follow the theme.** `echartsTheme.ts` becomes `buildEchartsTheme(mode)` + an `f1-light` registration + a `useChartTheme()` hook; the lap/telemetry/gauge charts remount on toggle. Per-series colours that ECharts does NOT inherit from the registered theme (gauge centre readout, delta zero-line markLine, lap-chart axis titles) were parametrised by mode too, so nothing renders dark-on-white.
- **Compound pills** get a permanent `border-hairline` so the white HARD chip survives on a light card.

## Checks
- tsc -b, oxlint, vitest (43/43), vite build — all green.
- Screenshot-verified on 2023 Monaco R (VER, LEC) in BOTH themes: light reads cleanly (dark axis text on light charts, bordered HARD pill, toggle visible), dark is unchanged.

## Known follow-up (not blocking)
- The selected-lap ring is a hardcoded white border; contrast is fine on team-coloured points but could be weaker against a pale livery on light — punch-list item, not shipped here.
- The temporary theme-preview `App.tsx` home renders no Header, so it doesn't show the toggle (inherits it when the real Home lands).