### PR TITLE
fix(webapp): dashboard polish — chart re-animation, maximize trap, circuit map

### DIFF
--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -51,19 +51,24 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
-          onClick={() => setIsCollapsed((value) => !value)}
-          className="size-8 px-0 text-fg-3"
-        >
-          {isCollapsed ? (
-            <Plus className="size-4" aria-hidden="true" />
-          ) : (
-            <Minus className="size-4" aria-hidden="true" />
-          )}
-        </Button>
+        {/* Collapse is a grid-only affordance. In the maximized overlay it just
+            hides the body, stranding the user on an empty full-screen card with
+            no way back (Restore is the way out) — so it's not offered there. */}
+        {!isMaximized && (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
+            onClick={() => setIsCollapsed((value) => !value)}
+            className="size-8 px-0 text-fg-3"
+          >
+            {isCollapsed ? (
+              <Plus className="size-4" aria-hidden="true" />
+            ) : (
+              <Minus className="size-4" aria-hidden="true" />
+            )}
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -81,11 +86,15 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     </div>
   )
 
-  const body = isCollapsed ? null : <div className="flex-1 overflow-auto p-4">{children}</div>
+  // Maximizing always shows the content — a collapsed-in-grid chart still opens
+  // full-screen with its body (and Restore is the only exit), so there's no way
+  // to land on an empty maximized card.
+  const showBody = isMaximized || !isCollapsed
+  const body = showBody ? <div className="flex-1 overflow-auto p-4">{children}</div> : null
   const footerStrip =
-    isCollapsed || !footer ? null : (
+    showBody && footer ? (
       <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
-    )
+    ) : null
 
   if (isMaximized) {
     return createPortal(

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -116,6 +116,11 @@ function baseOption(
     ...(yAxis as object),
   }
   return {
+    // No entrance/update animation on the telemetry traces. A timing-screen
+    // reads as an instrument, not a motion piece — and, practically, replaying
+    // the sweep on every driver toggle / data-settle (and twice under React
+    // StrictMode's dev double-mount) reads as a stutter, not polish.
+    animation: false,
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'line' },

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -24,8 +24,9 @@ export interface CircuitDominationSectionProps {
  *  no "dominance" to compare). */
 const MIN_DRIVERS_FOR_MAP = 2
 
-/** Matches the Streamlit figure's `height=360` (60% of its original 600px). */
-const MAP_HEIGHT_PX = 360
+/** Track height. Bumped past the Streamlit figure's 360 so the circuit reads
+ *  as the focal shape of the zone, with room for the coloured microsectors. */
+const MAP_HEIGHT_PX = 460
 
 /** Screen-pixel stroke width. Paired with `vector-effect="non-scaling-stroke"`
  *  on each segment so the line reads the same thickness regardless of how
@@ -109,17 +110,36 @@ interface CircuitMapProps {
   year: DashboardSearch['year']
 }
 
-/** The track SVG plus its driver legend, centered in a narrower column so it
- *  reads as a focal shape rather than stretching full-bleed (Streamlit
- *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
+/** Share of microsectors each driver was fastest through (0-100, rounded).
+ *  Derived from the same per-microsector colour array the segments are drawn
+ *  in, so the legend's "% dominated" always matches what's on the track. */
+function dominationShares(
+  colors: string[],
+  drivers: { driver: string; color: string }[],
+): Record<string, number> {
+  const total = colors.length
+  const shares: Record<string, number> = {}
+  if (total === 0) return shares
+  for (const { driver, color } of drivers) {
+    const count = colors.filter((segmentColor) => segmentColor === color).length
+    shares[driver] = Math.round((count / total) * 100)
+  }
+  return shares
+}
+
+/** The track SVG plus its driver legend. Fills its column so it reads as the
+ *  focal shape of the zone; each coloured microsector carries a `<title>` so
+ *  hovering the track reveals which driver was fastest through it. */
 function CircuitMap({ data, year }: CircuitMapProps) {
   const bounds = computeBounds(data.x, data.y)
   const viewBox = computeViewBox(bounds)
   const outlinePoints = buildOutlinePath(data.x, data.y)
   const segments = buildSegments(data.x, data.y, data.colors)
+  const colorToDriver = new Map(data.drivers.map((entry) => [entry.color, entry.driver]))
+  const shares = dominationShares(data.colors, data.drivers)
 
   return (
-    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-3xl flex-col gap-4 p-4')}>
+    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-4xl flex-col gap-4 p-4')}>
       <div
         role="img"
         aria-label="Circuit domination map: colored by fastest driver per microsector"
@@ -146,26 +166,32 @@ function CircuitMap({ data, year }: CircuitMapProps) {
               strokeWidth={SEGMENT_STROKE_PX}
               strokeLinecap="round"
               vectorEffect="non-scaling-stroke"
-            />
+              className="transition-opacity hover:opacity-60"
+            >
+              <title>{colorToDriver.get(segment.color) ?? 'Fastest'} fastest through here</title>
+            </line>
           ))}
         </svg>
       </div>
-      <CircuitLegend drivers={data.drivers} year={year} />
+      <CircuitLegend drivers={data.drivers} shares={shares} year={year} />
     </Card>
   )
 }
 
 interface CircuitLegendProps {
   drivers: { driver: string; color: string }[]
+  /** driver code -> % of microsectors that driver was fastest through. */
+  shares: Record<string, number>
   year: DashboardSearch['year']
 }
 
-/** Colour-dot legend, one swatch per driver — the SVG equivalent of the
- *  Streamlit figure's Plotly legend (invisible line traces named per driver).
- *  The dot keeps the data-driven `entry.color` (which may already carry
- *  contrast handling from the backend); the driver NAME is team-coloured via
- *  `getDriverTextColor` so it stays legible against the dark UI. */
-function CircuitLegend({ drivers, year }: CircuitLegendProps) {
+/** Colour-dot legend, one swatch per driver, with the driver's share of the
+ *  track (% of microsectors they were fastest through) in mono next to the
+ *  name — the SVG equivalent of the Streamlit figure's Plotly legend, plus the
+ *  at-a-glance "who dominated more" the coloured map only implies. The dot
+ *  keeps the data-driven `entry.color`; the NAME is team-coloured via
+ *  `getDriverTextColor` so it stays legible against the UI. */
+function CircuitLegend({ drivers, shares, year }: CircuitLegendProps) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
       {drivers.map((entry) => (
@@ -181,6 +207,11 @@ function CircuitLegend({ drivers, year }: CircuitLegendProps) {
           >
             {entry.driver}
           </span>
+          {shares[entry.driver] != null && (
+            <span className="font-mono text-xs tabular-nums text-fg-3">
+              {shares[entry.driver]}%
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -190,6 +190,11 @@ function buildLapChartOption(
   axisNameStyle: { color: string; fontFamily: string },
 ): EChartsOption {
   return {
+    // Match the telemetry charts: no entrance/update animation. The lap chart
+    // rebuilds on every driver toggle and selected-lap change, so replaying the
+    // line-draw each time (and twice under StrictMode's dev double-mount) reads
+    // as a stutter rather than polish.
+    animation: false,
     tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
     legend: {
       data: buildLegendData(seriesList, year),

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -23,10 +23,12 @@ const YEAR_OPTIONS: ComboboxOption[] = [2025, 2024, 2023].map((year) => ({
   label: String(year),
 }))
 
-const EYEBROW_CLASSNAME = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+const EYEBROW_CLASSNAME = 'text-center text-xs font-medium uppercase tracking-widest text-fg-3'
 
-/** A labelled selector cell: the small uppercase eyebrow above its control,
- *  matching `StatCard`'s eyebrow styling so the toolbar reads as one system. */
+/** A labelled selector cell: the small uppercase eyebrow centered over its
+ *  control, matching `StatCard`'s eyebrow styling so the toolbar reads as one
+ *  system. Centered (not left) so each label sits over the middle of its wide
+ *  field instead of orphaned in the top-left corner of it. */
 function SelectorField({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1.5">


### PR DESCRIPTION
Polish pass from Víctor's review of the round-2 dashboard, ahead of promoting dev → main.

## Fixes
- **Chart double-animation.** The lap + telemetry charts replayed their entrance animation on every driver toggle, and **twice** on first paint under React StrictMode's dev double-mount. Disabled ECharts animation on these data charts — a timing screen reads as an instrument, and it's snappier. (Prod never had the double, only dev; this also removes the re-animation-on-toggle in both.)
- **Maximize → empty-card trap.** Maximizing a chart then hitting the collapse (−) button hid the body inside the full-screen overlay with no way back, and Esc left the grid chart stuck empty. The collapse button is no longer offered while maximized, and a maximized card always renders its body (Restore is the only exit). Verified with a Playwright click test (maximized shows canvas, no collapse button, restore keeps the chart).

## Enhancements
- **Circuit Domination**: taller/wider so it's the focal shape of the zone, a hover `<title>` on each microsector (which driver was fastest there), and a per-driver **domination %** in the legend (e.g. LEC 62% · VER 38%), derived from the same colour array the map is drawn from.
- **Selector labels** (Year/GP/Session/Drivers) centered over their fields.

## Checks
- tsc -b, oxlint, vitest (43/43), vite build — all green.
- Screenshot-verified on 2023 Monaco R (VER, LEC); maximize/collapse verified functionally.