### PR TITLE
feat(webapp): dashboard round-3 polish — footer, maximize, sidebar, theme anim

### DIFF
--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react'
 import {
   type LucideIcon,
   ArrowRightLeft,
@@ -14,9 +14,17 @@ import {
 import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
-import { useUiStore } from '@/stores/ui'
+import { RAIL_WIDTH_MAX, RAIL_WIDTH_MIN, useUiStore } from '@/stores/ui'
 import { Button } from '@/components/Button'
 import { Tooltip } from '@/components/Tooltip'
+
+// Fixed collapsed width (icon-only rail, never resizable) — the counterpart
+// to `railWidth` in stores/ui.ts, which only governs the expanded state.
+const RAIL_WIDTH_COLLAPSED = 76
+
+// Keyboard step for the resize handle (role="separator"), so the control is
+// operable without a pointer per the WAI-ARIA window-splitter pattern.
+const RAIL_RESIZE_STEP = 16
 
 // Shared Link styling (#33, redesigned round 2 per docs/migration/design-specs/
 // app-chrome-round2.md §3 — the docs-sidebar grammar instead of a generic flat
@@ -124,23 +132,75 @@ function NavSection({
 /**
  * Acrylic left icon rail, redesigned to carry F1 StratLab's brand vocabulary
  * (docs-sidebar grouping + a brand block) instead of a generic flat list:
- * 76px collapsed / 232px expanded, driven by the shared `useUiStore` so the
- * collapsed state survives navigation and reloads (persisted under
- * `f1sl.ui`). Width itself is never transitioned — baseline-ui restricts
- * animation to transform/opacity (cheap, compositor-only); a width change is
- * a layout property, so it snaps instantly instead.
+ * 76px collapsed / a user-resizable 200-360px expanded (default 232px),
+ * driven by the shared `useUiStore` so both the collapsed state and the
+ * chosen width survive navigation and reloads (persisted under `f1sl.ui`).
+ *
+ * Width now transitions on collapse/expand (`transition-[width]`, ~200ms,
+ * `motion-reduce`-guarded) — a deliberate, narrow exception to baseline-ui's
+ * transform/opacity-only rule: once the rail became resizable, a hard snap
+ * on toggle read as broken next to a draggable edge. The main content pane
+ * (Shell.tsx) never needs to mirror this explicitly — it's a `flex-1`
+ * sibling of this `<nav>`, so the browser recomputes its box on every frame
+ * of the rail's width transition for free; there's no second width value to
+ * keep in lockstep.
+ *
+ * The transition is suppressed (`transition-none`) while the resize handle
+ * is being dragged, so the edge tracks the pointer 1:1 instead of lagging
+ * behind an easing curve.
  */
 export function Rail() {
   const railCollapsed = useUiStore((state) => state.railCollapsed)
   const toggleRail = useUiStore((state) => state.toggleRail)
+  const railWidth = useUiStore((state) => state.railWidth)
+  const setRailWidth = useUiStore((state) => state.setRailWidth)
+
+  // Drag-to-resize. `dragStartRef` holds the pointer x + rail width at the
+  // moment the drag began, so `handleResizeMove` can compute an absolute
+  // target width from the total pointer delta rather than accumulating
+  // per-event deltas (which would drift under fast pointer moves).
+  const [isResizing, setIsResizing] = useState(false)
+  const dragStartRef = useRef({ x: 0, width: railWidth })
+
+  function handleResizeStart(event: PointerEvent<HTMLDivElement>) {
+    if (railCollapsed) return
+    event.currentTarget.setPointerCapture(event.pointerId)
+    dragStartRef.current = { x: event.clientX, width: railWidth }
+    setIsResizing(true)
+  }
+
+  function handleResizeMove(event: PointerEvent<HTMLDivElement>) {
+    if (!isResizing) return
+    const delta = event.clientX - dragStartRef.current.x
+    setRailWidth(dragStartRef.current.width + delta)
+  }
+
+  function handleResizeEnd(event: PointerEvent<HTMLDivElement>) {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    setIsResizing(false)
+  }
+
+  function handleResizeKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setRailWidth(railWidth - RAIL_RESIZE_STEP)
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setRailWidth(railWidth + RAIL_RESIZE_STEP)
+    }
+  }
 
   return (
     <nav
       aria-label="Primary"
-      style={{ zIndex: Z.rail }}
+      style={{ zIndex: Z.rail, width: railCollapsed ? RAIL_WIDTH_COLLAPSED : railWidth }}
       className={cn(
         'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/70 backdrop-blur-md',
-        railCollapsed ? 'w-19' : 'w-58',
+        isResizing
+          ? 'transition-none'
+          : 'transition-[width] duration-200 ease-out motion-reduce:transition-none',
       )}
     >
       {/* Brand block. Aligns with Header's h-14 so rail + header form one
@@ -335,6 +395,34 @@ export function Rail() {
           </Button>
         </Tooltip>
       </div>
+
+      {/* Drag-to-resize handle. Absolutely positioned against the `sticky`
+          nav (a positioned element, so it's a valid containing block) and
+          rendered as the nav's last child, which — with no explicit z-index
+          on either side — is enough for it to paint above the normal-flow
+          content above it. Not rendered at all while collapsed: a collapsed
+          icon-only rail has no width worth dragging. */}
+      {!railCollapsed && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize navigation"
+          aria-valuenow={Math.round(railWidth)}
+          aria-valuemin={RAIL_WIDTH_MIN}
+          aria-valuemax={RAIL_WIDTH_MAX}
+          tabIndex={0}
+          onPointerDown={handleResizeStart}
+          onPointerMove={handleResizeMove}
+          onPointerUp={handleResizeEnd}
+          onPointerCancel={handleResizeEnd}
+          onKeyDown={handleResizeKeyDown}
+          className={cn(
+            'absolute inset-y-0 right-0 w-1.5 cursor-col-resize touch-none rounded-r-sm select-none',
+            'transition-colors hover:bg-purple-400/30 focus-visible:bg-purple-400/40 focus-visible:outline-none',
+            isResizing && 'bg-purple-400/40',
+          )}
+        />
+      )}
     </nav>
   )
 }

--- a/webapp/src/components/ChartCard.test.tsx
+++ b/webapp/src/components/ChartCard.test.tsx
@@ -33,7 +33,7 @@ describe('ChartCard', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('hides the body when the collapse button is clicked', () => {
+  it('keeps the body visible (no collapse affordance) — maximize is the only control', () => {
     render(
       <ChartCard title="Lap Times">
         <div>chart body</div>
@@ -41,7 +41,6 @@ describe('ChartCard', () => {
     )
 
     expect(screen.getByText('chart body')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /collapse chart/i }))
-    expect(screen.queryByText('chart body')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /collapse chart/i })).not.toBeInTheDocument()
   })
 })

--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -1,38 +1,52 @@
-import { forwardRef, useEffect, useState, type HTMLAttributes, type ReactNode } from 'react'
+import {
+  createContext,
+  forwardRef,
+  useEffect,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
-import { Maximize2, Minimize2, Minus, Plus } from 'lucide-react'
+import { Maximize2, Minimize2 } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 
-// Titled shell for a single chart: header (title + actions slot + maximize +
-// collapse), a scroll-contained body, and an optional footer strip. "Maximize"
-// portals the card to a full-viewport overlay so a chart can be inspected
-// without fighting a cramped dashboard grid cell; "collapse" just hides the
-// body (and footer) in place, for dashboards where a driver wants to fold a
-// chart they aren't using right now.
+// Titled shell for a single chart: header (title + actions slot + maximize), a
+// body, and an optional footer strip. "Maximize" portals the card to a
+// full-viewport overlay so a chart can be inspected without fighting a cramped
+// grid cell — the only per-chart control, since a full-screen view covers the
+// "look closer" need a collapse toggle used to.
+//
+// Charts read `ChartMaximizedContext` to FILL that overlay (rather than keeping
+// their fixed grid height and leaving dead space) and to key a remount so
+// ECharts re-measures at the new size — without it the canvas keeps its grid
+// dimensions and the hover/tooltip hit-testing lands in the wrong place.
 //
 // Acrylic-law exception: the overlay backdrop is chrome, not a data plane, so
 // `backdrop-blur` is allowed here even though data surfaces (the Card itself)
 // stay solid `--bg` with a hairline border, per Card.tsx.
+
+/** True while the chart is rendered inside the maximized full-viewport overlay.
+ *  Chart bodies read this to switch from their fixed grid height to filling the
+ *  overlay, and to key a remount so ECharts re-measures at the new size. */
+export const ChartMaximizedContext = createContext(false)
 
 export interface ChartCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string
   /** Right-aligned header slot, e.g. a range picker or a legend toggle. */
   actions?: ReactNode
   children?: ReactNode
-  /** Optional strip below the body (status / legend). Hidden while collapsed. */
+  /** Optional strip below the body (status / legend). */
   footer?: ReactNode
-  defaultCollapsed?: boolean
 }
 
 export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function ChartCard(
-  { title, actions, children, footer, defaultCollapsed = false, className, ...props },
+  { title, actions, children, footer, className, ...props },
   ref,
 ) {
   const [isMaximized, setIsMaximized] = useState(false)
-  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed)
 
   // Escape restores the maximized overlay, matching standard dialog behavior
   // even though this isn't a Radix Dialog (no focus trap needed here since
@@ -51,24 +65,6 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
-        {/* Collapse is a grid-only affordance. In the maximized overlay it just
-            hides the body, stranding the user on an empty full-screen card with
-            no way back (Restore is the way out) — so it's not offered there. */}
-        {!isMaximized && (
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
-            onClick={() => setIsCollapsed((value) => !value)}
-            className="size-8 px-0 text-fg-3"
-          >
-            {isCollapsed ? (
-              <Plus className="size-4" aria-hidden="true" />
-            ) : (
-              <Minus className="size-4" aria-hidden="true" />
-            )}
-          </Button>
-        )}
         <Button
           variant="ghost"
           size="sm"
@@ -86,15 +82,18 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     </div>
   )
 
-  // Maximizing always shows the content — a collapsed-in-grid chart still opens
-  // full-screen with its body (and Restore is the only exit), so there's no way
-  // to land on an empty maximized card.
-  const showBody = isMaximized || !isCollapsed
-  const body = showBody ? <div className="flex-1 overflow-auto p-4">{children}</div> : null
-  const footerStrip =
-    showBody && footer ? (
-      <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
-    ) : null
+  const body = <div className="flex-1 overflow-auto p-4">{children}</div>
+  const footerStrip = footer ? (
+    <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
+  ) : null
+
+  const content = (
+    <ChartMaximizedContext.Provider value={isMaximized}>
+      {header}
+      {body}
+      {footerStrip}
+    </ChartMaximizedContext.Provider>
+  )
 
   if (isMaximized) {
     return createPortal(
@@ -110,9 +109,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           className={cn('flex h-full w-full flex-col', className)}
           {...props}
         >
-          {header}
-          {body}
-          {footerStrip}
+          {content}
         </Card>
       </div>,
       document.body,
@@ -121,9 +118,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
 
   return (
     <Card ref={ref} className={cn('flex flex-col', className)} {...props}>
-      {header}
-      {body}
-      {footerStrip}
+      {content}
     </Card>
   )
 })

--- a/webapp/src/components/ThemeToggle.tsx
+++ b/webapp/src/components/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import { Moon, Sun } from 'lucide-react'
+import type { MouseEvent } from 'react'
 import { Button } from '@/components/Button'
 import { useUiStore } from '@/stores/ui'
 
@@ -6,8 +7,94 @@ import { useUiStore } from '@/stores/ui'
 // every routed page gets it for free. This component only flips the
 // two-state `theme` in `stores/ui.ts` — the `<html data-theme>` DOM stamping
 // and the FOUC guard already live in `providers.tsx` / `index.html`
-// (app-chrome-round2.md §2b-c), so ThemeToggle never touches the DOM
-// directly, it just reads/writes the store.
+// (app-chrome-round2.md §2b-c). The one exception is `handleClick` below: it
+// also stamps `data-theme` itself, synchronously, inside the View Transition
+// callback — see `runThemeViewTransition` for why that duplication is
+// required rather than a DOM violation.
+
+const VIEW_TRANSITION_DURATION_MS = 480
+
+/** The subset of `ViewTransition` this component actually reads. */
+interface ViewTransitionLike {
+  ready: Promise<void>
+}
+
+/**
+ * `document` augmented with the View Transitions API. Declared locally
+ * (never `any`) because TypeScript's bundled DOM lib only gained
+ * `startViewTransition` typings in recent releases — this intersection type
+ * is structurally compatible whether or not `lib.dom.d.ts` already declares
+ * the method, so the cast below is safe either way (see summary handoff for
+ * the compatibility reasoning).
+ */
+type DocumentWithViewTransitions = Document & {
+  startViewTransition?: (callback: () => void) => ViewTransitionLike
+}
+
+function getViewTransitionDocument(): DocumentWithViewTransitions {
+  return document as DocumentWithViewTransitions
+}
+
+/** False when the browser lacks View Transitions or the user asked for reduced motion — the caller should fall back to an instant, unanimated toggle. */
+function canAnimateThemeSwitch(): boolean {
+  const supportsViewTransitions =
+    typeof getViewTransitionDocument().startViewTransition === 'function'
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  return supportsViewTransitions && !prefersReducedMotion
+}
+
+/**
+ * Expands a circular reveal of the new theme from `(x, y)` — the toggle
+ * button's own center — outward until it covers the viewport. `index.css`
+ * disables the browser's default cross-fade on `::view-transition-old/new`,
+ * so the old frame just sits still underneath while this clip-path animation
+ * wipes the new one over it (the theme-toggle.rdsx.dev technique).
+ */
+function animateThemeCircleReveal(x: number, y: number) {
+  const endRadius = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y),
+  )
+  document.documentElement.animate(
+    { clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${endRadius}px at ${x}px ${y}px)`] },
+    {
+      duration: VIEW_TRANSITION_DURATION_MS,
+      easing: 'ease-in-out',
+      pseudoElement: '::view-transition-new(root)',
+    },
+  )
+}
+
+/**
+ * Runs `applyTheme` inside `document.startViewTransition`, then drives the
+ * circular reveal once the new frame is ready.
+ *
+ * `applyTheme` MUST mutate the DOM synchronously: the View Transitions API
+ * snapshots the "old" frame before the callback runs and the "new" frame
+ * right after it returns, but `providers.tsx`'s theme effect only re-stamps
+ * `data-theme` asynchronously on the next React commit — too late for the
+ * snapshot. That's why `handleClick` sets `data-theme` itself inside the
+ * callback; the store update still happens too, so providers.tsx's effect
+ * re-stamps the same value afterwards as a no-op.
+ */
+function runThemeViewTransition(x: number, y: number, applyTheme: () => void) {
+  document.documentElement.style.setProperty('--theme-x', `${x}px`)
+  document.documentElement.style.setProperty('--theme-y', `${y}px`)
+
+  const transition = getViewTransitionDocument().startViewTransition?.(applyTheme)
+  if (!transition) {
+    applyTheme()
+    return
+  }
+
+  transition.ready
+    .then(() => animateThemeCircleReveal(x, y))
+    .catch(() => {
+      // `ready` can reject (e.g. the browser skipped the transition). The
+      // theme has already flipped synchronously above, so there's nothing to
+      // recover — just drop the reveal animation.
+    })
+}
 
 /**
  * Sun/Moon icon-only button. The icon always depicts the theme you're about
@@ -20,12 +107,29 @@ export function ThemeToggle() {
   const toggleTheme = useUiStore((state) => state.toggleTheme)
   const Icon = theme === 'dark' ? Sun : Moon
 
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+    if (!canAnimateThemeSwitch()) {
+      toggleTheme()
+      return
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect()
+    const x = rect.left + rect.width / 2
+    const y = rect.top + rect.height / 2
+    const nextTheme = theme === 'dark' ? 'light' : 'dark'
+
+    runThemeViewTransition(x, y, () => {
+      document.documentElement.dataset.theme = nextTheme
+      toggleTheme()
+    })
+  }
+
   return (
     <Button
       variant="ghost"
       size="sm"
       aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-      onClick={toggleTheme}
+      onClick={handleClick}
       className="size-8 px-0"
     >
       <Icon

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -10,7 +10,7 @@
 // `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
 // scrubbing any one chart shows every driver's value at that distance.
 
-import { memo, useMemo } from 'react'
+import { memo, useContext, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type {
   DefaultLabelFormatterCallbackParams,
@@ -21,6 +21,7 @@ import type {
 import * as echarts from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
 import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
+import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTelemetry } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
@@ -261,13 +262,19 @@ function SyncedLineChart({
   height?: number
 }) {
   const chartTheme = useChartTheme()
+  // Inside the maximized overlay, fill the card instead of holding the fixed
+  // grid height (which would leave dead space). The `key` folds in `maximized`
+  // so the chart REMOUNTS at the new size — echarts-for-react only auto-resizes
+  // on window resize, not on this container change, so a stale canvas would
+  // mis-place the hover crosshair otherwise.
+  const maximized = useContext(ChartMaximizedContext)
   return (
-    <div role="img" aria-label={ariaLabel}>
+    <div role="img" aria-label={ariaLabel} className={maximized ? 'h-full' : undefined}>
       <ReactECharts
         theme={chartTheme}
-        key={chartTheme}
+        key={`${chartTheme}-${maximized}`}
         option={option}
-        style={{ height }}
+        style={{ height: maximized ? '100%' : height }}
         notMerge
         onChartReady={(instance) => {
           instance.group = CROSSHAIR_GROUP

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -2,17 +2,22 @@
 // `frontend/components/dashboard/lap_graph.py::_render_tyre_compound_legend`.
 //
 // One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
-// each annotated with per-driver lap counts. Counts always come from the
-// FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
-// chart, not "how many laps did each driver run on this tyre". Renders as a
-// single inline row (round-2 fix #3) — it lives in the Lap Chart card's
-// footer now, not as its own titled block, so the pills self-label and don't
-// need a `SectionHeader` above them.
+// each followed by per-driver lap counts. Counts always come from the FULL
+// (unfiltered) lap times — the outlier/invalid toggles only affect the chart,
+// not "how many laps did each driver run on this tyre". Renders as a single
+// inline row inside the Lap Chart card footer (round-2 #3), so the pills
+// self-label and don't need a `SectionHeader` above them.
+//
+// This is the RIGHT cluster of the timing-strip footer: its one accent is the
+// compound hue (on the pills); driver codes stay neutral (fg-3) — identity for
+// ≤3 drivers is unambiguous from the code text alone, and dropping team colour
+// here halves the strip's colour count and removes the worst light-theme
+// text-contrast offenders. The count is the mono, tabular, one-step-stronger
+// (fg-2) element — it's the datum.
 
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
-import { getDriverTextColor } from '../lib/drivers'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -55,14 +60,12 @@ export interface CompoundLegendProps {
   /** FULL (unfiltered) lap times. */
   lapTimes: LapTime[]
   drivers: string[]
-  /** Season year — team colours changed lineups across seasons (`getDriverTextColor`). */
-  year?: number
 }
 
-/** Inline compound-Pill row, each pill followed by its per-driver lap counts
- *  on the same line — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
+/** Inline compound-Pill row, each pill followed by its per-driver lap counts on
+ *  the same baseline — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
  *  laps are loaded yet (matches the Streamlit early-return). */
-export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
+export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
 
@@ -72,31 +75,28 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
     <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
       {compounds.map((compound) => {
         const variant = compoundVariant(compound)
+        const label = compoundLabel(compound)
         const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
+        const title = `${label}: ${driverCounts.map((d) => `${d.driver} ${d.count} laps`).join(', ')}`
         return (
-          <div key={compound} className="flex items-center gap-1.5">
+          <div key={compound} className="flex items-center gap-1.5" title={title}>
             {variant ? (
-              // Permanent hairline border (B3): HARD is a near-white chip
-              // that vanishes on a white card in the light theme; the border
-              // is near-invisible in dark and load-bearing in light.
+              // Permanent hairline border (B3): HARD is a near-white chip that
+              // vanishes on a white card in the light theme; the border is
+              // near-invisible in dark and load-bearing in light.
               <Pill compound={variant} className="border border-hairline">
-                {compoundLabel(compound)}
+                {label}
               </Pill>
             ) : (
-              <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+              <Pill tone="neutral">{label}</Pill>
             )}
             {driverCounts.length > 0 ? (
-              <span className="text-xs text-fg-3">
+              <span className="font-mono text-fg-3">
                 {driverCounts.map(({ driver, count }, index) => (
                   <span key={driver}>
-                    {index > 0 ? ' · ' : ''}
-                    <span
-                      className="font-mono tabular-nums"
-                      style={{ color: getDriverTextColor(driver, year) }}
-                    >
-                      {driver}
-                    </span>{' '}
-                    {count}
+                    {index > 0 ? <span className="text-fg-4"> · </span> : ''}
+                    {driver} <span className="tabular-nums text-fg-2">{count}</span>
+                    <span className="sr-only"> laps</span>
                   </span>
                 ))}
               </span>

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -13,11 +13,12 @@
 // picker instead accepts any click within a 20px radius of the nearest
 // plotted point (round-2 fix, see `docs/migration/design-specs/dashboard-round2.md#1`).
 
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useContext, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ECharts, EChartsOption } from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
 import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
+import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTime } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import { compoundLabel, compoundVariant } from '../lib/compounds'
@@ -377,6 +378,10 @@ export interface LapChartProps {
  *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
 export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
   const chartTheme = useChartTheme()
+  // Fill the maximized overlay instead of the fixed 400px grid height, and fold
+  // `maximized` into the chart key so it remounts at the new size (keeps the
+  // nearest-point click picking + hover aligned — see ChartCard's context).
+  const maximized = useContext(ChartMaximizedContext)
   const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
@@ -407,12 +412,16 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
   }, [])
 
   return (
-    <div role="img" aria-label="Lap times by lap, per driver">
+    <div
+      role="img"
+      aria-label="Lap times by lap, per driver"
+      className={maximized ? 'h-full' : undefined}
+    >
       <ReactECharts
         theme={chartTheme}
-        key={chartTheme}
+        key={`${chartTheme}-${maximized}`}
         option={option}
-        style={{ height: 400 }}
+        style={{ height: maximized ? '100%' : 400 }}
         notMerge
         onChartReady={handleChartReady}
       />

--- a/webapp/src/features/dashboard/components/LapChartFooter.tsx
+++ b/webapp/src/features/dashboard/components/LapChartFooter.tsx
@@ -1,18 +1,22 @@
-// Lap Chart card footer strip: telemetry-selection status (left) + tyre
-// compound legend (right), folded into the `ChartCard`'s `footer` slot so the
-// card reads as one unit — chart, controls, status — instead of a stack of
-// loose blocks below it (round-2 fix #3, see
-// `docs/migration/design-specs/dashboard-round2.md#3`). `LapChartSection`
-// only renders this once `lapTimes` is non-empty; both clusters are cheap to
-// compute off data it already has in hand.
+// Lap Chart card footer: a compact "timing-strip" — telemetry-selection status
+// (left) + tyre-compound legend (right), folded into the ChartCard footer slot
+// (round-2 #3, see docs/migration/design-specs/dashboard-round2.md#3). One row,
+// everything `text-xs` on a single baseline; hierarchy is carried by the fg
+// ramp (loaded lap = fg-1, code = fg-2, eyebrow = fg-3, hint = fg-4), not by
+// size. Team colour rides on a swatch DOT, never the code text: a filled dot
+// has no contrast floor, so it survives the light theme's white card where a
+// near-white team colour as text would be illegible — and the dot doubles as
+// the chart's line-colour key. `LapChartSection` renders this once `lapTimes`
+// is non-empty.
 
-import { Activity } from 'lucide-react'
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverTextColor } from '../lib/drivers'
+import { getDriverColor } from '../lib/drivers'
 import { CompoundLegend } from './CompoundLegend'
 
-/** `{ driver, lap }` pairs for the telemetry-status caption, in the store
- *  map's insertion order (click order / fastest-laps batch order). */
+const EYEBROW_CLASSNAME = 'font-medium uppercase tracking-widest text-fg-3'
+
+/** `{ driver, lap }` pairs for the status cluster, in the store map's insertion
+ *  order (click order / fastest-laps batch order). */
 function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
   return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
 }
@@ -27,10 +31,11 @@ export interface LapChartFooterProps {
   year: number | undefined
 }
 
-/** Left cluster: which lap's telemetry is loaded per driver, plus the
- *  click-to-switch hint (demoted here from its old standalone tip line).
- *  Right cluster: the inline tyre-compound legend. `flex-wrap` lets narrow
- *  cards stack the two clusters instead of overflowing. */
+/** Footer strip. Left cluster = "what you're looking at now" (a `Telemetry`
+ *  eyebrow + one dot·code·lap chip per loaded driver + a quiet click hint).
+ *  Right cluster = the stint reference (compound legend). Both clusters always
+ *  render, so a single-driver load never pins the legend to a lonely right
+ *  edge, and the hint is loudest exactly when nothing is loaded yet. */
 export function LapChartFooter({
   selectedLapsPerDriver,
   lapTimes,
@@ -38,31 +43,36 @@ export function LapChartFooter({
   year,
 }: LapChartFooterProps) {
   const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+  const hasSelection = captionParts.length > 0
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-      {captionParts.length > 0 ? (
-        <p className="flex items-center gap-2 text-sm text-fg-2">
-          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
-          <span>
-            Showing telemetry:{' '}
-            {captionParts.map((part, index) => (
-              <span key={part.driver}>
-                {index > 0 ? ', ' : ''}
-                <strong
-                  className="font-semibold"
-                  style={{ color: getDriverTextColor(part.driver, year) }}
-                >
-                  {part.driver}
-                </strong>{' '}
-                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
-              </span>
-            ))}
-            <span className="text-fg-3"> · click any point to switch lap</span>
+    <div className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 text-xs">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <span className={EYEBROW_CLASSNAME}>Telemetry</span>
+        {captionParts.map(({ driver, lap }) => (
+          <span
+            key={driver}
+            className="flex items-center gap-1.5"
+            title={`${driver} — Lap ${lap} telemetry loaded`}
+          >
+            <span
+              aria-hidden="true"
+              className="size-1.5 rounded-full ring-1 ring-inset ring-hairline"
+              style={{ backgroundColor: getDriverColor(driver, year) }}
+            />
+            <span className="font-mono font-medium text-fg-2">{driver}</span>
+            <span className="font-mono tabular-nums text-fg-1">
+              L{lap}
+              <span className="sr-only"> (lap {lap})</span>
+            </span>
           </span>
-        </p>
-      ) : null}
-      <CompoundLegend lapTimes={lapTimes} drivers={drivers} year={year} />
+        ))}
+        <span aria-hidden="true" className="hidden h-3 w-px bg-hairline sm:inline-block" />
+        <span className="hidden text-fg-4 sm:inline">
+          {hasSelection ? 'Click a point to switch lap' : 'Click a point to load telemetry'}
+        </span>
+      </div>
+      <CompoundLegend lapTimes={lapTimes} drivers={drivers} />
     </div>
   )
 }

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -69,6 +69,46 @@
   --tracking-widest: var(--tracking-widest);
 }
 
+/* View Transition circular theme reveal (ThemeToggle.tsx). Kill the browser's
+   default cross-fade so only the JS-driven clip-path circle animates — the
+   old frame sits still underneath while the new one wipes over it from the
+   toggle button's position (`--theme-x`/`--theme-y`, set by ThemeToggle). */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+  z-index: 1;
+}
+::view-transition-new(root) {
+  z-index: 2;
+}
+
+/* Subtle premium touch: the incoming frame starts a hair out of focus and
+   sharpens as the circle reveal completes, instead of snapping in crisp.
+   Duration is hardcoded to match ThemeToggle's `VIEW_TRANSITION_DURATION_MS`
+   (480ms) — keep the two in sync if either changes. Placed BEFORE the
+   reduced-motion override below so that override still wins when it applies. */
+@keyframes theme-reveal-focus {
+  from {
+    filter: blur(2px);
+  }
+  to {
+    filter: blur(0);
+  }
+}
+::view-transition-new(root) {
+  animation: theme-reveal-focus 480ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 @layer base {
   html {
     color-scheme: dark;

--- a/webapp/src/stores/ui.ts
+++ b/webapp/src/stores/ui.ts
@@ -11,10 +11,25 @@ import { persist } from 'zustand/middleware'
 // resolves here, not in the CSS.
 export type Theme = 'dark' | 'light'
 
+// Drag-to-resize bounds for the expanded rail (Rail.tsx owns the collapsed
+// width, which is fixed and never resizable). Exported so Rail.tsx can reuse
+// the exact same numbers for its `aria-valuemin`/`aria-valuemax` instead of
+// duplicating the bounds and risking drift between the clamp and the a11y
+// attributes that describe it.
+export const RAIL_WIDTH_MIN = 200
+export const RAIL_WIDTH_MAX = 360
+const RAIL_WIDTH_DEFAULT = 232
+
+function clampRailWidth(width: number): number {
+  return Math.min(RAIL_WIDTH_MAX, Math.max(RAIL_WIDTH_MIN, width))
+}
+
 interface UiState {
   railCollapsed: boolean
   toggleRail: () => void
   setRailCollapsed: (collapsed: boolean) => void
+  railWidth: number
+  setRailWidth: (width: number) => void
   theme: Theme
   toggleTheme: () => void
 }
@@ -25,6 +40,8 @@ export const useUiStore = create<UiState>()(
       railCollapsed: false,
       toggleRail: () => set((state) => ({ railCollapsed: !state.railCollapsed })),
       setRailCollapsed: (collapsed) => set({ railCollapsed: collapsed }),
+      railWidth: RAIL_WIDTH_DEFAULT,
+      setRailWidth: (width) => set({ railWidth: clampRailWidth(width) }),
       theme: 'dark',
       toggleTheme: () => set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
     }),


### PR DESCRIPTION
Second polish pass from Víctor's review, ahead of dev → main.

## Changes
- **Lap-chart footer redesigned** (Fable design audit) into a compact *timing-strip*: a `Telemetry` eyebrow + one dot·code·lap chip per loaded driver (team colour rides the swatch DOT, code text is neutral) + a quiet click hint; the compound legend counts go mono/tabular with neutral codes. Fixes the earlier light-theme issue where team-coloured text was near-illegible on the white card — a filled dot has no contrast floor. Verified in both themes.
- **Removed the per-chart collapse (+/-) button.** Maximize covers the look-closer need; collapse only invited the empty-card trap (fixed last PR). ChartCard is simpler now.
- **Maximized chart fills the overlay** instead of holding its fixed grid height (no more dead space below), and remounts at the new size so the hover crosshair/tooltips stay aligned — the charts read a `ChartMaximizedContext`. Verified functionally (maximized fills, restore keeps the chart).
- **Rail drag-to-resize**: a right-edge `separator` handle (pointer + keyboard), width persisted and clamped 200-360px, plus a subtle width transition on collapse/expand. Verified (drag +60px → 232→289px).
- **Theme toggle animation**: a View Transitions circular reveal expanding from the button, with reduced-motion + unsupported-browser fallbacks. Verified (flips dark↔light, no runtime errors).

## Checks
- tsc -b, oxlint, vitest (43/43), vite build — all green.
- Screenshot-verified on 2023 Monaco R (VER, LEC): footer in dark + light, maximized fill, sidebar resize + theme toggle functional.