### PR TITLE
Promote dashboard migration (round-2 + polish) to main

### DIFF
--- a/backend/api/v1/endpoints/circuit_domination.py
+++ b/backend/api/v1/endpoints/circuit_domination.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/circuit-domination", tags=["telemetry"])
 
 
 @router.get("")
-async def get_circuit_domination(
+def get_circuit_domination(
     year: int = Query(..., ge=2018, le=2030, description="Racing season year"),
     gp: str = Query(..., min_length=1, description="Grand Prix name (e.g., 'Spain', 'Belgium')"),
     session: str = Query(..., pattern="^(FP1|FP2|FP3|Q|R|S|SQ)$", description="Session type"),

--- a/backend/api/v1/endpoints/telemetry.py
+++ b/backend/api/v1/endpoints/telemetry.py
@@ -10,14 +10,22 @@ from backend.services.telemetry.telemetry_service import (
     get_lap_times,
     get_telemetry_data_from_db,
 )
+from backend.services.telemetry.session_cache import prewarm_session
 from backend.utils.laps_cache import get_laps_df
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 router = APIRouter(prefix="/telemetry", tags=["telemetry"])
 
+# NOTE (perf): these handlers are plain ``def`` (NOT ``async def``) on purpose.
+# They call synchronous, CPU/IO-blocking FastF1 code; a ``def`` handler runs in
+# Starlette's threadpool, so several telemetry requests fired by one selection
+# (lap-times + N lap-telemetry + circuit-domination) run concurrently instead of
+# serializing on the event loop — and a slow FastF1 parse no longer freezes the
+# whole server. See session_cache.py for the parse-once half of the fix.
+
 
 @router.get("/data")
-async def get_telemetry_data(
+def get_telemetry_data(
     year: int = Query(...),
     gp: str = Query(...),
     session: str = Query(...),
@@ -28,8 +36,26 @@ async def get_telemetry_data(
     return data
 
 
+@router.post("/prewarm", status_code=202)
+def prewarm(
+    background_tasks: BackgroundTasks,
+    year: int = Query(...),
+    gp: str = Query(...),
+    session: str = Query(...),
+):
+    """Warm the FastF1 session cache for (year, gp, session) in the background.
+
+    The frontend calls this when the user picks a session, so the ~2-15s parse
+    starts while they choose drivers — by the time lap-times/telemetry fire, the
+    session is already loaded and the charts fall in instead of hanging.
+    Returns 202 immediately; the load runs after the response is sent.
+    """
+    background_tasks.add_task(prewarm_session, year, gp, session)
+    return {"status": "prewarming", "year": year, "gp": gp, "session": session}
+
+
 @router.get("/gps")
-async def get_gps(year: int = Query(..., description="Year of the season (e.g., 2024)")):
+def get_gps(year: int = Query(..., description="Year of the season (e.g., 2024)")):
     """
     Get available Grand Prix events for a specific year.
     """
@@ -38,7 +64,7 @@ async def get_gps(year: int = Query(..., description="Year of the season (e.g., 
 
 
 @router.get("/sessions")
-async def get_sessions(
+def get_sessions(
     year: int = Query(..., description="Year of the season"),
     gp: str = Query(..., description="Grand Prix name")
 ):
@@ -50,7 +76,7 @@ async def get_sessions(
 
 
 @router.get("/drivers")
-async def get_drivers(
+def get_drivers(
     year: int = Query(..., description="Year of the season"),
     gp: str = Query(..., description="Grand Prix name"),
     session: str = Query(..., description="Session type (FP1, FP2, FP3, SQ, Q, S, R)")
@@ -77,7 +103,7 @@ async def get_drivers(
         "asks to FORECAST a future race lap."
     ),
 )
-async def get_laps(
+def get_laps(
     year: int = Query(..., description="Season year (2023, 2024 or 2025)."),
     gp: str = Query(..., description="Grand Prix name (city/circuit form preferred, country names also accepted)."),
     session: str = Query(
@@ -108,7 +134,7 @@ async def get_laps(
         "compare_drivers instead."
     ),
 )
-async def get_lap_telemetry_endpoint(
+def get_lap_telemetry_endpoint(
     year: int = Query(..., description="Season year (2023, 2024 or 2025)."),
     gp: str = Query(..., description="Grand Prix name (city/circuit form preferred)."),
     session: str = Query(

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,17 @@
 import logging
+import sys
 from contextlib import asynccontextmanager
+
+# Force UTF-8 on this process's streams. Several services print non-ASCII
+# glyphs (e.g. telemetry_service's "✓"/"⚠"/"❌"); on a Windows cp1252 console
+# those `print(...)` calls raise UnicodeEncodeError, and because they sit inside
+# broad try/except blocks the crash is swallowed and the endpoint silently
+# returns empty data (the whole telemetry Dashboard shows "no data"). The
+# hasattr guard keeps this safe under a captured stdout (e.g. pytest).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 
 from backend.api.v1.endpoints import circuit_domination, comparison, telemetry, chat, voice, strategy
 from backend.core.config import FRONTEND_URL, mcp_enabled

--- a/backend/services/telemetry/fastf1_client.py
+++ b/backend/services/telemetry/fastf1_client.py
@@ -1,6 +1,7 @@
-import fastf1
 import pandas as pd
 from typing import List, Optional
+
+from backend.services.telemetry.session_cache import get_loaded_session
 
 
 class SessionData:
@@ -15,9 +16,11 @@ class SessionData:
         self.session_data = self._load_session()
 
     def _load_session(self):
-        session = fastf1.get_session(self.year, self.circuit, self.current_session)
-        session.load(telemetry=self.telemetry, laps=self.laps, weather=self.weather)
-        return session
+        # Delegates to the process-wide session cache: the same FastF1 session is
+        # parsed once and reused across the 4-6 SessionData objects a single
+        # dashboard interaction builds (see session_cache.py). Read-only after
+        # load, so sharing one object across requests is safe.
+        return get_loaded_session(self.year, self.circuit, self.current_session)
 
     def get_driver_lap_times(self, drivers: Optional[List[str]] = None):
         """

--- a/backend/services/telemetry/session_cache.py
+++ b/backend/services/telemetry/session_cache.py
@@ -1,0 +1,91 @@
+"""In-process cache of loaded FastF1 sessions.
+
+Loading + parsing a FastF1 session (telemetry + laps + weather) costs 2-15s and,
+without a cache, runs on EVERY ``SessionData(...)`` construction — from disk each
+time. A single dashboard interaction builds 4-6 ``SessionData`` objects for the
+SAME session (lap-times, each lap-telemetry, circuit-domination, driver list), so
+the same parse used to run 4-6x, serialized. This caches the loaded session by
+``(year, gp, session)`` with a small LRU and a per-key lock, so concurrent
+requests for the same session wait for ONE load instead of stampeding.
+
+Loaded FastF1 sessions are read-only after ``load()``, so sharing a single object
+across requests is safe (all downstream use is reads: ``laps.pick_drivers``,
+``get_car_data``, ``pick_fastest`` …).
+
+--- WHERE TO CHANGE IF THE LOAD CONTRACT CHANGES ---
+``fastf1_client.SessionData._load_session`` delegates here; the endpoints just
+build ``SessionData`` as before. Raise ``_MAXSIZE`` only with memory in mind (a
+race session with telemetry is hundreds of MB).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from typing import Dict, Tuple
+
+import fastf1
+
+# A race session with telemetry is hundreds of MB; 2 covers the common
+# dashboard-then-comparison pattern without unbounded growth.
+_MAXSIZE = 2
+
+_Key = Tuple[int, str, str]
+
+_cache: "OrderedDict[_Key, object]" = OrderedDict()
+_cache_lock = threading.Lock()          # guards _cache structure
+_key_locks: Dict[_Key, threading.Lock] = {}
+_key_locks_guard = threading.Lock()
+
+
+def _lock_for(key: _Key) -> threading.Lock:
+    """Return the dedicated load-lock for a key, creating it once."""
+    with _key_locks_guard:
+        lock = _key_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _key_locks[key] = lock
+        return lock
+
+
+def get_loaded_session(year: int, gp: str, session: str):
+    """Return a fully-loaded FastF1 Session for (year, gp, session), cached.
+
+    The first call for a key parses from disk (slow); later calls return the same
+    object instantly. Concurrent first-calls for the same key are serialized by a
+    per-key lock so the parse runs exactly once (no thundering herd).
+    """
+    key: _Key = (year, gp, session)
+
+    # Fast path: already cached.
+    with _cache_lock:
+        if key in _cache:
+            _cache.move_to_end(key)
+            return _cache[key]
+
+    # Slow path: exactly one loader per key.
+    with _lock_for(key):
+        # Another thread may have loaded it while we waited for the lock.
+        with _cache_lock:
+            if key in _cache:
+                _cache.move_to_end(key)
+                return _cache[key]
+
+        loaded = fastf1.get_session(year, gp, session)
+        loaded.load(telemetry=True, laps=True, weather=True)
+
+        with _cache_lock:
+            _cache[key] = loaded
+            _cache.move_to_end(key)
+            while len(_cache) > _MAXSIZE:
+                _cache.popitem(last=False)
+        return loaded
+
+
+def prewarm_session(year: int, gp: str, session: str) -> None:
+    """Load a session into the cache without returning it (fire-and-forget).
+
+    Called from the prewarm endpoint so the parse starts while the user is still
+    picking drivers, turning "30s after the click" into "the charts fall in".
+    """
+    get_loaded_session(year, gp, session)

--- a/backend/services/telemetry/telemetry_service.py
+++ b/backend/services/telemetry/telemetry_service.py
@@ -180,66 +180,14 @@ def get_lap_times(year: int, gp: str, session: str, drivers: List[str]) -> List[
 
         print(f"Filtered to {len(laps_filtered)} valid laps (excluded pit laps and inaccurate laps)")
 
-        # Additional filter: Verify each lap has COMPLETE telemetry data for ALL TELEMETRY GRAPHS
-        # This ensures that all telemetry graphs (Speed, Throttle, Brake, RPM, Gear, DRS, Delta)
-        # can be painted for the selected laps.
-        #
-        # NOTE: X, Y (GPS) are NOT required here because:
-        # - Circuit Domination uses its own API endpoint (get_circuit_domination)
-        # - Distance can be calculated from Speed and Time if GPS is missing
-        #
-        # Required columns from FastF1 for telemetry graphs:
-        # - Speed: For speed graph
-        # - Throttle: For throttle graph
-        # - Brake: For brake graph
-        # - RPM: For RPM graph
-        # - nGear: For gear graph (FastF1 uses 'nGear' not 'Gear')
-        # - DRS: For DRS graph
-        # - Time: For delta graph and distance calculation
-
-        REQUIRED_COLUMNS = ['Speed', 'Throttle', 'Brake', 'RPM', 'nGear', 'DRS', 'Time']
-
-        laps_with_complete_telemetry = []
-        for idx, lap_data in laps_filtered.iterrows():
-            try:
-                # Try to get telemetry for this lap
-                telemetry = lap_data.get_car_data()
-
-                # Check if telemetry exists and is not empty
-                if telemetry is None or telemetry.empty:
-                    continue
-
-                # Verify ALL required columns exist
-                missing_columns = [col for col in REQUIRED_COLUMNS if col not in telemetry.columns]
-                if missing_columns:
-                    print(f"Lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')} missing columns: {missing_columns}")
-                    continue
-
-                # Verify each required column has valid data (not all NaN)
-                has_valid_data = True
-                for col in REQUIRED_COLUMNS:
-                    if telemetry[col].isna().all():
-                        print(f"Lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')}: column '{col}' has no valid data")
-                        has_valid_data = False
-                        break
-
-                # Only include lap if all columns have valid data
-                if has_valid_data:
-                    laps_with_complete_telemetry.append(idx)
-
-            except Exception as e:
-                # Skip laps that fail to load telemetry
-                print(f"Skipping lap {lap_data.get('LapNumber', '?')} for {lap_data.get('Driver', '?')}: {e}")
-                continue
-
-        # Filter to only laps with complete telemetry data
-        if laps_with_complete_telemetry:
-            laps_filtered = laps_filtered.loc[laps_with_complete_telemetry]
-            print(f"✓ Verified {len(laps_filtered)} laps have COMPLETE telemetry data for ALL graphs")
-        else:
-            print("⚠ No laps with complete telemetry data found")
-            laps_filtered = pd.DataFrame()  # Empty DataFrame
-
+        # NOTE (perf): the previous per-lap telemetry validation loop
+        # (`lap.get_car_data()` for EVERY candidate lap, ~50-150 pandas slices per
+        # request, 5-20s on its own even with the session cached) was removed. It
+        # only pre-filtered laps that lack complete telemetry — a guard the UI now
+        # handles gracefully: /lap-telemetry returns {} for such a lap and the
+        # dashboard shows a "pick another lap" notice (since #34). The cheap
+        # IsAccurate + LapTime + no-pit filter above is sufficient to build the
+        # chart, and dropping this loop is the single biggest lap-times speedup.
         result = []
 
         # Iterate through filtered laps

--- a/backend/services/telemetry_service.py
+++ b/backend/services/telemetry_service.py
@@ -15,6 +15,7 @@ import os
 import warnings
 
 from backend.core.driver_colors import get_driver_color
+from backend.services.telemetry.session_cache import get_loaded_session
 
 # Suppress specific FastF1/pandas warnings
 warnings.filterwarnings('ignore', message='.*fill_value.*')
@@ -94,9 +95,9 @@ def get_circuit_domination_data(
     try:
         logger.info(
             f"Requesting session from FastF1: {year} {gp} {session_type}")
-        session = fastf1.get_session(year, gp, session_type)
-        logger.info("Loading session data (this may take time on first run)...")
-        session.load()
+        # Reuse the process-wide session cache (parse once, shared with the
+        # telemetry endpoints) instead of a fresh load per request.
+        session = get_loaded_session(year, gp, session_type)
         logger.info("Session loaded successfully")
     except Exception as e:
         logger.error(f"Failed to load session: {e}", exc_info=True)
@@ -394,10 +395,9 @@ def fetch_lap_telemetry(
     logger.info(
         f"Fetching lap telemetry: {year} {gp} {session_type} - {driver} {lap_description}")
 
-    # Load session
+    # Load session (reuse the process-wide session cache)
     try:
-        session = fastf1.get_session(year, gp, session_type)
-        session.load()
+        session = get_loaded_session(year, gp, session_type)
         logger.info(f"Session loaded: {year} {gp} {session_type}")
     except Exception as e:
         logger.error(f"Failed to load session: {e}")

--- a/docs/migration/design-specs/app-chrome-round2.md
+++ b/docs/migration/design-specs/app-chrome-round2.md
@@ -1,0 +1,196 @@
+# App Chrome + Design System — Round 2 Plan
+
+> Execution plan (Fable, 2026-07-14). Refinements to the app SHELL (rail + header) and the design system underneath it: light theme + toggle, rail redesign, a typography/colour rulebook, and a future onboarding sketch. Plan only — build next session, one PR per item, screenshot-verified on the golden session (2023 Monaco R, VER,LEC), dark AND light once item 1 lands.
+
+## 1. Scope, references & key discoveries
+
+Sources of truth audited: `webapp/src/app/{Rail,Header,Shell,providers,router}.tsx`, `webapp/src/styles/tokens.css`, `webapp/src/index.css`, `webapp/src/stores/ui.ts`, `webapp/src/lib/zIndex.ts`, `webapp/src/charts/echartsTheme.ts` + the two brand-convention sites: the **landing** (`~/…/TFG/f1stratlab-web/`: `colors_and_type.css`, `landing.css`, `components/App.jsx`) and the **docs site** (parent repo `docs/styles/{tokens,docs}.css`). Skills applied: `baseline-ui` (`.claude/skills/baseline-ui/SKILL.md`) + `frontend-design`; ui-skills catalogue consulted conceptually (navigation / motion / layout categories) for the rail pattern.
+
+Key discoveries that shape every item below:
+
+1. **Neither the landing nor the docs has a light theme or a theme toggle.** Both are dark-only (`docs/index.html:100-101` pins `theme-color #0c0d14`; the landing has zero `data-theme`/toggle code). "Mirror the landing's light palette" is therefore impossible — **we derive the light palette from the token semantics** and the app becomes the first branded surface with a toggle. The toggle itself is new brand vocabulary, not a port.
+2. **The docs sidebar is the strongest reference for the rail** (`docs/styles/docs.css:301-385`): grouped sections with tiny uppercase titles + a 4px purple dot, active link = purple gradient wash + 2px left bar with glow, mono meta tags. That is the on-brand "premium rail" grammar — the current Rail has none of it.
+3. **The landing centers; the app left-aligns.** `landing.css:309-313` centers `.section-head` by default (marketing grammar, with a `.left` variant). The docs site — the app-like sibling — is left-aligned throughout. The migrated Dashboard's left H1 + left `SectionHeader`s is **correct**; codified in §4.
+4. **A real token bug exists:** brand `--tracking-widest: 0.18em` (`tokens.css:108`) is never mapped into Tailwind's `@theme` (`index.css:9-60` maps colors + fonts only), so every `tracking-widest` utility in the app silently renders Tailwind's default **0.1em**. Two different eyebrow trackings ship today (§4, D1).
+
+---
+
+## 2. Item 1 — Light theme + toggle in the top bar
+
+### Analysis
+
+`tokens.css` is **light-READY but not light-COMPLETE**. Ready: the ramp is fully semantic (`--bg-0..5`, `--fg-1..4`, `--divider/hairline`, shadows, gradients), and `index.css:9` maps it via `@theme inline` so utilities reference the vars — a light theme is a var swap, exactly as the file's own comment promises (`tokens.css:8-10`). Translucent chrome (`bg-bg-2/80` in Rail, `bg-bg-1/80` in Header) also survives the swap: Tailwind v4 renders opacity modifiers on var colors via `color-mix()`, so no component edits needed there.
+
+Not complete — four hard blockers:
+
+| # | Blocker | Where |
+|---|---|---|
+| B1 | `html { color-scheme: dark }` hardcoded | `index.css:63-65` |
+| B2 | Status colors are neon-on-dark: `--success #43ff64`, `--warning #ffbd33` fail contrast on white | `tokens.css:51-54` |
+| B3 | `--tire-hard: #e6e6e6` — white chip on white bg | `tokens.css:59` |
+| B4 | ECharts theme hardcodes resolved dark hex ("a build-time JS module cannot read CSS vars") | `charts/echartsTheme.ts:13-18,29-44` |
+
+No `@media (prefers-color-scheme)` blocks exist anywhere in the webapp today — a clean slate for the interplay rule.
+
+### Plan
+
+**(a) Light token block — `styles/tokens.css`** (append after `:root`, ~35 overrides under `:root[data-theme='light']`):
+
+```css
+:root[data-theme='light'] {
+  color-scheme: light;                            /* resolves B1 declaratively */
+  --bg-0: #f5f5fa;  --bg-1: #eef0f7;  --bg-2: #e9eaf4;   /* page / deep / chrome */
+  --bg-3: #ffffff;  --bg-4: #f7f7fc;  --bg-5: #eceaf9;   /* card / elevated / input */
+  --fg-1: #14121f;                                  /* near-black, purple tint (mirror of bg-1) */
+  --fg-2: rgba(20,18,31,0.75); --fg-3: rgba(20,18,31,0.58);
+  --fg-4: rgba(20,18,31,0.42); --fg-inv: #ffffff;
+  --accent-hover: var(--purple-700);                /* purple-300 fails as text on white */
+  --success: #15803d; --warning: #b45309; --danger: #dc2626; --info: #1d4ed8;  /* B2 */
+  --divider: rgba(20,18,31,0.10); --divider-strong: rgba(20,18,31,0.18);
+  --hairline: rgba(20,18,31,0.06);
+  --grad-hero: radial-gradient(ellipse 120% 80% at 50% 0%,
+    rgba(108,92,231,0.14) 0%, rgba(108,92,231,0.05) 35%, transparent 70%);
+  --shadow-card: 0 2px 10px rgba(20,18,31,0.08);
+  --shadow-elev: 0 12px 40px rgba(20,18,31,0.14);
+  --shadow-glow: 0 0 0 1px rgba(108,92,231,0.30), 0 12px 40px rgba(108,92,231,0.15);
+  --shadow-inset: inset 0 1px 0 rgba(255,255,255,0.6);
+}
+```
+
+Purple ramp, blue ramp and tyre colors stay identical (they are identity colors). **B3** is NOT solved by swapping `--tire-hard` (HARD is white-banded in real F1) — instead every compound chip gets a permanent `border-hairline` (one-line change wherever compound pills render, e.g. `App.tsx:46-53` and the dashboard `CompoundLegend`), which is invisible-ish in dark and load-bearing in light. `::selection` (purple-600 bg + white text) passes in both themes — untouched.
+
+**(b) Theme state — `stores/ui.ts`** (extend the existing persisted store, NOT a new hook file):
+
+```ts
+theme: 'dark' | 'light'          // default 'dark' — brand-first, both sibling sites are dark
+toggleTheme: () => void
+```
+
+Two-state on purpose (no 'system'): both brand surfaces are dark-only, so dark is the identity default, and a two-state toggle keeps CSS single-sourced. If 'system' is ever wanted, it resolves inside the store/subscription — the CSS below never changes.
+
+**(c) DOM stamping + interplay rule.** Single source of truth = the `data-theme` attribute; **no `@media (prefers-color-scheme)` blocks in app CSS, ever** (avoids the two-writers problem). Wiring:
+- `app/providers.tsx`: subscribe once — `useUiStore` selector for `theme`, effect sets `document.documentElement.dataset.theme = theme`. ~6 lines in `Providers`.
+- **FOUC guard** — `webapp/index.html`: 3-line inline script before the module script: `try { const t = JSON.parse(localStorage.getItem('f1sl.ui')).state.theme; if (t) document.documentElement.dataset.theme = t } catch {}` (zustand/persist stores `{state:{...},version}` under `f1sl.ui`, see `stores/ui.ts:21`). Without it, a light-theme user gets one dark frame per load.
+
+**(d) Toggle control — new `components/ThemeToggle.tsx`, mounted inside `app/Header.tsx:22`** (after `{children}`, right cluster) so every routed page gets it for free. lucide `Sun`/`Moon` (lucide-react already a dep, `package.json:40`), ghost `Button` size sm, icon-only with `aria-label="Switch to light/dark theme"` (baseline-ui MUST), icon swap ≤150ms opacity+rotate, `motion-reduce:transition-none`. Note: `/` (temporary theme-preview `App.tsx`) renders no Header — it inherits the toggle when the real Home lands (separate polish PR); acceptable gap.
+
+**(e) ECharts (B4) — the single biggest cost.** Refactor `charts/echartsTheme.ts` to `buildEchartsTheme(mode: 'dark' | 'light')` with two const palettes (light: fg/line/hairline → the rgba(20,18,31,…) family, tooltip bg `#ffffff`, title `#14121f`; series palette unchanged). `charts/registerEcharts.ts:10` registers both `'f1'` and `'f1-light'`. New 4-line `useChartTheme()` (in `charts/registerEcharts.ts`) returns the theme name from the ui store. Update the three consumption sites — `charts/Gauge.tsx:119`, `features/dashboard/components/ChannelChart.tsx:223`, `features/dashboard/components/LapChart.tsx:229` — to `theme={chartTheme} key={chartTheme}` (keyed remount; toggling is rare, remount is fine). `LapChart.tsx:14` also imports the raw `echartsTheme` object — route that through the mode-aware builder.
+
+**(f) Verify.** Contrast spot-checks (fg-3 on bg-3 ≥ 4.5:1; purple-600 as text only ≥ 18px on light, else purple-700) + full-page screenshots of Dashboard in both themes on the golden session.
+
+**Effort: M-L (~1 day).** (a)-(d) ≈ 3h · (e) ≈ 3-4h · (f) ≈ 1-2h. Informed by: `frontend-design` (theme-as-token-swap), token audit above.
+
+---
+
+## 3. Item 2 — Rail redesign (de-slop the sidebar)
+
+### Analysis — why it reads "typical-LLM"
+
+`Rail.tsx` today: a bare flat list starting at the very top of the viewport (no brand block), uniform `gap-1` items, active state = a flat solid `bg-bg-4` pill (`Rail.tsx:16`), ~90 lines of hand-rolled generic 20px SVGs (`Rail.tsx:36-101`), and a full-width centered chevron button at the bottom (`Rail.tsx:250-260`) — the exact default an LLM emits for "sidebar". Zero brand vocabulary, while the docs sidebar (`docs.css:301-385`) and landing nav (`landing.css:35-78`: active = purple-300 + glowing gradient underline; logo = Space Grotesk 600 15px) already define what F1 StratLab navigation looks like.
+
+### Redesign spec
+
+Widths: 232px expanded / 76px collapsed (nudged from 220/72 for the new left indicator + brand block). Width still snaps, never transitions (layout prop — `Rail.tsx:148-151` rationale stands). Acrylic law unchanged: `bg-bg-2/70 backdrop-blur-md`, chrome only.
+
+```
+┌────────────────────────────┐
+│ ◆ F1 StratLab          h-14│  ← brand block, border-b hairline, aligns with Header h-14
+├────────────────────────────┤     → one continuous chrome line across rail + header
+│  Home                      │
+│                            │
+│  TELEMETRY ·               │  ← section label: 10px SG 600 uppercase tracking-widest
+│  ▍Dashboard                │     text-fg-4 + 4px purple-500 dot (docs.css:328-334)
+│   Comparison               │  ← active: grad-purple-soft wash + 2px purple-400 left bar
+│   Lab                      │     w/ soft glow (docs.css:352-364); icon → purple-300
+│                            │
+│  PIT WALL ·                │
+│   Strategy                 │
+│   Race                     │
+│                            │
+│  ASSIST ·                  │
+│   Chat                     │
+│  (flex-1 spacer)           │
+├────────────────────────────┤
+│ v0.9        [⇤]        p-3 │  ← mono version tag (fg-4) + icon-only collapse button
+└────────────────────────────┘
+```
+
+Concrete changes, all in `webapp/src/app/Rail.tsx` (full rewrite, same public surface):
+
+1. **Brand block** (new, top): `h-14 border-b border-hairline px-4 flex items-center gap-2.5`. Mark = 24px `rounded-md` square, `bg-[image:var(--grad-purple)]`, "F1" in mono 700 10px white (pure CSS, no asset). Wordmark "F1 StratLab" `font-display font-semibold text-[15px] tracking-tight` (landing `.logo`, `landing.css:52-58`); hidden when collapsed (mark centers). Links to `/`.
+2. **Grouped nav** (docs-sidebar grammar): Home standalone, then sections **Telemetry** (Dashboard, Comparison, Lab), **Pit wall** (Strategy, Race), **Assist** (Chat). Section label per the diagram; when collapsed, labels swap to a `mx-3 border-t border-hairline` rule so grouping survives at 76px.
+3. **Items**: `h-9 rounded-lg px-3 gap-3 text-sm relative`. Inactive: `text-fg-3` (icon `text-fg-4`) → hover `text-fg-1 bg-fg-1/[0.04]` — **use `fg-1`-based alpha, not `white/…`, so the hover works in both themes** (white in dark, near-black in light). Active: `text-fg-1` + `bg-[image:var(--grad-purple-soft)]` + absolutely-positioned left bar `left-0 inset-y-2 w-0.5 rounded-full bg-purple-400 shadow-[0_0_8px_rgba(108,92,231,0.6)]`, entering via `scale-y` 150ms ease-out (compositor-only, `motion-reduce` guarded). The route-literal typing constraint (`Rail.tsx:8-14`) stays — but rendering a different child per state needs TanStack Link's **children-as-function** form (`{({ isActive }) => …}`) instead of `activeProps` classNames; `to` remains a literal at each call site.
+4. **Icons → lucide-react** (delete `Rail.tsx:36-101`): `House`, `LayoutDashboard`, `ArrowRightLeft` (Comparison — already its icon in `DashboardPage.tsx:117`, keep consistent), `FlaskConical`, `Crosshair` (Strategy), `Flag` (Race), `MessageSquare` (Chat). `size-[18px]`, `strokeWidth={1.75}`, `aria-hidden`. −90 LOC.
+5. **Footer**: replace the full-width centered button (`Rail.tsx:250-260`) with `p-3 border-t border-hairline flex items-center justify-between`: mono `v0.9` tag (`text-[10px] text-fg-4`, hidden collapsed; docs `sidebar-footer` nod, `docs.css:373-385`) + icon-only ghost `Button` `size-8` using lucide `PanelLeftClose`/`PanelLeftOpen`, existing `aria-label`s kept, wrapped in the existing `Tooltip`.
+6. **Motion budget** (baseline-ui): color transitions 150ms + the active-bar scale — nothing else. No width animation, no layout props, ≤200ms everywhere.
+7. **Collapsed state**: icons centered in a `size-9` hit area; active state = wash on that square + left bar retained; `title` tooltip mechanism (`Rail.tsx:132-135`) kept.
+
+Also touch: `app/Rail.test.tsx` (labels, collapse aria, new section labels). No new deps; `useUiStore.railCollapsed` contract unchanged.
+
+**Effort: M (~4h incl. screenshot loop).** Informed by: `baseline-ui` (aria on icon-only buttons, compositor-only motion, fixed z-scale — `Z.rail` unchanged), docs sidebar (`docs.css:301-385`), landing nav (`landing.css:35-78`), ui-skills *navigation* category (grouped rail + brand block + collapse pattern).
+
+---
+
+## 4. Item 3 — Typography + text-colour rulebook
+
+### Audit verdicts
+
+- **Alignment**: landing centers section heads (`landing.css:309-313`) — marketing grammar only. The docs site is left-aligned. **The app left-aligns: the Dashboard's left "Dashboard" H1 (`Header.tsx:21`) + left `SectionHeader`s (`features/dashboard/components/SectionHeader.tsx:11-15`) are correct.** Centered text in-app is reserved for empty/zero states (`EmptyState.tsx:24`) and modal confirmations.
+- **Eyebrow grammar** is the brand's signature type move (landing `colors_and_type.css:195-202`: uppercase, 0.18em, 600): the app reuses it in neutral form (fg-3 + purple tick) — correct, but the tracking is silently wrong app-wide (D1).
+- **Colour**: the landing colours *only* key numbers/words in purple-300 inside neutral prose, separators in fg-4 (`components/App.jsx:216-225`), and uses gradient text exactly once, on the hero H1 (`landing.css:277-282`). The app must keep colour that scarce.
+
+### The rulebook (app-wide, reusable)
+
+1. **Fonts**: Space Grotesk (`font-display`) = titles/headers. Inter (`font-body`) = UI + prose. JetBrains Mono = every number that identifies or measures (lap times, gaps, confidence, versions), always with `tabular-nums`.
+2. **Alignment**: left, always. Exceptions: `EmptyState` bodies and modal confirmations may center. Never center a section title or page H1 in-app.
+3. **In-app scale**: page title 18px SG **600** (Header) · section header 14px SG 500 uppercase eyebrow fg-3 + purple tick (`SectionHeader`) · card title 14px SG 500 fg-1 sentence-case (`ChartCard.tsx:72`) · stat label 12px uppercase eyebrow fg-3 (`StatCard.tsx:39`) · body 14px Inter fg-2 · caption 12px fg-3/fg-4. Rendered-markdown content: 24/20/18 (`Markdown.tsx:13-19`). Hero scale (≥48px) is reserved for the future real Home — one marketing moment per app.
+4. **Eyebrows**: uppercase + brand tracking **0.18em** + font-medium. Neutral variant (fg-3) for section/stat labels; brand variant (purple-300) reserved for hero moments, max one per view (baseline-ui: one accent per view).
+5. **Weights**: SG 600 for titles ≥ 18px, 500 below; 700 only for stat values and hero. Never bold body prose for emphasis — restructure instead.
+6. **Text is neutral by default** (fg-1 → fg-4 by hierarchy). Colour is a signal, never decoration:
+   - **purple** = interactive states + THE one key number/word of a view (landing hero-meta pattern);
+   - **team colours** = driver identity only (names, series, dots — `features/dashboard/lib/drivers.ts`);
+   - **tyre colours** = compounds only; **semantic** (success/warning/danger/info) = state only;
+   - **blue ramp** = neutral data series (first slot of `echartsTheme.ts:29`); **fg-4** = separators (`·`).
+7. **Never gradient text in-app** (the landing hero is the single sanctioned exception; baseline-ui bans it outright).
+8. `text-balance` on headings, `text-pretty` on paragraphs (base layer already balances h1-h3, `index.css:74-79`).
+9. Tracking comes from brand tokens via Tailwind theme — no `tracking-[…]` arbitrary values (see D1).
+
+### Deviations found (fix in this round)
+
+| # | Deviation | Where | Fix |
+|---|---|---|---|
+| D1 | Brand `--tracking-widest` (0.18em, `tokens.css:108`) never mapped into `@theme` → Tailwind default 0.1em ships in every eyebrow; `App.tsx:22,58` hand-rolls `tracking-[0.18em]` — two trackings coexist | `index.css:9-60` (missing map); consumers `SectionHeader.tsx:12`, `SelectorsToolbar.tsx:26`, `StatCard.tsx:39`, `DataTable.tsx:134` | Add `--tracking-wide: var(--tracking-wide); --tracking-widest: var(--tracking-widest);` (+ tight/tighter/tightest) to `@theme inline`; delete arbitrary values in `App.tsx` |
+| D2 | `tracking-wide` on table headers = Tailwind 0.025em vs brand 0.04em | `DataTable.tsx:134` | Covered by D1 |
+| D3 | Page title SG **regular** `text-lg` — under-weighted vs brand h-scale (landing titles are 600) | `Header.tsx:21` | `font-display text-lg font-semibold tracking-tight text-fg-1` |
+| D4 | Temporary Home uses marketing scale in-app | `App.tsx:25` | Dies with the real Home redesign (separate PR) — no action here |
+| D5 | Chart title colour hardcoded white | `echartsTheme.ts:32` | Absorbed by item 1(e) |
+
+**Effort: S (~2h).** D1+D2+D3 are ~10 lines total plus a `tracking-[` sweep; the rulebook lives in this doc and gets linked from the webapp README. Informed by: `baseline-ui` (typography section), landing + docs audit above.
+
+---
+
+## 5. Item 4 — Onboarding (future work, LexFlow-style)
+
+Not built this round — recorded now so keys/mount points don't collide later.
+
+- **Keys** (namespaced like the store, `f1sl.*`): `f1sl.welcomed` (welcome modal seen) · `f1sl.tour.<page>` (per-page coach marks, e.g. `f1sl.tour.dashboard`). Mirrors LexFlow's `lexflow.welcomed` / `onboarded` / `tutorial-completed` gating.
+- **Phase 1 — WelcomeModal (cheap, ship with a polish PR):** built on the existing `components/Modal.tsx`; mounts in `app/Shell.tsx` beside `<Outlet/>`, gated on `!localStorage['f1sl.welcomed']`. Content: brand mark + one-line pitch + three bullets (Dashboard / Strategy / Chat) + primary CTA **"Open a sample session"** deep-linking `/dashboard?year=2023&gp=Monaco&session=R&drivers=VER,LEC` (the golden offline-cached session) + ghost "Skip". Both paths set the key. Effort S (~2h) when scheduled.
+- **Phase 2 — per-page spotlight tour:** anchor registry + Popover-based coach marks (or driver.js — decide then), gated per `f1sl.tour.<page>`, triggered on first visit of each migrated tab. Defer until Strategy/Race/Chat exist — a tour of "coming soon" pages is noise.
+- **Harness note:** the screenshot/E2E scripts must seed these keys in `addInitScript` (the FRONTEND_VISUAL_VERIFICATION pattern) or every capture shows the modal.
+
+**Effort now: 0 (doc only).** Informed by: LexFlow first-run gating pattern.
+
+---
+
+## 6. Build order & effort summary
+
+| Order | Item | PR | Effort | Depends on |
+|---|---|---|---|---|
+| 1 | §4 rulebook fixes (D1-D3) | `fix(webapp): map brand tracking tokens + header weight` | S (~2h) | — |
+| 2 | §3 rail redesign | `feat(webapp): redesign app rail` | M (~4h) | 1 (correct tracking for section labels) |
+| 3 | §2 light theme + toggle | `feat(webapp): light theme + header toggle` | M-L (~1 day) | 2 (rail is tokens-only → theme-proof by construction; style it once) |
+| 4 | §5 onboarding | future sprint | S later | real Home + ≥2 migrated tabs |
+
+Every PR: screenshot-verify on 2023 Monaco R (VER,LEC), dark first, both themes after PR 3; commit explicit paths (never `-A`), no repo-wide prettier (Windows autocrlf gotcha).
+
+**Key files:** `webapp/src/app/{Rail,Header,Shell,providers}.tsx` · `webapp/src/styles/tokens.css` · `webapp/src/index.css` · `webapp/src/stores/ui.ts` · `webapp/src/charts/{echartsTheme,registerEcharts}.ts` + `Gauge.tsx` · `webapp/src/features/dashboard/components/{SectionHeader,SelectorsToolbar,ChannelChart,LapChart}.tsx` · `webapp/src/components/{StatCard,DataTable,Modal}.tsx` · `webapp/index.html` — references `f1stratlab-web/{colors_and_type,landing}.css` + `docs/styles/docs.css:301-385`.

--- a/docs/migration/design-specs/chat-voice.md
+++ b/docs/migration/design-specs/chat-voice.md
@@ -1,0 +1,171 @@
+# AI Chat + Voice — Design-First Spec (issues #39 + #40)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit AI Chat + Voice functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared vocabulary from `strategy.md`/`model-lab.md` (`ActionBadge`, `CompoundPill`, `ConfidenceDial`, `NlpMessageCard`, state tiers, deep-links-never-auto-fire). Sources: `frontend/pages/chat.py` (532), `frontend/components/chatbot/*` (~1.5k), `frontend/components/voice/*` + `streamlit_audio_viz` (React+ogl orb), `frontend/services/{chat_service,voice_api}.py`, `frontend/utils/{chat_state,chat_navigation,report_storage}.py`, `backend/api/v1/endpoints/{chat,voice}.py`, `backend/services/chatbot/chat_engine.py`, `backend/models/tool_schemas.py`, MIGRATION_PLAN §6.6/§6.7/§6.8/E4/E5/E8/W7/W8, `st_6_AI_Chat.png`.
+
+## 1. Purpose & the job
+
+Chat is the **conversational front door to the entire model family**: an analyst that CALLS the real tools. The backend chat engine is an MCP client exposing 14 tools (6 predictors + orchestrator + RAG regulations + FastF1 telemetry/lap-times/compare/race-data + listings) to the LLM via OpenAI `tools=`; the SPA speaks **REST/SSE only** and never touches MCP. Its job: *"Ask anything about a race moment in plain language, watch the system pick and run the right instrument, and get the evidence (metrics, strategy cards, INLINE charts) plus a plain-English read - then take the whole session home as a Markdown report."* Voice is the same analyst hands-free, fronted by the audio-reactive orb - the demo's emotional signature. This surface is the TFG agent work made tangible; it must feel like a serious Claude/ChatGPT-class client, not a widget.
+
+**FIVE KEY DISCOVERIES in the Streamlit source** that drive this design:
+1. **Stop is cosmetic today.** The Stop button only sets `chat_should_stop`, checked *between* SSE events (`chat.py:337-339`); the HTTP stream and the LLM keep running server-side. The SPA's `postStream` + AbortController + `reader.cancel()` (`sse.ts:54-57`) actually tears the connection down - a real Stop, free.
+2. **The status-poller thread is a Streamlit workaround.** A daemon thread polls `GET /chat/status` every 1 s to relabel the spinner (`chat.py:99-128`) because Streamlit can't consume the `stage` SSE events mid-rerun. The stream already carries them (`chat_engine.py:158-314`) - the SPA renders stages inline and drops the poller AND the endpoint dependency.
+3. **"Rename" doesn't exist, and saved chats collide.** §6.6 lists "saved-chat list + rename"; `chat_sidebar.py` has no rename UI, and chats are keyed by an auto-generated *name* (first 30 chars of message 1, `chat_state.py:159-197`) - two chats opening with the same words silently overwrite each other. The SPA stores id-keyed records with a `title` field + real inline rename: satisfies the parity row AND fixes the collision bug.
+4. **The voice loop is tool-less.** `POST /voice-chat` goes straight to the LLM (`voice.py:257-345`, no MCP dispatch): "tyre status for VER lap 30" *typed* runs the TCN; *spoken*, it gets improvised prose. The three building blocks (`/transcribe`, `/tool-message-stream`, `/synthesize`) already exist - the SPA can compose a tool-aware voice loop client-side (§7.1).
+5. **The orb hot-mics on mount.** `useAudioLevel.start()` fires as soon as the orb renders (`AudioOrb.tsx:53-57`) - the mic is live with no visible indicator. The SPA requests mic permission only on entering Voice mode and shows an explicit listening state.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+### 2.1 Chat (§6.6)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | Sidebar Text/Voice toggle (`chat_sidebar.py:38-58`) | KEEP | Segmented `Tabs` at sidebar top; mode in URL (`?mode=voice`). |
+| 2 | New Chat button (`:61-71`) | KEEP | Primary `Button`; also `⌘/Ctrl+Shift+O`. |
+| 3 | Saved-chat list, active highlight, load, delete-current (`:74-113`) | KEEP + FIX | Id-keyed `ConversationList` (Discovery 3): inline rename (pencil / double-click), per-row delete with `Toast`+undo, active ring. Auto-title from first message preserved (`chat_state.py:176-180` logic ported). |
+| 4 | Reports(n) expander: list + download + delete + clear all (`:116-145`) | KEEP | `ReportsPanel` disclosure; rows = timestamp · chat title · size, download + delete actions. Cap 20 (parity, `report_storage.py:50-52`). |
+| 5 | Empty state: hint line + 4 example-prompt chips (`chat_history.py:199-236`) | **KEEP VERBATIM** | Same copy + behavior (click = send that exact prompt). Chips: Tyre status → "Tyre status for VER at lap 30 in Bahrain" · Pace prediction → "Predict pace for LEC lap 25 Monaco" · FIA regulation → "What do articles 55 and 57 say about safety car procedures?" · Full strategy → "Full strategy for NOR lap 40 Australia risk 0.7". Hint: "Mention a **driver**, **GP**, and **lap** to trigger an analysis, or try an example below." Chip click auto-sends (explicit in-page action - allowed; deep links are not, §5.4). |
+| 6 | `st.chat_input` Enter-to-send (`chat_input.py:31-37`) | KEEP + IMPROVE | `Composer`: autosize textarea, Enter=send, Shift+Enter=newline, disabled-with-Stop while streaming. |
+| 7 | Image attach behind expander, png/jpg/jpeg → base64 data-URI (`chat_input.py:20-28`, `chat_service.py:23-48`) | KEEP + IMPROVE | Paperclip popover with `FileDrop` + paste-from-clipboard + drag-anywhere-onto-thread; preview `AttachmentChip` with remove. Client-side downscale to ≤768 px JPEG before send (the Qwen3-VL sizing rationale from `chat_navigation.py:85-101`, now client-side). |
+| 8 | Latest user image rides along on text-only follow-ups (`chat.py:297-306`) | KEEP | Subtle but load-bearing: `_last_user_image` port in the send builder, so "and what about the braking zones?" still sees the screenshot. |
+| 9 | SSE streaming, token-by-token bubble (`chat.py:309-369`, `chat_service.py:311-377`) | KEEP (free upgrade) | `useChatStream` on `postStream` (`lib/api/sse.ts` - already built). Tokens append to a live `Markdown` bubble; no rerun-per-token. |
+| 10 | Stage narration via /chat/status poll thread (`chat.py:33-52,99-128`) | KEEP labels / DROP poller | `StageTicker` renders the inline `stage` events with the SAME humanized copy map (`_STAGE_LABELS`, ported verbatim - it's good copy). Poller + `X-Request-Id` plumbing dropped (Discovery 2; keep sending a uuid header for backend logs). |
+| 11 | Stop button, partial kept + "_[Response stopped by user]_" marker (`chat.py:68-96,349-350`) | KEEP + FIX | Real abort (Discovery 1). Same marker text appended to the persisted partial. Esc also stops. |
+| 12 | Tool-call badge per invoked tool (`tool_result_renderer.py:38-46`) | KEEP + IMPROVE | `ToolBadge`: lucide icon per tool family + label + state (running pulse → done / error). Appears at `calling_<tool>` stage, resolves when `tool_result` lands - the badge IS the tool timeline. |
+| 13 | Tool result renderers by display_type: metrics / strategy_card / table / text / chart (`tool_result_renderer.py:331-337`) | KEEP (reshaped) | `ToolResultCard` switches on `display_type` (§6.3). strategy_card renders with the **shared Strategy vocabulary**: `ActionBadge` + confidence + scenario scores + reasoning disclosure - a mini `DecisionCard`, same visual language as `/strategy`. |
+| 14 | Inline charts for lap-times / telemetry / compare / race-data, Plotly (`chart_builders.py`) | KEEP (re-engined) | `InlineChart` + TS option-builder dispatcher → ECharts (F1-1, §6.3). Compound-tinted markers, pit-stop markLines, pit-lap outlier masking all ported as pure lib fns with tests. |
+| 15 | Graceful tool-error: red error card + LLM plain-English follow-up (`tool_result_renderer.py:244-271`, dossier #36) | KEEP (both halves) | `ToolErrorCard` (danger left edge, tool name, message) for the `{"error": …}` envelope; the token stream that follows IS the LLM explanation - render both, never swallow either. |
+| 16 | Report generation → save + Markdown download; reports in sidebar (`chat.py:382-423`, `chat_service.py:381-426`) | KEEP + IMPROVE (=E4) | One click: header action "Generate report" → button spinner → saves to Reports + triggers download + `Toast`. Two-step dance dropped (E4 accepted). Same backend call: `POST /tool-message` with the fixed summary instruction, temp 0.4, max_tokens 4000. |
+| 17 | System prompt + injected F1 context (`chat_system_prompt`, `chat_f1_context`) | KEEP (clarified) | The real system prompt lives server-side (`chat_engine._SYSTEM_PROMPT`); the session key is vestigial (always ""). SPA keeps only `context{}` on the wire - held by `ContextCapsule` (§5.4) and the chat record. |
+| 18 | LLM health warning banner (`chat.py:450-455`) | KEEP (demoted) | `GET /chat/health` on mount (Query, staleTime 30 s) → amber "LLM offline" `Pill` in the header; non-blocking, composer stays usable. |
+| 19 | History/saved/reports lost on refresh | IMPROVE (accepted §6.8) | Chat slice persisted (§6.5). Voice stays ephemeral (parity). |
+| 20 | Cross-page "Ask AI" pending-message flow, auto-send (`chat_navigation.py:15-72`, `chat.py:167-223,515-527`) | KEEP (re-gated) | Deep-link INTO chat with context + optional image; lands as prefilled, focused composer + `ContextCapsule` - **one Enter to fire, never auto-send** (§5.4; documented deviation, consistent with the sibling-spec rule that deep links never auto-fire LLM calls). |
+| 21 | Empty-SSE defensive fallback message (`chat.py:358-363`) | KEEP | If a stream ends with no tokens and no tool_result, render the same "no response received" notice instead of a blank bubble. |
+| 22 | Injected bubble/sidebar CSS, python-markdown rendering (`chat_history.py:21-193`, `chat_message.py`) | DROP | `Markdown` component + tokens carry it; zero injected CSS. |
+
+### 2.2 Voice (§6.7)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 23 | Audio-reactive orb, React+ogl Iridescence shader, states idle/recording/processing/playing (`streamlit_audio_viz/frontend/src/*`) | **KEEP - lift verbatim** | It is already React+TS. Drop the `streamlit-component-lib` bridge (`index.tsx`), keep `AudioOrb.tsx` + `Iridescence.tsx` + `useAudioLevel.ts` + `styles.css` as `features/chat/voice/orb/`. Delete the `console.log` debug (`AudioOrb.tsx:31-37`). Mic capture gated on explicit mode entry (Discovery 5) + visible LISTENING chip. `prefers-reduced-motion` → static gradient orb, level-driven only. |
+| 24 | Voice picker: curated 4-voice catalog, never calls the API (`voice_chat.py:16-22,292-313`) | KEEP + FIX row | §6.7 says "picker from `GET /voice/voices`" but Streamlit hardcodes `VOICE_CATALOG`. SPA: curated 4 as the default list (same ids + descriptions), "All voices…" expands from the real endpoint. Row satisfied for the first time. |
+| 25 | Mic record via `st.audio_input`, dedupe vs `last_processed_audio` (`voice_input.py:14-65`) | IMPROVE | `MicBar`: 44 px record toggle + live mono timer + cancel; MediaRecorder (webm/opus - backend accepts `.webm`, `voice_api.py:274-280`). Dedupe hack dies with Streamlit reruns. |
+| 26 | Full loop `POST /voice-chat` (STT→LLM→TTS), voice form field (`voice_api.py:194-246`) | KEEP (parity path) | `useVoiceSession` state machine drives it. Tool-aware composed loop is §7.1 (needs a 3-LOC backend additive for voice selection). |
+| 27 | Exchange history: transcript bubble + reply bubble + MP3 player, latest autoplays (`voice_chat.py:94-181`) | KEEP (reshaped) | `VoiceExchangeCard` in the same thread grammar: transcript (user), reply (assistant), replay button, `processing_time` chip. One shared `HTMLAudioElement` + analyser feeds the orb; autoplay latest only. |
+| 28 | Services-ready guard: poll /voice/health up to 60 s with warming copy (`voice_chat.py:256-289`) | KEEP + IMPROVE | Warmup panel over the orb: elapsed + "warming voice services (first launch downloads models)…", 2 s poll; record disabled until `stt_ready && tts_ready`. Failure → error card with the health JSON behind a disclosure. |
+| 29 | Playing badge tied to `is_playing`, reset on next recording (`voice_chat.py:198-236,479-485`) | KEEP | `useVoiceSession` status drives a single state chip (LISTENING / TRANSCRIBING / THINKING / SPEAKING) + orb state - one source of truth, no flicker. |
+| 30 | Voice report button (history → chat shape → generate_report) (`voice_chat.py:316-366`) | KEEP | Same one-click report treatment as #16. |
+| 31 | Clear history (`voice_chat.py:520-532`) | KEEP | Ghost button + confirm. Voice history ephemeral (§6.8 parity). |
+| 32 | Page-level iframe CSS nukes for the orb (`voice_chat.py:396-432`) | DROP (cause gone) | The orb is a native component now; no iframe, no blanket CSS overrides. |
+
+Zero functional loss; three deliberate re-gatings (#20 no auto-fire, #24 real endpoint, #23 mic consent), each documented here.
+
+## 3. Layout & IA
+
+Route `/chat` (stub exists, `router.tsx:70-74`). One page, two modes; the sidebar and thread grammar are shared so switching modes feels like changing instruments, not pages.
+
+```
+┌ SIDEBAR (acrylic; Sheet overlay <1024px) ┐┌ THREAD ─────────────────────────────────────┐
+│ [ 💬 Text ┃ 🎙 Voice ]  (segmented)      ││ header: "AI Chat"  (LLM offline·pill)       │
+│ [+ New chat]                             ││        [⤓ Generate report] (≥2 messages)   │
+│ HISTORY (3)                              ││                                             │
+│ ▸ Tyre status for VER at lap 3…  ✎ ⌫    ││ ┌ user ────────────────────── [img chip] ┐  │
+│   Predict pace for LEC lap 25…           ││ │ Full strategy for NOR lap 40 Australia │  │
+│   What do articles 55 and 57…            ││ └─────────────────────────────────────────┘ │
+│ REPORTS (2) ▾                            ││ ┌ assistant ──────────────────────────────┐ │
+│   07/14 09:12 · Tyre status…  ⬇ ✕       ││ │ [⛭ Recommend Strategy ●done]  ToolBadge │ │
+│                                          ││ │ ┌ mini DecisionCard ──────────────────┐ │ │
+│ (voice mode: same sidebar,               ││ │ │ [PIT_NOW] conf 82% · scenarios list │ │ │
+│  history list stays text-chats)          ││ │ │ ▸ reasoning                        │ │ │
+└──────────────────────────────────────────┘│ │ └────────────────────────────────────┘ │ │
+                                            │ │ Streamed prose (Markdown, live)…       │ │
+  EMPTY STATE (no messages):                │ └─────────────────────────────────────────┘ │
+  hint line + 4 example chips (2×2),        │ streaming: StageTicker "Running the full    │
+  verbatim copy (§2.1 #5)                   │ strategy orchestrator (5 agents + LLM)..."  │
+                                            │ ┌ COMPOSER ───────────────────────────────┐ │
+                                            │ │ [📎][img ×] Ask me anything about F1…   │ │
+                                            │ │            [▸ Send] / [⏹ Stop] while ⚡ │ │
+                                            │ └─────────────────────────────────────────┘ │
+                                            └─────────────────────────────────────────────┘
+VOICE MODE (same shell; thread center swaps):
+│   ╭────────╮   state chip: ● LISTENING / TRANSCRIBING / THINKING / SPEAKING │
+│   │  ORB   │   voice: [Aria - US female, conversational ▾]  (All voices…)  │
+│   ╰────────╯   warming overlay until stt_ready && tts_ready                │
+│   VoiceExchangeCards (transcript → reply · ▶ replay · 3.2s chip)           │
+│   MicBar: [ ● Record  00:07 ]  [✕ cancel]        [⤓ report] [⌫ clear]     │
+```
+
+**States:** Empty (hint + 4 chips; composer focused) · Streaming (StageTicker narrates stages; ToolBadge pulses on `calling_*`; tokens fill the bubble; composer → Stop; thread `aria-live=polite`) · Tool-error (ToolErrorCard + the streamed LLM explanation below it) · Transport error (Toast + inline "retry last message" on the failed bubble; input preserved) · Rate-limited (429 → Toast "Chat is limited to 20 requests/min"; composer stays) · LLM offline (amber header pill; send still attempts) · Voice warming (orb dimmed + progress copy; record disabled) · Voice error (per-stage: transcription failed → retry keeps the recording; TTS failed → text reply still shown with a "couldn't speak this" note) · Empty voice (orb idle-breathing + "hold Record and ask about a race moment").
+
+## 4. Components
+
+**Reuse as-is:** `Markdown` (message prose + reports), `Pill`, `Toast`, `FileDrop`, `Button`, `Card`, `Tabs` (mode toggle), `Tooltip`, `Skeleton`, `EmptyState`, `DataTable` (table display_type), `Sheet` (in `Modal.tsx` - mobile sidebar), **`postStream`** (`lib/api/sse.ts` - built for exactly this), ECharts + `F1_THEME` + `tireColors`, `lib/drivers.ts` (team colours in chart series).
+
+**Shared vocabulary from sibling specs (consume, don't fork):** `ActionBadge` + `ConfidenceDial` + `CompoundPill` (strategy.md §4) render the `strategy_card` display type - `recommend_strategy` / `predict_tire` / `predict_pit` results in chat look EXACTLY like their Strategy/Lab counterparts at `size="sm"`. `NlpMessageCard` (model-lab.md §4) upgrades `analyze_radio` results (display_type `table` stays as fallback). One model family, one visual language, third surface.
+
+**New shared (build here):**
+- `MessageThread` - `role=log` scrollable column of message groups; sticky day dividers; auto-scroll with "jump to latest" affordance when the user has scrolled up; `content-visibility:auto` on bubbles (no virtualization needed at these lengths).
+- `ToolBadge` - pill w/ lucide icon per tool family (Gauge=pace, CircleDot=tire, Swords=situation, Wrench=pit, RadioTower=radio, Scale=regulations, Brain=strategy, LineChart=telemetry family, List=listings) + running/done/error state. Also wanted by Model Lab's run header long-term.
+- `InlineChart` - lazy-mounted ECharts host for chat bubbles: fixed 340 px height, theme'd, toolbox save-image, `IntersectionObserver` render-on-visible (charts below the fold cost nothing).
+
+**Feature-local (`webapp/src/features/chat/`):**
+- `ChatPage.tsx` (owns `?mode&c`, mounts sidebar/thread/composer) · `search.ts` (`mode: 'text'|'voice'` default text; `c?: chatId`) · `store.ts` (persisted chat slice §6.5) · `useChatStream.ts` (postStream → typed event reducer: stage/tool_result/token/done; AbortController owner).
+- `components/`: `ChatSidebar` (+`ConversationList`, `ReportsPanel`), `MessageBubble`, `StageTicker`, `ToolResultCard` (display_type switch), `ToolErrorCard`, `Composer` (+`AttachmentChip`, `ExamplePrompts`), `ContextCapsule`.
+- `charts/`: `buildLapTimesOption.ts`, `buildTelemetryOption.ts`, `buildCompareOption.ts`, `buildRaceDataOptions.ts` (returns TWO options - positions + lap times, parity with `build_race_data_figure`), `index.ts` dispatcher `buildToolChartOptions(toolName, data): EChartsOption[] | null`. Pure, unit-tested against captured payload fixtures. Reuse `features/dashboard/components/channels.ts` series styling for the telemetry panes and the Comparison delta fill treatment for `compare_drivers` - do not invent a fourth chart dialect.
+- `voice/`: `VoicePanel.tsx`, `orb/` (lifted `AudioOrb`+`Iridescence`+`useAudioLevel`), `VoiceOrb.tsx` (thin wrapper mapping `useVoiceSession` status → orb props), `MicBar.tsx`, `VoicePicker.tsx`, `VoiceExchangeCard.tsx`, `useVoiceSession.ts` (state machine + MediaRecorder + playback analyser), `voiceStore.ts` (ephemeral).
+- Promote to `lib/`: `lib/lapMarks.ts` - `detectPitLaps()` + `maskPitLapOutliers()` ported pure from `chart_builders.py:66-151,471-490` with unit tests (stint-increment first, compound-change fallback; median×1.15 outlier mask). `lib/api/chat.ts` + `lib/api/voice.ts` types.
+
+## 5. Interactions & flows
+
+1. **Send** - Enter → optimistic user bubble (+image chip) → `useChatStream` fires POST `tool-message-stream` with history-before-this-message (the `_prepare_send_context` exclusion, trivial here) → `stage` events tick the StageTicker with the verbatim `_STAGE_LABELS` copy → `calling_<tool>` mounts a pulsing ToolBadge → `tool_result` renders the card/chart instantly (before the summary!) → `token`s stream the prose → `done` persists the turn + auto-titles a new chat. The tool card appearing *before* the LLM explanation is the correct dramaturgy: evidence first, narrative second - Streamlit already ordered it this way, the SPA makes it visible.
+2. **Stop** - Stop button or Esc → `abort()` → connection torn down (Discovery 1) → partial text kept + "_[Response stopped by user]_" → composer re-enabled. If a tool_result already landed, it stays.
+3. **Example chips** - click sends the verbatim prompt immediately (parity behavior; an explicit in-page click, not a deep link).
+4. **"Ask AI about this view" (E8, the product glue)** - other tabs call `navigate({to:'/chat'})` with a `pendingAsk` handoff written to the chat store (never URL - prompts/images don't belong in query strings): `{prompt, image?, context{year,gp,session,drivers,chart_type}, newChat?}`. Chat lands with a `ContextCapsule` chip row (GP · session · drivers, dismissible) + prefilled focused composer; **one Enter fires it**. Images come from ECharts `getDataURL()` client-side - the Plotly-kaleido server render (`chat_navigation.py:75-131`) dies. Capsule context rides as `context{}` on every subsequent send in that chat.
+5. **Report** - one click: button spins → `POST /tool-message` (fixed instruction, temp 0.4, max_tokens 4000) → saved to Reports + browser download + Toast (E4). Sidebar rows re-download anytime.
+6. **Chats** - New Chat snapshots current (auto-title) and opens fresh; switching loads instantly from the store; rename inline; delete with undo Toast. Active chat id in URL (`?c=`) → a conversation is shareable-in-place across refreshes.
+7. **Voice loop (parity path)** - Record (MediaRecorder, live timer) → stop → `useVoiceSession`: TRANSCRIBING → `POST /voice-chat` (multipart + `voice` field) → exchange card appended (transcript + reply) → SPEAKING: decode `audio_base64`, play through the shared audio element + analyser → orb reacts → idle. Errors per stage keep the recording for retry. 429 (6-cap / 12-min limit) → Toast with the budget.
+8. **Mode switch** - segmented toggle; both histories survive the switch (separate slices); mic permission requested on first Voice entry, orb shows LISTENING only while the analyser is actually running.
+9. **Keyboard** - Enter send · Shift+Enter newline · Esc stop · ⌘/Ctrl+Shift+O new chat · ↑ in empty composer edits your last message (recall). Thread is `role=log` + `aria-live=polite`; chips, badges and transport all real buttons.
+
+## 6. Data & migration notes
+
+**Chat endpoints** (`backend/api/v1/endpoints/chat.py`; all rate-limited capacity 10 / 20 per min):
+
+| Endpoint | Use |
+|---|---|
+| `POST /api/v1/chat/tool-message-stream` (:282) | THE chat call. Body `{text, image?: dataURI, chat_history[], context{}, model, temperature, max_tokens}` (+ optional `X-Request-Id` header, logs only). SSE events, in order: `stage {stage}` (keys: `preparing_tools`, `model_choosing_tool`, `calling_<tool>`, `summarizing_with_llm`, `composing_response` - label map ported verbatim from `chat.py:33-52` with the same sentence-case fallback for unknown keys) → optional `tool_result {tool_result:{tool_name, display_type, data, summary}}` → `token {token}` × N → `done {llm_model?, tokens_used?, error?}`. |
+| `POST /tool-message` (:244) | Non-streaming variant - report generation only. |
+| `GET /chat/health` (:43) | `{lm_studio_reachable}` → header pill. |
+| `GET /chat/status` (:233) | NOT used by the SPA (Discovery 2). Do not port the poller. |
+
+`display_type` contract (`tool_schemas.py:43-70`): metrics → `predict_pace`, `predict_situation` · strategy_card → `predict_tire`, `predict_pit`, `recommend_strategy` · table → `analyze_radio` · chart → `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data` · text → `query_regulations` (answer + source-articles disclosure), `list_gps`/`list_drivers` (chip lists), `get_lap_range` (one-liner), JSON fallback. Error envelope: `data == {"error": …}` (≤2 keys, `tool_result_renderer.py:244-250`) forces text → `ToolErrorCard`. **Type `data` tolerantly per family and always keep the JSON-disclosure fallback** - payloads are tool-shaped, not schema'd. One `tool_result` per turn today; type the store field as an array so a future multi-tool engine costs nothing.
+
+**Wire history:** `[{role:'user'|'assistant', type:'text'|'image'|'tool_result', content, timestamp}]` - keep the exact shape (backend `build_messages` compresses to the last 5 interactions server-side, `llm_service.py:397-421`). Improvement (verify against `build_messages` first): substitute `tool_result` content with its `summary` string on the wire - the LLM never consumed the raw chart arrays anyway, and today they inflate every subsequent request.
+
+**Voice endpoints** (`backend/api/v1/endpoints/voice.py`): `GET /voice/health` `{status, stt_ready, tts_ready, stt_model}` (cold start 30-60 s - model download; poll 2 s) · `GET /voice/voices` `{voices[{id,name,language}], count}` · `POST /voice/transcribe` multipart → `{text, language, duration}` · `POST /voice/synthesize` `{text, rate, volume}` → MP3 bytes (**no `voice` param today** - see §7.1) · `POST /voice/voice-chat` multipart + `voice` form field → `{transcript, response_text, audio_base64, processing_time}`, rate-limited capacity 6 / 12 per min.
+
+**State split (§6.8 disposition):** URL = `mode`, `c` (chat id). TanStack Query = `/chat/health`, `/voice/health` (polling), `/voice/voices`. Zustand `features/chat/store.ts` **persisted** = `chats: Record<id, {id, title, createdAt, context, messages[]}>`, `activeChatId`, `reports[{id, filename, markdown, chatTitle, createdAt, sizeKb}]` (cap 20). Streaming turn state (partial text, stages, abort ref) lives in `useChatStream` local state - never persisted mid-flight. `voiceStore` ephemeral (in-memory): `exchanges[]`, `status`, `selectedVoice`, `servicesReady`. Streamlit keys map 1:1: `chat_history/saved/current_chat_name` → chats+activeChatId · `chat_streaming/should_stop/current_request_id/stream_placeholder/input_key` → die with reruns · `chat_pending_message/pending_auto_send/chat_pending_text` → `pendingAsk` in-memory handoff · `exported_reports` → reports · voice keys → `useVoiceSession`/`voiceStore` · `current_page` → router.
+
+**Persistence gotcha (the one hard one):** image data-URIs (~100-250 kB each) blow the ~5 MB localStorage quota fast. Persist the chat slice through an **IndexedDB storage adapter** (`idb-keyval`, ~600 B) on Zustand `persist`; keep reports + prefs in localStorage. Belt-and-braces: store attachment images downscaled (≤768 px JPEG - already required for the model) and cap persisted chats at 50 with LRU eviction + Toast.
+
+**Other gotchas:** nginx already allows the payloads (`client_max_body_size 25m`, `webapp/nginx.conf:15`) · backend clamps `max_tokens` server-side (send 1000, parity) · empty-stream fallback message (#21) is a real edge, keep it · `compare_drivers` payload ships `pilot.color` - prefer it over `getDriverColor` fallback (same rule as Comparison) · assistant prose is bilingual (system prompt mirrors user language) - `Markdown` must not assume English · MediaRecorder mimeType negotiate `audio/webm;codecs=opus` with `audio/mp4` Safari fallback; name the file by actual type so `_get_audio_content_type` maps right.
+
+## 7. New features (ranked)
+
+1. **Tool-aware voice** ⚡ (M, the flagship) - compose the loop client-side: `/transcribe` → transcript card → **`/tool-message-stream`** (tools! inline charts! stage narration while the orb "thinks") → `/synthesize` the final prose (markdown-stripped) → orb speaks. Kills Discovery 4: spoken questions hit the same models as typed ones, and voice mode inherits every chat renderer free. Backend-additive **B1**: optional `voice` field on `TTSRequest` (~3 LOC) so the picker keeps working; until B1, composed-loop replies use the default voice and `/voice-chat` stays as the fallback path behind a flag.
+2. **Ask-AI deep links everywhere (E8)** ⚡ (S) - the `ContextCapsule` handoff (§5.4) + a ghost "Ask AI about this view" button on Dashboard/Comparison/Strategy/Lab cards. ECharts `getDataURL()` makes the screenshot free. This is what ties the six surfaces into one product.
+3. **Chat search + pin (E5)** (S) - filter-as-you-type over titles + message text (it's all client-side now); pin up to 3 chats above the list.
+4. **Slash commands** (S) - `/` in the empty composer opens a menu of the 4 example templates + `report`; picks fill the composer with editable placeholders (`/tyre VER 30 Bahrain`). Demo-friendly, zero backend.
+5. **Wire-history slimming** (S, verify) - tool_result → summary substitution (§6). Cuts token burn on long analytical chats.
+6. **Chart → page cross-links** (S) - inline lap-times/telemetry/compare charts get a "Open in Dashboard/Comparison" action carrying the context URL - the reverse of E8.
+7. **Voice previews** (XS, needs B1) - play a 2 s sample per voice in the picker.
+8. **Export-all / import** (XS) - download all chats as JSON from the sidebar footer (E5 tail); pairs with persistence.
+
+## 8. Better than Streamlit
+
+Real streaming (tokens render at DOM speed; the plan's measured ~95% per-token render cost cut) instead of rerun-per-token · a Stop that actually stops the backend stream, not a flag checked between frames · stage narration inline from SSE - the 1 s polling daemon thread and its endpoint dependency deleted · chats/reports survive refresh, id-keyed, renameable, deep-linkable (`?c=`) - no more same-title silent overwrites · inline charts are live ECharts (hover, zoom, save-image) in the one app-wide chart theme, not static Plotly re-rendered per rerun through 8 near-duplicate builders · tool evidence renders with the SAME `ActionBadge`/`CompoundPill`/`NlpMessageCard` vocabulary as Strategy/Lab - a tyre cliff looks identical on all three surfaces · the orb is a first-class component instead of a sandboxed iframe fought with page-level CSS nukes (`voice_chat.py:396-432` deleted) · mic consent explicit with a visible listening state instead of hot-mic-on-mount · voice can call the real models (§7.1) instead of improvising · screenshots for Ask-AI generated client-side by ECharts, no kaleido round-trip · accessible by construction: `role=log` live region, real buttons, keyboard map, reduced-motion orb.
+
+## Acceptance criteria (#39 + #40, condensed)
+
+§6.6 rows pass (with the rename amendment: rename EXISTS now, note in PR) + §6.7 rows pass (voice picker actually reads `GET /voice/voices`) · example chips byte-identical copy + click-sends (test asserts the 4 strings) · `useChatStream` reducer unit-tested against a captured SSE fixture (stage→tool_result→token→done, plus error-envelope and empty-stream cases) · Stop aborts the fetch (network-level assert: reader cancelled, no further tokens) and keeps the partial with the verbatim marker · dispatcher fixture tests per chart family incl. pit-vline detection + outlier masking parity with the Python fns · tool error renders card AND the following LLM explanation (dossier #36 regression test) · persistence round-trip: refresh restores chats incl. an image attachment (IndexedDB path) and reports · report is one-click and lands in the sidebar + download + toast · voice: record disabled until health-ready; each pipeline stage failure surfaces distinctly and keeps the recording; orb states track the session machine; reduced-motion honored · keyboard-only: send, stop, new chat, mode switch, chip activation · rate-limit 429s surface as Toasts with the budget, on both chat (20/min) and voice (12/min).
+
+**Key files:** `frontend/pages/chat.py` + `frontend/components/chatbot/{chat_sidebar,chat_history,chat_input,chat_message,tool_result_renderer,chart_builders}.py` + `frontend/services/{chat_service,voice_api}.py` + `frontend/utils/{chat_state,chat_navigation,report_storage}.py` · voice `frontend/components/voice/{voice_chat,voice_input}.py` + orb `frontend/components/streamlit_audio_viz/frontend/src/{AudioOrb,Iridescence,useAudioLevel}.tsx|ts` (lift these three + styles.css) · backend `backend/api/v1/endpoints/{chat.py,voice.py}`, `backend/services/chatbot/chat_engine.py:158-332` (event flow), `backend/models/tool_schemas.py:22-70` (tools + display map) · grammar `webapp/src/lib/api/sse.ts` (postStream - the cornerstone), `webapp/src/components/{Markdown,Pill,Toast,FileDrop,Tabs,Modal(Sheet)}.tsx`, `webapp/src/features/dashboard/components/{channels.ts,ChannelChart.tsx}` (chart styling to reuse), `webapp/src/styles/tokens.css` · sibling specs `docs/migration/design-specs/{strategy,comparison,model-lab}.md` (shared vocab) · route stub `webapp/src/app/router.tsx:70-74`.

--- a/docs/migration/design-specs/comparison.md
+++ b/docs/migration/design-specs/comparison.md
@@ -1,0 +1,139 @@
+# Comparison — Design-First Spec (issue #36, flagship)
+
+> Design-first blueprint (Fable, 2026-07-14). The app's demo centerpiece. Sources: `frontend/pages/comparison.py`, `frontend/components/comparison/synchronized_comparison_animation.py` (1116 LOC), `backend/api/v1/endpoints/comparison.py`, `backend/services/comparison_service.py`, MIGRATION_PLAN §1.2/§2.4-P4-2/§3.5/§4.2/§6.5/E3/W4, `st_5_Comparison.png`. `comparison/legacy/*` is dead — ignore.
+
+## 1. Purpose & the job
+
+Answers one question at three zoom levels: **"where does one driver gain on the other — and why?"** One glance = result banner (who won, by how much, microsector tally). One lap = the replay (watch the gap open/close at 60fps). One corner = pause anywhere, synced crosshairs across Delta/Speed/Brake/Throttle expose the mechanism.
+
+**The idea that changes everything:** Streamlit's replay is *distance-locked* — both dots advance one index/frame, always side-by-side, the "gap" only in the delta subplot. The new engine runs on a **TIME clock**: at t=34.2s each dot sits at its own distance-at-time → the faster driver visibly pulls away on track. The replay stops being an animated chart and becomes a race. Earns the expressive motion register — but only on the replay card (glow reserved for the one primary card).
+
+## 2. Functionality inventory (KEEP/IMPROVE/DROP)
+
+| # | Streamlit (file) | Verdict | Target |
+|---|---|---|---|
+| 1 | Year/GP/Session cascading selectors (`comparison.py:109`) | KEEP | Dashboard `SelectorsToolbar` grammar in a sticky context bar, state in URL. |
+| 2 | 2-driver multiselect cap 2 | KEEP | `Combobox` maxSelected=2, enforced in validateSearch. |
+| 3 | Explicit COMPARE button (not reactive) | KEEP | Fetch is expensive (cold FastF1 ~60s, 120s timeout); selection cheap+reactive, comparison explicit+cancellable. |
+| 4 | "Only fastest laps compared" notice | KEEP | Info chip (lucide `flag`) inline. |
+| 5 | "animation takes time" warning toast | DROP | Existed because of Plotly frame-baking; staged skeleton replaces it. |
+| 6 | "⏳ Rendering animation…" spinner (`:154`) | DROP | No frame pre-bake anymore; render instant on data. |
+| 7 | Lap-times box, winner in team colour, "X first by Ns" (`_render_lap_times_info`) | IMPROVE | `ResultBanner`: same + microsector tally ("16/25") client-side from `circuit.colors`. |
+| 8 | Q-phase green chip + amber fairness warning (`metadata.qualifying_phase`/`.warning`) | KEEP | `Pill` success/warning in banner. Real domain logic — surface verbatim. |
+| 9 | Circuit animation: 25 microsectors reveal, 50-pt trails, ringed dots | IMPROVE | `TrackCanvas` 60fps, time-domain (dots separate physically), smooth trails, dominance reveal preserved as signature moment. |
+| 10 | Delta subplot: faster = flat 0-line, slower = ±delta | IMPROVE | Single delta curve vs faster's zero baseline + signed area fill tinted by who's ahead — "who gains where" readable w/o motion. |
+| 11 | Speed/Brake/Throttle progressive painting | IMPROVE | Full static ECharts (never redrawn) + shared playhead cursor + translucent "future dimmer" sliding w/ playhead (compositor-only). Full trace inspectable while paused. |
+| 12 | Play 120ms/frame (~8fps) / Pause / ⟲ Reload | IMPROVE | `ReplayTransport`: real HTML buttons (fixes dossier #33 — Playwright couldn't click Play) + speed + keyboard. |
+| 13 | Frame slider "Frame: N" | IMPROVE | Time-based `ReplayScrubber` in seconds + S1/S2/S3 sector ticks + `aria-valuetext`. |
+| 14 | `hovermode='x unified'` cross-chart hover | KEEP | ECharts axisPointer + `echarts.connect` — the shipped `SyncedLineChart` pattern (ChannelChart.tsx). Active when paused. |
+| 15 | Ask-AI button w/ COMPARISON_TEMPLATE | KEEP | "Ask AI about this comparison" ghost → deep-link `/chat` w/ context. Ships disabled-w/-tooltip if #39 not landed. |
+| 16 | `session_state['comparison_data']` persistence | KEEP (free) | TanStack Query cache; survives navigation. |
+| 17 | 404 "driver not found" toast | KEEP | Toast + inline error + "change driver" hint. |
+
+Zero functional loss; two Streamlit workarounds (5,6) dropped because their cause is gone.
+
+## 3. Layout & IA
+
+Route `/comparison` (already stubbed sharing Dashboard search shape — keep, so "Go to comparison" carries context).
+
+```
+┌ STICKY CONTEXT BAR (acrylic) ────────────────────────────────────────────┐
+│ [2024▾][Monaco GP▾][Q▾][VER✕ LEC✕ ▾(max 2)]  [⚑ fastest laps]  [COMPARE▸]│
+├ RESULT BANNER (calm) ────────────────────────────────────────────────────┤
+│ VER 1:10.342  LEC 1:11.824   ●VER first by 1.482s                        │
+│ [✓ fastest laps from Q3] [⚠ phase warning]  faster in 16/25 microsectors │
+├ ╔═══════════ REPLAY CARD — the ONE glow card ═════════════════════════╗ ─┤
+│ ║   TRACK CANVAS (55%)          │ ┌DELTA(area±)┐ ┌SPEED(2 lines)┐    ║   │
+│ ║   dominance ribbon + trails   │ │     ┊cursor │ │      ┊cursor │    ║   │
+│ ║   + 2 team dots + gap "▲+.32s"│ ┌BRAKE────────┐ ┌THROTTLE──────┐    ║   │
+│ ╟───────────────────────────────────────────────────────────────────╢   │
+│ ║ TRANSPORT [⏮][▶/⏸][1×▾] 0:34.2 ──●──── 1:10.3  ticks S1│S2│S3 [⧉]║   │
+│ ╚═══════════════════════════════════════════════════════════════════╝   │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+Replay card = hero (glow, expressive register, ~80% viewport ≥1280px): track left 55%, 2×2 channel grid right 45%, transport docked full-width bottom — one instrument, one clock. <1280px: track full-width top (min 360px), charts 2×2 below (1-col <720px), transport sticky to card bottom. Selectors+banner frame it (solid bg-3, no glow, ≤180ms mounts).
+
+**States:** Idle (EmptyState, COMPARE disabled until all 5 selections — error-toast-on-click impossible by construction) · Comparing (skeleton of final layout, staged copy "Loading session→Extracting fastest laps→Synchronizing telemetry", cancel via AbortController) · Ready (paused t=0: full track neutral grey, dots on start line, full traces, delta fill; Play pulses once, motion-safe — already a complete static analysis screen) · Playing (clock runs, dominance reveals behind leader, trails stream, cursors sweep, live gap counts, hover suppressed) · Paused mid-lap (freeze; axisPointer hover + connect re-enabled → Dashboard-parity inspection) · Finished (full map lit, gap = final delta; ▶→⟲ Replay; no auto-loop unless toggled) · Error (404 detail inline + toast, Retry keeps selection).
+
+## 4. The replay engine — one-clock architecture
+
+**4.1 Clock is time, not frames.** Backend returns 500 pts/driver on a common DISTANCE grid + each driver's real `lap_time`, but NO time array (verified: `synchronize_telemetry` interpolates distance/x/y/speed/throttle/brake only). Client synthesizes each driver's time domain w/ the math the backend already uses for delta (`calculate_delta_time`):
+```
+tᵢ[k] = Σ_{j<k} Δd[j] / (vᵢ[j]/3.6)   (cumulative trapezoid, s)
+tᵢ    = tᵢ · (lap_timeᵢ / tᵢ[last])     (scale to real lap time)
+```
+Strictly increasing `timeAtDistance` per driver; inverse `distanceAtTime(t)` = binary-search+lerp (the `interp()` in `ChannelChart.tsx:163` → promote to `lib/interp.ts`). **Replay duration = max(lap_time₁, lap_time₂)** → faster dot parks at the line while the slower finishes — the gap made physical.
+
+**4.2 Data flow & state placement:**
+```
+URL search (TanStack Router, comparison/search.ts) — COMPARE sets compare=1 → enables query
+  ▼ useComparison(search)  (TanStack Query, staleTime:Infinity) → GET /comparison/compare
+  ▼ buildReplayModel(payload)  (PURE, memoized, UNIT-TESTED)
+     ├ Float32Array channels per driver (distance,x,y,speed,throttle,brake)
+     ├ timeAtDistance₁/₂ + distanceAtTime₁/₂ samplers
+     ├ delta series + sign-split area segments
+     ├ track geometry: bounds, y-flip, viewBox (reuses circuitDraw.ts), microsector segments
+     └ duration, sector-boundary times, winner metadata
+  ▼ useReplayClock(duration)  (the ONE clock)
+     ├ rAF loop; playhead in a REF, never React state
+     ├ transport API: play/pause/seek/setSpeed/restart
+     ├ subscribe(cb) → every frame w/ tSec  (canvas + cursor overlays)
+     └ useReplayTime(hz=10) → throttled React state (text readouts only)
+  ▼ consumers, all from the same tick: TrackCanvas · CursorOverlay×4 · FutureDimmer×4 · LiveGapReadout · ReplayTransport
+```
+State tiers (A5-1): **URL** = year/gp/session/drivers(cap 2)+optional `t` moment-link · **TanStack Query** = payload (immutable, staleTime:Infinity) · **Zustand replayStore** (`f1sl.replay`) = status/speed/loop/trackMode · **ref inside useReplayClock** = playhead time (60 setState/s would re-render the tree; refs + imperative draw = standard rAF discipline, §1.2).
+
+**4.3 rAF loop:** `t = min(t + dt·speed, duration); for cb of subscribers cb(t); if t>=duration finished`. Zero alloc in-loop (Float32Arrays pre-baked, trail slices = index ranges). `visibilitychange` pauses (no time jump on tab return). Budget <4ms/frame (canvas ~1-2ms, cursor transforms ~0). 60fps comfortable.
+
+**4.4 Track renderer (`TrackCanvas` + pure `trackDraw.ts`):** offscreen STATIC layer (ribbon once per data/resize, reuse computeBounds/flipY, add `fitCanvas()` track-units→px w/ aspect lock + DPR≤2 cap, base grey #94a3b8 low-alpha ~10px) + DYNAMIC layer every tick: (1) dominance reveal — microsector segments whose end-distance < leader's distance stroked in `circuit.colors` (25 sectors, per-pixel smooth), (2) trails — last ~2.5s of each driver's real x/y racing line, 3px alpha fade (off under reduced-motion), (3) dots — 7px team-colour fill (`pilot.color` from payload), 2px white ring, soft glow (the one glow on data — it IS the data), (4) gap link — when on-track separation <~8% track length, dashed line connects dots w/ live gap label. Canvas `role=img`+aria-label; visually-hidden `aria-live=polite` announces pause/finish.
+
+**4.5 Channel charts — ECharts static + DOM cursor (critical perf decision):** the 4 charts are ECharts w/ fully STATIC series — `setOption` once per data load, NEVER per frame. Playhead = **DOM overlay: absolutely-positioned 1px line, `transform: translateX(px)`** (compositor-only, ~0 main-thread) — chosen over `dispatchAction`/`setOption`-per-frame (both re-render chart internals). `CursorOverlay` maps playhead distance (leader's distance-at-time; all x-axes = distance like Dashboard) → px via `chart.convertToPixel({xAxisIndex:0}, d)` cached per resize (per-frame = one multiply-add). `FutureDimmer` = 2nd overlay (full-width `rgba(bg-2,.5)`, translateX(cursorPx)) restores progressive-reveal for free. Paused → overlays freeze, native `tooltip.trigger:axis` + `echarts.connect` group take over (Dashboard-parity). Delta: 1 series = slower's delta vs faster's zero baseline (dashed markLine at 0) + split-sign area fill tinted by who leads (driver-1 colour above zero, driver-2 below, 15% alpha) → dominance timeline even stopped.
+
+**4.6 Transport & a11y (fixes dossier #33):** `ReplayTransport` real HTML controls (Button ghost + lucide): ⏮restart, ▶/⏸ (aria-pressed, 44px hit), speed menu (0.25/0.5/1/2), loop toggle, track-mode menu (§7), share-moment. `ReplayScrubber` on Radix Slider: value=seconds, `aria-valuetext="34.2s of 70.3 — VER ahead 0.32s"`, mono readouts, **S1/S2/S3 sector ticks** (placeholder 25/50/75% if sector data absent); drag=seek() live (O(1) redraw — humiliates Plotly), drag pauses + resumes on release. **Keyboard** (scoped to focused card): Space/K play-pause, ←/→ ±0.5s, Shift+←/→ ±5s, Home/End, J/L speed, R restart. `prefers-reduced-motion`: no pulse/trails/GSAP; replay only on explicit action (never autoplays → V3-5 by construction). Focus rings, tab order play→scrubber→speed→secondary.
+
+## 5. Components
+
+Reuse: `Card` glow (replay card, the one glow), `Button`/`Pill`/`Toast`/`Skeleton`/`EmptyState`/`Tooltip`, `Combobox` maxSelected (cap 2), `Slider` (scrubber base), `SyncedLineChart`+`echartsTheme`+connect group (paused inspection), `circuitDraw.ts` (extended w/ canvas `fitCanvas()`), `dashboard/search.ts` pattern (cloned MAX_DRIVERS=2), `getDriverColor` (fallback only — payload ships colours).
+
+New (`webapp/src/features/comparison/`): `ComparisonPage.tsx`, `search.ts` (cap 2, optional t=), `queries.ts` (useComparison), `components/{ComparisonToolbar,ResultBanner,AskAiButton}.tsx`, `replay/{buildReplayModel.ts (PURE, unit-test seam), useReplayClock.ts, replayStore.ts, TrackCanvas.tsx, trackDraw.ts (PURE), ChannelGrid.tsx, ChannelPane.tsx, CursorOverlay.tsx, ReplayTransport.tsx, ReplayScrubber.tsx, LiveGapReadout.tsx}`. Promote `interp` → `lib/interp.ts`. **`ReplayTransport` + `useReplayClock` are the reusable seams** (future live-timing feed + Arcade consumers want a transport+clock abstraction — keep them free of comparison-specific types).
+
+## 6. Data & migration notes
+
+Endpoint (exists): `GET /api/v1/comparison/compare?year&gp&session&driver1&driver2` (schema.ts:191). Response:
+```jsonc
+{ "circuit": { "x":[500], "y":[500], "colors":["#hex"×500] },  // centreline avg; colors = 25-microsector dominance per point
+  "pilot1": { "distance":[500],"x":[500],"y":[500],"speed":[500],"throttle":[500],"brake":[500],
+              "lap_time":70.342,"color":"#3671C6","name":"VER","lap":14 },
+  "pilot2": { /* same */ },
+  "delta": [500],  // + = pilot1 slower here (speed-integrated, scaled to real lap-time diff)
+  "metadata": { "rotation":40,"aspect_ratio":1.8,"qualifying_phase":"Q3"|null,"warning":"..."|null } }
+```
+Payload ≈500pts×13 arrays×~10B ≈ **150-250 kB** vs multi-MB pre-baked Plotly figure (P4-2 −90%+ met by NOT shipping frames).
+
+Interp math to port (unit-test seam): (1) `np.interp`→`interp()` already in ChannelChart.tsx:163 → promote to `lib/interp.ts`; (2) time-domain synthesis + delta = TS port of `comparison_service.calculate_delta_time` (`Δd/(v/3.6)` cumulative + scale, comparison_service.py:185-232) in `buildReplayModel.ts`. **Golden-fixture test:** run the Python fns on 2023 Monaco Q VER/LEC → `tests/fixtures/comparison-monaco-2023.json`, assert TS port within 1e-6 (like `outliers.test.ts`). Pins the port to thesis-validated math.
+
+URL (`comparison/search.ts`): `/comparison?year=2023&gp=Monaco Grand Prix&session=Q&drivers=VER,LEC[&t=34.2]`. Drivers CSV upper/dedup/**cap 2**; `t` optional float clamped [0,duration], applied once on load (moment link), written only by share button. Dashboard's "Go to comparison" gracefully truncates 3 drivers → 2.
+
+**Optional additive backend (NOT parity gates):** B1 — real `time` arrays in compare payload (FastF1 has it; /lap-telemetry already returns it) → kills the speed-integration approx (client keeps synthesis as fallback), ~15 LOC. B2 — official S1/S2/S3 boundaries in metadata → true scrubber ticks + per-sector splits.
+
+## 7. New features (ranked)
+
+1. **Corner call-outs** (M) — detect braking zones (brake-rise) + apexes (speed minima) from arrays in hand; label T1..Tn; pause near one → micro-card "T5: LEC brakes 14m later, exits +6km/h, gains 0.09s". Pure client. **The** analyst feature.
+2. **Track colour modes** (S) — transport menu: Dominance (parity) · Speed heatmap · Gain/loss (delta-derivative). One draw-fn switch.
+3. **Ghost dot** (S) — hollow marker of the other driver at this elapsed time on your line; explains the delta visually.
+4. **Share a moment** (XS) — copy URL w/ `&t=34.2` + toast. Zero backend.
+5. **Export a clip** (M) — `canvas.captureStream(60)` + MediaRecorder → WebM for README/social. Dev-flag first.
+6. **Official sector splits** (S+backend) — needs B2.
+7. **3D upgrade (E3)** (L) — r3f track w/ elevation, chase-cam, emissive dominance. Lazy chunk, mounts on toggle, 2D fallback. Engine ready: useReplayClock subscribers don't care if consumer is canvas 2D or three. The defense flex; never parity.
+8. **Any-lap comparison** (M+backend) — not only fastest; needs lap1/lap2 params.
+
+Recommended for #36: parity + ranks 2-4 (near-free once engine exists). Rank 1 = fast-follow PR; 5-8 = backlog.
+
+## 8. Better than Streamlit (demo script)
+8fps→60fps (clock vs flipbook) · physically-true replay (dots on real time, you WATCH the gap open — no broadcast graphic does head-to-head like this) · multi-MB→~200kB · instant continuous scrubbing (seek(t) = 1 canvas frame, feels like a video editor) · accessible by construction (real buttons, labelled slider, keyboard map, live-region, reduced-motion) · paused = full analysis screen (complete curves + synced crosshairs) · shareable (`&t=` reproduces the moment) · state survives navigation.
+
+## Acceptance criteria (#36, condensed)
+§6.5 parity rows pass · 60fps sustained (DevTools trace in PR, <8ms/frame) · buildReplayModel golden test vs Python fixture green · keyboard-only transport (axe/Playwright can click Play — regression test named after dossier #33) · prefers-reduced-motion honored (no pulse/trails, replay only on explicit action) · URL round-trip incl `t=` · NO setOption inside the rAF loop (assert via spy).
+
+**Key files:** `frontend/pages/comparison.py` + `frontend/components/comparison/synchronized_comparison_animation.py` · port math `backend/services/comparison_service.py` (synchronize_telemetry, calculate_delta_time, calculate_microsector_colors) · endpoint `backend/api/v1/endpoints/comparison.py` · grammar `webapp/src/features/dashboard/{search.ts,store.ts,queries.ts,components/ChannelChart.tsx,components/circuitDraw.ts}` · route stub `webapp/src/app/router.tsx:63-67`.

--- a/docs/migration/design-specs/dashboard-round2.md
+++ b/docs/migration/design-specs/dashboard-round2.md
@@ -1,0 +1,181 @@
+# Dashboard - Round 2 Fixes Plan
+
+> Execution plan (Fable, 2026-07-14). Five refinements to the shipped Dashboard (issue #34 + elevation round 1), designed from the real code and the current screenshot (2023 Monaco R, VER/LEC). This is a build-tomorrow plan, not a design-first spec: each item carries root-cause/analysis, the concrete file:line change plan, and an S/M/L effort tag. All paths relative to `webapp/src/` unless noted. Golden verify session: **2023 Monaco R, VER+LEC** (only offline-cached FastF1 session).
+
+**Scope of files touched:**
+
+| Item | Files |
+|---|---|
+| 1 Click bug | `features/dashboard/components/LapChart.tsx`, `LapChartSection.tsx` |
+| 2 Drivers loading | `components/Combobox.tsx`, `features/dashboard/components/SelectorsToolbar.tsx` (+ backend follow-up issue) |
+| 3 Controls fold-in | `components/ChartCard.tsx`, `features/dashboard/components/{LapChartSection,LapControls,CompoundLegend}.tsx` (+ new `LapChartFooter.tsx`) |
+| 4 8th chart | `features/dashboard/components/{channels.ts,ChannelChart.tsx,TelemetryGrid.tsx}` (+ new `accel.test.ts`) |
+| 5 Drag-to-zoom | `features/dashboard/components/{ChannelChart,LapChart}.tsx` |
+
+---
+
+## 1. BUG - clicking a lap-chart point does nothing (M)
+
+### Root cause
+
+The handler chain is **wired correctly and sound**, verified end to end: `LapChart.tsx:233` binds `onEvents={{ click: handleClick }}` -> `handleClick` (:218-224) -> `extractLapClick` (:184-194) -> `onLapClick`; `LapChartSection.tsx:87` passes `onLapClick={setLap}`; `store.ts:39-40` merges into `selectedLapsPerDriver`; `TelemetryGrid.tsx:98-101` reads it via `useLapTelemetries` (`queries.ts:172-244`), which fires a new `lap-telemetry` query per changed (driver, lap). So the candidates rule out as follows:
+
+- **(c) wrapper interception - RULED OUT.** `role="img"` (`LapChart.tsx:227`) is ARIA-only, it does not affect pointer events; the ChartCard body (`components/ChartCard.tsx:97`, `overflow-auto p-4`) sits behind the canvas, not over it.
+- **(d) echarts-for-react binding - RULED OUT.** v3.0.6 binds `onEvents` at init and only re-binds on a deep-equality miss; `handleClick` is `useCallback`-stable over zustand's stable `setLap`, so `{ click: handleClick }` deep-equals across renders. `notMerge` drives `setOption`, not re-init, so the listener survives option rebuilds.
+- **(a) hit area - PRIMARY CAUSE.** With `tooltip.trigger: 'item'` and default line-series hit-testing, ECharts fires a series `click` only when the pointer hits a drawn graphic. After the round-1 de-bead, symbols are `symbolSize: 5` (`LapChart.tsx:94`); a ~78-lap race across a ~700-900 px grid spaces dots ~9-11 px apart, so the real target is a 5 px dot (`emphasis.scale: 1.6` only grows it *after* hover registers, which is the same tiny target). Clicking the connecting line does not help: `triggerLineEvent` defaults to false, and even when enabled the polyline event carries no per-point `data`, so `extractLapClick` correctly returns `null` through its guards. Most clicks land 3-10 px off a dot and **no event fires at all**.
+- **(b) invisible success - COMPOUNDING CAUSE.** When a click *does* land, there is often nothing to see. The page auto-loads each driver's fastest lap on mount (`DashboardPage.tsx:67-74`), so clicking in the fastest region re-selects the already-loaded lap (a same-value `setLap` merge, zero state change). Clicking a genuinely different lap changes only the small caption (`LapChartSection.tsx:109-128`) and the telemetry grid **below the fold** (see the screenshot's page height). No marker on the chart, no toast, no scroll. Successful clicks read as "nothing happened" too.
+
+So: not a broken handler, a **hit-area + feedback** defect. The fix must work regardless of which factor bit the user on any given click.
+
+### Fix plan (three layers, all land together)
+
+**1a. Nearest-point picking (decouple the hit area from the 5 px dot).** In `LapChart.tsx`:
+
+- Remove the `onEvents` item-click path (:218-224, :233) - one deterministic code path instead of two racing ones.
+- Add `onChartReady={(chart) => bindNearestPointClick(chart, propsRef)}` on the `ReactECharts` (:228-234). New helper `bindNearestPointClick` registers `chart.getZr().on('click', handler)`:
+  - Guard: `if (!chart.containPixel({ gridIndex: 0 }, [e.offsetX, e.offsetY])) return` - legend/axis/title clicks stay inert.
+  - For every plotted point (per visible series), `chart.convertToPixel({ seriesIndex }, value)`, compare squared pixel distance to the click, keep the minimum, accept when within a **20 px radius** (comfortable touch-size target). Max ~240 points (3 drivers x ~80 laps), trivial per click.
+  - Pixel-space nearest (not `convertFromPixel` + data-space nearest) because it matches what the eye considers "the closest dot" when lap times differ wildly on y (the Monaco rain wall in the screenshot).
+- The zr handler binds once per chart instance, so it reads laps/`onLapClick` from a `useRef` updated on every render (`propsRef.current = { laps: plotted per-series data, onLapClick }`).
+- `symbolSize: 5` stays - the de-bead visual is untouched; only the interaction radius grows.
+
+**1b. Visible selected-lap marker.** Pass `selectedLaps: Record<string, number>` into `LapChart` (new prop; `LapChartSection.tsx:60` already reads `selectedLapsPerDriver`, hand it down at :83-88). In `buildDriverSeries` (`LapChart.tsx:90-100`), when `lap.lap_number === selectedLaps[driver]`, emit a per-point override object: `{ value, compound, symbolSize: 11, itemStyle: { borderColor: '#fff', borderWidth: 2 } }`. Each driver's loaded lap renders as a ring; a successful click **visibly moves the ring at the click site**, independent of the below-the-fold grid.
+
+**1c. Click feedback toast.** In `LapChartSection.tsx`, replace the direct `onLapClick={setLap}` (:87) with a local `handleLapClick(driver, lap)`:
+
+- Same lap already loaded -> `toast({ title: "${driver} lap ${lap}", description: 'Already showing this lap.', tone: 'info' })`, no store write.
+- New lap -> `setLap(driver, lap)` + `toast({ title: "${driver} lap ${lap} loaded", description: 'Telemetry updated below.', tone: 'success' })`.
+- `useToast` from `@/components/Toast`; the provider is already mounted app-wide (`app/providers.tsx:21`), nothing to add.
+
+No store or query changes anywhere.
+
+### Browser verification
+
+Backend on :8000, `npm run dev` in `webapp/`, open `/dashboard?year=2023&gp=Monaco Grand Prix&session=R&drivers=VER,LEC`.
+
+1. Click **8-10 px off** any dot -> DevTools Network shows `GET /api/v1/telemetry/lap-telemetry?...&lap_number=N`, the ring jumps to that lap, success toast, caption updates.
+2. Click the already-ringed fastest lap -> "already showing" info toast, **no** refetch.
+3. Click the legend / axis area -> nothing (containPixel guard).
+4. Toggle Outliers/Invalid, click near a filtered-out region -> picker only finds *visible* points (it searches the plotted series data, which is `filterResult.visible`).
+5. After item 5 lands: drag a zoom/pan gesture -> no phantom lap pick (zrender suppresses `click` after a real drag; if a phantom fires, add a mousedown->mouseup delta < 4 px guard in the handler).
+
+Optionally script 1-2 as a Playwright check per the `shot.mjs` harness.
+
+---
+
+## 2. Drivers combobox unusable too long after picking a session (S + backend follow-up)
+
+### Analysis
+
+`useDrivers` (`features/dashboard/queries.ts:69-89`) hits `GET /api/v1/telemetry/drivers` -> `get_drivers` (`backend/api/v1/endpoints/telemetry.py:79`) -> `get_available_drivers` (`backend/services/telemetry/telemetry_service.py:92-105`), which constructs `SessionData` -> `session_cache.get_loaded_session` (`backend/services/telemetry/session_cache.py:51-82`) doing a **full** `load(telemetry=True, laps=True, weather=True)`: 2-15 s warm, 30 s+ on a cold FastF1 download. The prewarm POST (`DashboardPage.tsx:85-87`) fires on the same navigation, so `/drivers` just queues behind the same per-key lock (`session_cache.py:67`) for the whole parse. Meanwhile the combobox renders `disabled={!value.session || driversQuery.isLoading}` (`SelectorsToolbar.tsx:101`) - **visually identical** (`opacity-50`) to "no session picked yet", so 15 s of legitimate work reads as "broken control".
+
+### Fix plan (frontend, this round)
+
+- `components/Combobox.tsx`: add `loading?: boolean` to `ComboboxProps` (:122-131) and `MultiComboboxProps` (:185-199). In both triggers, when loading:
+  - render an inline spinner SVG (`animate-spin`, same hand-rolled-icon pattern as :18-61, no new dep) in place of `ChevronDownIcon` (:165 single / :292 multi);
+  - set `aria-busy="true"` and make the trigger non-interactive (`pointer-events-none`);
+  - do **not** apply the disabled `opacity-50` dim; use a lighter treatment (e.g. `opacity-80`) so *working* is visually distinct from *unavailable*.
+- `SelectorsToolbar.tsx:94-105` (Drivers cell): `disabled={!value.session}`, `loading={driversQuery.isLoading}`, `placeholder={driversQuery.isLoading ? 'Loading drivers…' : 'Select drivers (max 3)'}`.
+- Same `loading` pass on the GP (:79) and Session (:90) comboboxes - those queries are fast, but the consistency is one prop each.
+- Error one-liner: when `driversQuery.isError`, placeholder becomes "Couldn't load drivers - reselect the session" (retry already capped at 1 by `HISTORICAL`, `queries.ts:31`).
+
+### Backend follow-up (file as its own issue, do NOT block this round)
+
+A light roster path so the combobox fills in <1 s while the full parse continues in the background:
+
+- **Option A (preferred):** `GET /drivers` gains a fast path using a laps/telemetry-free FastF1 load (`session.load(laps=False, telemetry=False, weather=False, messages=False)` + `session.results`) behind its own tiny cache; codes + names come from the API results, no parquet parse, no contention on the heavy per-key lock. Must verify `results` populates without laps for 2023-2025.
+- **Option B:** static roster index `(year, gp, session) -> [{code, name}]` generated offline from the featured parquet / HF dataset, served as JSON. Zero FastF1 in the path; costs a build step + a staleness story.
+- Anti-option: the webapp's `features/dashboard/lib/drivers.ts` team-colour map knows season-level codes but **not who ran a given session** - never fake the roster from it.
+
+---
+
+## 3. Controls/legend block mini-redesign (M)
+
+### Analysis
+
+Below the chart card, `LapChartSection.tsx` stacks four loose blocks at section `gap-4` (:76): the `LapControls` row (:92-102), a standalone tip line (:104-107), the "Showing telemetry" caption (:109-128), and `CompoundLegend` with its own "TYRE COMPOUNDS" `SectionHeader` (`CompoundLegend.tsx:71`). Four different vertical rhythms, plus a second section-style header floating right under a card, produce the "un poco raro" reading in the screenshot: the block belongs to the lap chart but doesn't *look* owned by it. All four pieces are dashboard-local (grep: no usages outside `features/dashboard/`), safe to reshape.
+
+### New layout
+
+Everything folds into the Lap Chart `ChartCard`: **controls -> card header** (the `actions` slot already exists, `ChartCard.tsx:44-46` + :74), **status + compounds -> a new card footer strip**.
+
+```
+┌ Lap Chart ————— [⏱ Fastest laps] [👁 Outliers·0] [👁 Invalid·0] · [–] [⛶] ┐
+│                                                                           │
+│                          (chart, 400 px)                                  │
+│                                                                           │
+├───────────────────────────────────────────────────────────────────────────┤
+│ ⚡ VER Lap 23 · LEC Lap 46   · click any point to switch lap               │
+│                     (Medium) VER 53 · LEC 9   (Hard) LEC 42   (Inter) 22  │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+One strip, two clusters: left = telemetry status (team-coloured codes, mono lap numbers) with the click tip demoted to a subdued suffix; right = inline compound micro-legend (pill + per-driver counts). `flex flex-wrap items-center justify-between gap-x-6 gap-y-2`; narrow screens stack the clusters naturally.
+
+### Concrete moves
+
+1. `components/ChartCard.tsx`: add optional `footer?: ReactNode`; render `{footer ? <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div> : null}` after the body in **both** the normal card (:121-126) and the maximized overlay (:99-118) so the strip survives maximize. Hide it while collapsed (same branch as `body`, :97). Shared-primitive change; other charts can adopt later.
+2. `LapChartSection.tsx`: `:77` becomes `<ChartCard title="Lap Chart" actions={<LapControls …/>} footer={footer}>`; delete the standalone blocks :92-130. `footer` renders only when `lapTimes.length > 0` (while loading, the body `Skeleton` :79 is the whole story).
+3. New `components/LapChartFooter.tsx` (feature-local): left cluster = the caption content currently at :109-128 plus the ` · click any point to switch lap` suffix (replaces the whole MousePointerClick tip block :104-107); right cluster = the inline `CompoundLegend`.
+4. `LapControls.tsx`: logic untouched (:64-101); it just renders inside `actions` now. If the header wraps badly under ~480 px, add `flex-wrap` to the ChartCard header row (`ChartCard.tsx:71`), nothing else.
+5. `CompoundLegend.tsx`: reshape from column-per-compound (:70-103) to a single inline row - `[Pill] VER 53 · LEC 9` groups separated by `gap-x-4`; delete the `SectionHeader` (:71), the pills are self-labelling. Keep the invariant that counts come from the FULL unfiltered `lapTimes` (:5-7).
+
+Result: one card = one unit (chart + its controls + its status); the page below returns to clean section-level rhythm (Lap Chart card, Circuit Domination card, Telemetry section). Verify with before/after full-page screenshots (dark only, parity rule).
+
+---
+
+## 4. 8th telemetry chart - fill the DRS gap (M)
+
+### Analysis
+
+The grid is `xl:grid-cols-2` (`TelemetryGrid.tsx:31`) rendering 7 cards in Streamlit order speed/delta/throttle/brake/rpm/gear/drs (:113 + `channels.ts:57-91`); DRS is a short 180 px state band (`ChannelChart.tsx:37`) sitting **alone** in the last row - the emptiest-looking corner of the page.
+
+### The pick: Longitudinal acceleration (g)
+
+Derived entirely from arrays already in every `lap-telemetry` response (`lib/api/telemetry.ts:23-34`): central difference over `speed` + `time`, `a[i] = ((v[i+1] - v[i-1]) / 3.6) / (t[i+1] - t[i-1]) / 9.81`, then a 3-point moving average to tame FastF1's ~4-5 Hz sampling noise.
+
+Why this over the alternatives:
+
+- **Real race-engineering channel.** Braking spikes (-4..-5 g) expose braking points and intensity; traction zones show corner-exit quality; lift-and-coast is directly visible. None of that is readable off the speed trace alone, so it adds information instead of rearranging it.
+- **Works with 1 driver.** A speed-delta channel degenerates exactly like Delta (`ChannelChart.tsx:386-390`, "needs >= 2 drivers"), which would leave 2 of 8 slots dead in single-driver use.
+- **Zero new data / zero backend.** Sector splits have no sector data in the payload; circuit-domination (`lib/api/telemetry.ts:37-42`) is x/y-indexed with no distance mapping, so a dominance strip can't honestly join the distance crosshair.
+- **No duplication.** A throttle+brake "inputs" overlay only pays if it *replaces* the two existing cards (7 -> 6, the opposite of the goal).
+
+### Plan
+
+- `channels.ts`: extend the `key` union (:27) with `'accel'`; add helper `longitudinalAccelG(t: LapTelemetry): number[]` (central diff + 3-point smoothing; guard `dt === 0` on repeated timestamps by carrying the previous value); insert the entry after `gear`, **before** `drs`: `{ key: 'accel', title: 'Longitudinal Accel', yName: 'Long. Accel (g)', transform: longitudinalAccelG }`. Y autoranges via the shared `scale: true` (`ChannelChart.tsx:99-105`). Declared order then yields rows **[Speed · Delta] [Throttle · Brake] [RPM · Gear] [Accel · DRS]** - 8 slots, symmetric, with the two "state-ish" charts sharing the last row.
+- `TelemetryGrid.tsx`: no structural change (:144-154 already maps rest-channels in declared order); update the 7-chart header comment (:1-6). CSS grid stretch already equalizes the last row's card shells; center the 180 px DRS band vertically inside its stretched card (wrap the chart in `flex h-full flex-col justify-center` when `channel.band`, around `ChannelChart.tsx:261-267`) so the short plot doesn't hug the card top.
+- Test: `features/dashboard/components/accel.test.ts` beside `outliers.test.ts` - synthetic constant-accel ramp -> constant g; flat speed -> 0 g; `dt=0` guard.
+- **Fallback** (decision point on real Monaco data during build): if the derivative is too noisy even smoothed, do the grid reflow instead - DRS card spans both columns (`xl:col-span-2`) as a full-width state strip under the 3x2 grid. One-line change, no new channel, still no lonely slot.
+
+---
+
+## 5. Drag-to-zoom on every chart (M)
+
+### Analysis
+
+ECharts 6.1.0 / echarts-for-react 3.0.6 (`webapp/package.json`). The 7 telemetry charts share crosshair group `'telemetry-crosshair'` via `echarts.connect` (`ChannelChart.tsx:48`, :227-230); connected charts **propagate dataZoom actions**, and x = distance on all of them, so a synced x-zoom is meaningful, not cosmetic. `LapChart` is *not* in the group (x = lap number) and gets its own independent zoom. Streamlit/Plotly's native box-zoom is the parity bar.
+
+### Plan
+
+- `ChannelChart.tsx` `baseOption` (:92-144), two additions every telemetry chart inherits:
+  - `dataZoom: [{ type: 'inside', xAxisIndex: 0, filterMode: 'none', zoomOnMouseWheel: 'shift', moveOnMouseMove: true, moveOnMouseWheel: false }]` - drag-pan + Shift+wheel zoom. Plain wheel **must remain page scroll**: 7-8 tall charts with unconditional wheel-capture is a scroll trap. `filterMode: 'none'` keeps each chart's y range stable while panning (no rescale jitter across 8 synced charts).
+  - `toolbox: { right: 8, top: 0, feature: { dataZoom: { yAxisIndex: 'none', filterMode: 'none' }, restore: {} } }` - the toolbox magnifier is the Plotly-style **box zoom** (click, drag a box, x-only via `yAxisIndex: 'none'`); `restore` is the reset. Check icon collision with the centered legend (:114-122) at 2-3 drivers; nudge `right` if needed.
+- **Sync check:** zoom Speed via box-zoom -> Gear/DRS/Accel crosshair AND window follow (connect propagates `dataZoom` + `restore` through the group). The DRS band participates (same x axis).
+- **Reset:** toolbox restore per chart, propagated group-wide. Known caveat: `restore` re-applies the init-time option, and both chart types rebuild options with `notMerge` on data changes (which already resets zoom on driver/filter change - acceptable: zoom is transient inspection state). If restore misfires under echarts-for-react's re-`setOption`, fall back to a small "Reset zoom" action dispatching `{ type: 'dataZoom', start: 0, end: 100 }` - the ChartCard `actions` slot from item 3 is the natural home.
+- `LapChart.tsx` `buildLapChartOption` (:140-175): same `dataZoom` inside + toolbox pair, no group. Keep `zoomOnMouseWheel: 'shift'` for cross-page consistency. Box-zooming into the flat low-1:15 pack (screenshot) is the actual Streamlit-era use case.
+- **Interplay with item 1:** after any pan/box drag on the lap chart, verify the zr nearest-point handler doesn't fire a phantom pick (zrender suppresses `click` after a genuine drag; if not, the delta guard from item 1's verification list covers it). Also re-verify `convertToPixel` picking under an active zoom window - it maps through the current axis scale, so picking zoomed-out (hidden) points is naturally excluded by the 20 px radius, but confirm in browser.
+
+---
+
+## Do-first ordering
+
+| # | Item | Effort | Why this slot |
+|---|---|---|---|
+| 1 | Lap-click bug (item 1) | M | The UI literally says "Click a lap to inspect it" - a broken promise is the highest-pain defect. Everything else is polish on top of a working core loop. |
+| 2 | Drivers loading affordance (item 2) | S | Smallest diff, fully independent files, big perceived-quality win. File the backend roster follow-up issue at the same time. |
+| 3 | Controls fold-in (item 3) | M | Reshapes the strip whose copy item 1 touches (the tip line becomes the footer suffix) - landing 1 first avoids writing that caption twice. Also creates the ChartCard `footer`/`actions` seams item 5's reset fallback may use. |
+| 4 | Drag-to-zoom (item 5) | M | Pure chart-option work; verify the click-vs-drag interplay against item 1's picker while both are fresh in-head. |
+| 5 | 8th chart (item 4) | M | New feature with a data-dependent decision point (accel vs DRS-span reflow); lowest cost to cut or defer if the round runs long. |
+
+Branching: one `feat/` branch per PR to `dev` per project flow; natural split is 1+2 (fix + quick win), 3+5 (layout + interaction), 4 (new channel). Every PR: screenshot-verify on the golden session (dark only at parity), `npm run typecheck && npm run lint && npm run test` in `webapp/`, commit explicit paths (never `-A`, Windows autocrlf gotcha).

--- a/docs/migration/design-specs/model-lab.md
+++ b/docs/migration/design-specs/model-lab.md
@@ -1,0 +1,184 @@
+# Model Lab — Design-First Spec (issue #38)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Model Lab's functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared vocabulary from `strategy.md` (`ActionBadge`, `CompoundPill`, `ConfidenceDial`, state tiers, raw↔component URL boundary). Sources: `frontend/pages/model_lab.py` (930 LOC), `backend/api/v1/endpoints/strategy.py`, agent output dataclasses in `src/agents/*.py`, MIGRATION_PLAN §6.4/E10/W6, `st_4_Model_Lab.png`.
+
+## 1. Purpose & the job
+
+Model Lab is the **model inspector**: put any ONE of the six predictors on the bench, feed it a real race moment, and see exactly what it says and why. Strategy shows the orchestrated *decision*; the Lab shows each *instrument* in isolation — the transparency surface for the TFG's model family (XGBoost pace, TCN+MC-Dropout tyres, LightGBM overtake/SC, HistGBT pit + LightGBM undercut, the N24 NLP radio pipeline). Its job: *"For this GP/driver/lap, what does model X predict, with what uncertainty, against what threshold — and what did the LLM layer say about it?"*
+
+Streamlit treats it as six repetitive form-tabs. The migrated version is a **workbench**: a model rail with identity cards (model type + thesis eval headline + run status), one shared bench frame (context → run → metrics → viz → reasoning), and a per-model run history. The audience is the developer/defender demoing models individually, and the curious analyst poking at a race moment.
+
+**THREE KEY DISCOVERIES in the Streamlit source** that drive this design:
+1. **Dead UI:** the Overtake tab's "Contextual factors" panel + factor bar chart (`model_lab.py:468-505`) read `data.contextual_factors` — a field **no agent ever returns** (zero matches in `src/agents/` and `backend/`). The panel has rendered its empty-fallback forever. Meanwhile the REAL context the agent returns (`gap_ahead_s`, `pace_delta_s`, `sc_currently_active`) is discarded.
+2. **Fabricated data:** the Safety-car tab's 3/5/7-lap horizon bars (`model_lab.py:541-543`) invent the 5- and 7-lap values client-side as `sc3×1.2` and `sc3×1.4`. The model has ONE trained target (`sc_within_3_laps`). Two of the three bars are made up.
+3. **Dropped fields:** `RadioOutput.corrections` (LLM-flagged NLP mismatches) and `rcm_events` are never rendered; both Overtake and SC tabs call the SAME `/situation` endpoint separately, so the one model runs twice and the two tabs can silently disagree.
+
+Fixing these is the core of the elevation — same honesty move as Strategy's 14-vs-6-field discovery.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file:line) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" `st.warning` (`model_lab.py:48`) | KEEP (demoted) | Info chip in the context bar, same as Strategy §2.1. |
+| 2 | GP → Driver cascading selectors (`:50-74`) | KEEP | `Combobox`es, URL-bound, driver name in team colour. |
+| 3 | Lap-range slider + single-lap slider BOTH always visible (`:88-100`) | IMPROVE | Only the control the active model uses renders: Pace → `DualRangeSlider`; Tyres/Overtake/SC/Pit → single `Slider`; Radio → corpus pickers. Kills the "which slider matters?" confusion. |
+| 4 | `_fetch_lap_state` + session-state cache (`:105-132`) | KEEP (free) | TanStack Query keyed `['lab','lap-state',gp,driver,lap]`, staleTime Infinity. |
+| 5 | Lap-state 404 → "driver may have retired" warning (`:118-129`) | KEEP + IMPROVE | Inline in context bar + one-click "jump to last valid lap" (max from `/lap-range`). |
+| 6 | 6 tabs, each Run → metrics → chart → reasoning (`:896-929`) | KEEP (reshaped) | Model rail (vertical tablist) + ONE shared `RunFrame`; same run→metrics→viz→reasoning grammar for all six. §3. |
+| 7 | Pace: batch lap-range run, 45–60 s spinner (`:209-267`) | KEEP + IMPROVE | Elapsed timer + honest "~N laps · typically 45–60 s" framing + chart skeleton + Cancel (AbortController). No fake staged copy — it's one POST. P4-9. |
+| 8 | Pace chart: actual-vs-pred + CI band + compound dots + stint vlines + MAE badge (`:139-206`) | KEEP | ECharts: line + `ci_p10/p90` band, compound-coloured scatter via `tireColors`, stint `markLine`s, MAE chip in card header. Null `pred` rows (stint-first laps) render as gaps, never zeros. |
+| 9 | Pace summary metrics: last pred / CI / range MAE (`:240-263`) | KEEP | 3 `StatCard`s. |
+| 10 | Tyres: warning badge + 4 metrics (deg rate, cliff P10/50/90) (`:367-388`) | KEEP | `Pill` (PIT_SOON danger / MONITOR warning / OK success) + `StatCard`s, deg rate in mono. |
+| 11 | Tyres: overlay cliff bar chart (`:274-311`) | IMPROVE | Replace the confusing 3-overlaid-bars with a **`StintRunway`** — the lap-axis strip from Strategy's `StintTimeline`, reused: "now" marker → P10→P50→P90 cliff gradient zone. Same data, legible form. |
+| 12 | Tyres: degradation projection line + P50 cliff vline (`:314-347`) | KEEP | ECharts line + `markLine` at P50 cliff; area fill under curve. |
+| 13 | 60-lap cliff cap + "capped" caption (`:370-394`) | KEEP | Domain guard, honest caption. Cap in the view layer, raw values in the run record. |
+| 14 | Overtake: threat badge + probability gauge (`:441-466`) | KEEP + IMPROVE | Existing `Gauge` primitive + **threshold tick at 0.80** (the model's real `high_overtake` decision threshold from CFG) with caption. Threat `Pill`. |
+| 15 | Overtake: contextual-factors panel + factor bars (`:468-505`) | **DROP (dead)** → REPLACE | Field never exists (Discovery 1). Replace with a **SituationFacts strip** of what `/situation` actually returns: gap-ahead chip (DRS badge when <1.0 s), pace-delta trend arrow (±s/lap vs car ahead), `sc_currently_active` flag. Real data, zero backend work. |
+| 16 | SC: gauge (sc_prob_3lap) (`:534-538`) | KEEP + IMPROVE | `Gauge` + threshold tick at 0.30 (`high_sc`). |
+| 17 | SC: 3/5/7-lap horizon bars (`:539-558`) | **DROP (fabricated)** → REPLACE | Discovery 2: 5/7-lap values are invented multipliers. Replace with an honest **baseline-lift bar**: this lap's P(SC≤3 laps) vs the season base rate (the model's real framing — lift 1.67× headline from N14). **§6.4 parity row needs amending** — flagged, with rationale, rather than silently ported. |
+| 18 | SC: contextual factors panel (`:562-569`) | DROP (dead) | Same nonexistent field. SituationFacts strip covers it. |
+| 19 | Overtake & SC each POST `/situation` separately (`:445,520`) | IMPROVE | ONE shared situation run feeds both models' views (Discovery 3). Running either fills both; a "shared run — Situation agent scores both" caption keeps it honest. Halves calls, kills divergence. |
+| 20 | Pit: compound badge + stop P05/50/95 metrics (`:597-611`) | KEEP + IMPROVE | `CompoundPill` (strategy spec) + `ActionBadge` for `action` — **vocab must add `REACTIVE_SC`** (PitStrategyOutput emits it; strategy's 5-value enum doesn't include it): siren icon, danger, subtle pulse. |
+| 21 | Pit: 3-bar stop-duration chart (`:615-635`) | IMPROVE | P05—P50—P95 is one distribution, not 3 categories: render a horizontal **interval strip** (dumbbell: band P05→P95, dot at P50, mono labels). Honest, half the height. |
+| 22 | Pit: undercut gauge + window details (`:639-661`) | KEEP | `Gauge` (threshold 0.522 — N16's operating point) + detail list: `ActionBadge`, target driver in team colour, recommended lap. All fields nullable → conditional render. |
+| 23 | Radio: dual mode toggle (`:765-779`) | KEEP | Segmented `Tabs`: "Race radio" / "Free text". Both modes are §6.4 parity. |
+| 24 | Radio lookup: own GP/driver/lap pickers + transcript preview (`:782-830`) | KEEP + IMPROVE | Corpus has its own GP list (`/radio-available-gps`) — inherit the page GP/driver when present in the corpus, else prompt. Lap picker shows "(N with radio)"; transcript preview as a mono quote card. |
+| 25 | Radio free text: textarea + analyse (`:854-879`) | KEEP + IMPROVE | Add 3 example chips ("Box box box, Plan B", "Tyres are gone", "Yellow flag sector 2") that fill the textarea — demo-friendly. Text never goes in the URL. |
+| 26 | Radio results: alerts + NLP message cards (sentiment/intent/entities) + reasoning (`:672-762`) | KEEP + IMPROVE | `NlpMessageCard` component (sentiment-tinted edge, sentiment `Pill`, intent chip, typed entity chips) — **build once, share with Race Analysis Tab 3** (§6.3 renders the identical shape). |
+| 27 | `RadioOutput.corrections` + `rcm_events` | **NEW (dropped today)** | Discovery 3: render corrections as an "LLM cross-check" panel (original intent → suggested intent + reason) and RCM events as flag-coloured rows. Free data. |
+| 28 | Results persist silently across selector changes (`ml_*_result` keys) | IMPROVE | Stale-run honesty (same contract as Strategy): result stays visible but gets an amber "context changed — result is for Lap 18 / Monaco" banner + Re-run. |
+| 29 | `_warning_badge` / `_metric_html` raw-HTML injection | DROP | `Pill` / `StatCard` primitives carry it. |
+| 30 | Purple-border chart CSS injection (`:891`) | DROP | `ChartCard` + tokens. |
+
+Zero functional loss except two deliberate, documented drops (#15, #17) whose replacements show MORE real information than the originals.
+
+## 3. Layout & IA
+
+Route `/lab` (stub exists, `router.tsx:55-58`).
+
+**IA verdict: not 6 flat content-tabs — a model rail + one shared bench.** The six models keep tab semantics (vertical `role=tablist`), but each rail entry is a **model identity card**: icon, name, model-type chip (XGBoost / TCN+MC / LightGBM / HistGBT+LGBM / NLP×3), thesis eval headline (MAE 0.411 s · AUC-PR 0.549 · …), and a run-status dot (idle ○ / running ◐ pulse / done ● / stale ◍ amber). The rail answers at a glance "which models have I run against this moment?" — impossible in flat tabs. Below 1024 px the rail collapses to the horizontal segmented `Tabs` with the same status dots.
+
+```
+┌ Header: "Model Lab"                                  [→ Send to Strategy] ┐
+│ ╔═ CONTEXT BAR (sticky, acrylic) ═════════════════════════════════════╗   │
+│ ║ (2025 ·chip) [Grand Prix ▾]  [Driver ▾ NOR]   ⟨per-model lap ctrl⟩  ║   │
+│ ║   Pace:   Lap window ●━━━━━━━● 8–28                                 ║   │
+│ ║   others: Lap ●━━━○━━━ 18   · lap-state chip: ⟨MEDIUM · age 12 · P4⟩║   │
+│ ║   Radio:  [GP w/ radio ▾][Driver ▾][Lap (7 with radio) ▾] | mode ⇄  ║   │
+│ ╚═════════════════════════════════════════════════════════════════════╝   │
+│ ┌ MODEL RAIL ─────────┐ ┌ BENCH — RunFrame (shared scaffold) ──────────┐  │
+│ │ ● Pace              │ │ ┌ run header ────────────────────────────┐  │  │
+│ │   XGBoost·MAE .411s │ │ │ Tyre degradation · TCN + MC-Dropout    │  │  │
+│ │ ◐ Tyres      ←activo│ │ │ ⟨run for Lap 18 · 14:32⟩  [▶ Run] [✕]  │  │  │
+│ │   TCN·MC N=50       │ │ └────────────────────────────────────────┘  │  │
+│ │ ● Overtake ┐ shared │ │ [PIT_SOON pill]  [.041 s/lap][P10 6][P50 9] │  │
+│ │ ● Safety c ┘ run    │ │ ┌ STINT RUNWAY ──────────────────────────┐  │  │
+│ │ ○ Pit               │ │ │ now▼        ▒P10═P50═P90▒ cliff zone   │  │  │
+│ │ ○ Radio             │ │ └────────────────────────────────────────┘  │  │
+│ │                     │ │ ┌ DEG PROJECTION (ECharts line+cliff) ───┐  │  │
+│ │ run history ▾       │ │ └────────────────────────────────────────┘  │  │
+│ │  · L18 14:32 ●      │ │ ▸ 🧠 Agent reasoning (Markdown disclosure)  │  │
+│ │  · L18 14:29 ●      │ └──────────────────────────────────────────────┘  │
+│ └─────────────────────┘                                                    │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+**The shared frame contract** — every model renders the same four zones in order: (1) run header (title, model chip, run-context timestamp chip, Run/Re-run/Cancel), (2) verdict row (`Pill`s/`ActionBadge` + `StatCard`s), (3) viz zone (1–2 charts/gauges), (4) reasoning disclosure (`Markdown`, never truncated). Per model:
+
+| Model | Verdict row | Viz zone |
+|---|---|---|
+| Pace | last pred · CI P10–P90 · range MAE | actual-vs-pred chart (CI band, compound dots, stint lines) |
+| Tyres | warning `Pill` · deg rate · cliff P10/50/90 | `StintRunway` + deg projection line |
+| Overtake | threat `Pill` · SituationFacts strip (gap/DRS · Δpace · SC-active) | `Gauge` w/ 0.80 threshold tick |
+| Safety car | threat `Pill` · SituationFacts strip | `Gauge` w/ 0.30 tick + baseline-lift bar |
+| Pit | `ActionBadge` · `CompoundPill` · rec lap | stop-duration interval strip + undercut `Gauge` (0.522 tick) + window details |
+| Radio | alert banners (severity-sorted) | `NlpMessageCard` list + corrections panel + RCM rows |
+
+**States (per model, independent):**
+- **Idle** — identity card hero: one-line "what this model does", eval headline, ghosted preview sketch, `[▶ Run]` (disabled-with-reason until context complete; Radio-lookup additionally until a lap with radio is picked).
+- **Running** — Run→Cancel, elapsed mono timer. Pace: chart-shaped `Skeleton` + "Scoring ~21 laps · typically 45–60 s" (no fake stages — it's one POST; StatusStepper would be theatre here). Others resolve in ≤ a few s: button spinner + result skeleton.
+- **Done** — zones reveal staged (verdict → viz → reasoning, ≤400 ms total, motion-safe); run-context chip pinned ("Lap 18 · ran 14:32").
+- **Stale** — context no longer matches the run: amber banner "Result is for Lap 18 — you're now on Lap 22" + Re-run. Result never silently lies (fixes #28).
+- **Error** — 422/404 inline error card w/ agent name + Retry (config preserved); lap-state DNF 404 pinned to context bar with "jump to last valid lap"; 429 → `Toast` with limit info (pace-range is 5 runs/10 min — surface the budget).
+
+**Cancel** is a client abort (AbortController); the pace-range run continues server-side — the button says "Stop waiting" semantics and the toast notes the rate-budget still burns. Honest, zero backend change.
+
+## 4. Components
+
+**Reuse as-is:** `Combobox`, `Slider` + `DualRangeSlider` (from #35), `Tabs` (mobile rail + radio mode toggle), `Card`, `ChartCard`, `StatCard`, `Pill`, `Skeleton`, `EmptyState`, `Toast`, `Tooltip`, `Button`, `Markdown`, **`Gauge`** (`charts/Gauge.tsx` — built for exactly these three probabilities), ECharts + `F1_THEME` + `tireColors`, `lib/drivers.ts` (team colours; already promoted by #35).
+
+**Shared-primitive extensions (coordinate with #35):**
+- `Gauge` + optional `threshold?: number` prop — a hairline tick + caption at the model's real decision threshold (0.80 overtake · 0.30 SC · 0.522 undercut). One prop, big honesty win; keeps the clean progress-arc design (no traffic-light bands).
+- `ActionBadge` vocab + `REACTIVE_SC` (siren, danger, subtle pulse) — the Pit agent emits it; strategy's enum missed it.
+- `CompoundPill` — used verbatim (pit rec, pace-chart legend, lap-state chip).
+- `StintTimeline` (strategy spec) → parametrize into **`StintRunway`** shared under `src/components/` or `features/agents/`: Lab uses the bare form (now + cliff zone), Strategy the annotated form (+ pit target ▲, stint end).
+
+**New shared (build here, consumed elsewhere):**
+- `NlpMessageCard` — sentiment-edge card: sentiment `Pill`, intent chip, typed entity chips (driver/team/track entities get icons), mono transcript. **Race Analysis Tab 3 (§6.3) renders the identical shape — build once in `src/components/`, not feature-local.**
+
+**Feature-local (`webapp/src/features/lab/`):**
+- `LabPage.tsx` — owns URL, cascade resets, threads context.
+- `ModelRail.tsx` — vertical tablist of `ModelRailItem`s (identity + status dot); collapses to `Tabs` <1024 px.
+- `LabContextBar.tsx` — GP/Driver combos + per-model lap control + lap-state preview chip.
+- `RunFrame.tsx` — the shared scaffold; consumes a `ModelDef` (`{id, icon, title, modelChip, evalHeadline, contextNeeds, run, ResultView}`) — adding a 7th model = one registry entry.
+- `models/` — `PaceResultView`, `TyreResultView`, `SituationResultView` (two lenses: overtake/SC over ONE run), `PitResultView`, `RadioResultView` (+ `RadioLookupControls`, `FreeTextControls`, `CorrectionsPanel`), each with pure ECharts option-builder fns (`buildPaceChartOption` etc.) exported for reuse by Strategy's agent micro-tabs.
+- `RunHistoryStrip.tsx` — per-model past runs (context chip + verdict glyph); click restores.
+- `store.ts` — Zustand run records; `search.ts` — URL contract.
+
+## 5. Interactions & flows
+
+1. **Pick a model** — rail click; URL `model=` updates; bench swaps `ResultView` (fade ≤180 ms); context bar swaps the lap control. Status dots persist across switches.
+2. **Set the moment** — GP → Driver (cascade clears downstream); lap slider live-updates the lap-state chip (query prefetch on release, so single-lap models show compound/age/position before any run). Pace never fetches lap-state (server builds per-lap states itself).
+3. **Run** — mutation fires; button → Cancel + elapsed. Overtake/SC: one `/situation` mutation, `onSuccess` writes a run record tagged for BOTH models (rail shows both dots filled).
+4. **Read** — verdict first, viz second, reasoning one disclosure away. Threshold ticks put every probability in context ("87% vs the 80% action threshold").
+5. **Iterate** — nudge the lap → stale banner → Re-run; each run appends to history; two same-model runs at the same context expose MC-Dropout / LLM variance (tyre P50 wobble is a *feature* to show, not hide).
+6. **Radio dual-mode** — mode toggle in the bench (not the context bar). Lookup: corpus GP ▾ (auto-inherits page GP when the corpus has it, marked "inherited") → driver ▾ → lap ▾ ("7 with radio") → transcript quote card → Analyse. Free text: textarea + example chips → Analyse. Both funnel into the same `RadioResultView`.
+7. **Send to Strategy** — header action deep-links `/strategy?gp=…&driver=…&laps=…` prefilled ("what does the full council say about this moment?"). Never auto-runs (strategy rule).
+
+## 6. Data & migration notes
+
+All under `/api/v1/strategy` (`backend/api/v1/endpoints/strategy.py`):
+
+| Endpoint | Line | Rate limit | Notes |
+|---|---|---|---|
+| `GET /available-gps?year` · `/available-drivers?gp&year` · `/lap-range?gp&driver&year` | 235/244/254 | — | Shared with Strategy; same query keys → cache shared across pages. |
+| `GET /lap-state?gp&driver&lap&year` | 269 | — | 404 = DNF/no telemetry → context-bar error + jump-to-valid. |
+| `POST /pace-range {year,gp,driver,lap_start,lap_end}` | 419 | **5 / 10 min** | → `{predictions[{lap,actual,pred,ci_p10,ci_p90,compound,stint}], count}`. `pred:null` on stint-first laps (no `Prev_LapTime`) → chart gaps. 45–60 s. |
+| `POST /tire {lap_state}` | 538 | 20 / min | → `TireOutput`: `compound, current_tyre_life, deg_rate, laps_to_cliff_p10/p50/p90, warning_level(PIT_SOON\|MONITOR\|OK), reasoning`. |
+| `POST /situation {lap_state}` | 564 | 20 / min | → `RaceSituationOutput`: `overtake_prob, sc_prob_3lap, threat_level(LOW\|MEDIUM\|HIGH), gap_ahead_s, pace_delta_s, sc_currently_active, reasoning`. **Feeds both Overtake and SC views.** NO `contextual_factors`, NO 5/7-lap fields — do not type them. |
+| `POST /pit {lap_state}` | 590 | 20 / min | → `PitStrategyOutput`: `action(…+REACTIVE_SC), recommended_lap?, compound_recommendation, stop_duration_p05/p50/p95, undercut_prob?, undercut_target?, sc_reactive, reasoning`. Nullable undercut pair → conditional render. |
+| `POST /radio {lap_state, radio_msgs[], rcm_events[]}` | 616 | 20 / min | → `RadioOutput`: `radio_events[] (NLP dicts — type tolerantly: sentiment/intent/entities nested under `.analysis` or top-level), rcm_events[], alerts[], reasoning, corrections[{driver,original_intent,suggested_intent,span,reason}]`. Do NOT send a `source` key in radio_msgs (crashes `RadioMessage` — Streamlit comment `:837`). |
+| `GET /radio-available-gps?year` · `/radio-laps?gp&year[&driver]` · `/radio-transcript?gp&driver&lap&year` | 745/763/824 | — | Corpus lookups; `radio-laps` returns per-driver `laps[{lap,text,has_transcript,audio_path}]`. |
+
+Types in `lib/api/strategy.ts` (extend #35's file — same schemas, one source of truth).
+
+**URL** (`features/lab/search.ts`, raw↔component boundary as Dashboard): `/lab?model=tyres&gp=Hungarian Grand Prix&driver=NOR&lap=18&laps=8-28&rmode=lookup&rgp=…&rdrv=VER&rlap=12`. `model` 6-enum default `pace`; `lap` clamped to `/lap-range` after fetch; `laps` encoded `a-b`; radio params only serialized when ≠ inherited context; free text NEVER in URL. Cascade: gp→clears driver/lap/laps/radio-overrides; driver→clears lap/laps. **Deep links reproduce config, never auto-run** (compute + rate budget).
+
+**State split:** TanStack Query staleTime Infinity for gps/drivers/lap-range/lap-state/radio-corpus lookups. Model runs = **`useMutation`** (MC-Dropout + LLM reasoning are non-deterministic — a cache "hit" would misrepresent a fresh run), `onSuccess` appends to Zustand `features/lab/store.ts`: `runs: LabRun[]{id, model, context{gp,driver,lap|lapRange|radioInput}, result, ranAt}` (cap ~30, sessionStorage), `activeRunByModel: Record<ModelId, runId>`. Situation runs register under both `overtake` and `safetycar`. Stale = `run.context ≠ current context` (pure compare, rendered by `RunFrame`).
+
+**Parity amendment to flag in the PR:** §6.4 row "Safety car: gauge + 3/5/7-lap horizon bars" — the 5/7-lap bars are client-fabricated (`model_lab.py:542-543`); this spec replaces them with the real 3-lap probability + baseline-lift framing. Update the row to "gauge + baseline-lift comparison" with a pointer here.
+
+## 7. New features (ranked) & the Strategy overlap
+
+1. **Model identity cards w/ thesis eval headlines** ⚡ (S) — type chip + headline metric (pace MAE 0.4104 s · tyre coverage 0.7078 · overtake AUC-PR 0.5491 · SC 0.0723 (lift 1.67×) · pit P50 MAE 0.4893 s · undercut 0.6739) as static registry constants sourced from the IEEE report. Makes the Lab a model museum — the defense flex.
+2. **Run history + variance view** ⚡ (M, = plan E10) — history strip per model; select two runs of the same model+context → overlay (two runway zones / two dials) exposing MC-Dropout spread. Store already holds the records.
+3. **Surface the dropped Radio fields** ⚡ (S) — corrections cross-check panel + RCM event rows. Free data, real insight.
+4. **SituationFacts strip** ⚡ (S) — gap/DRS + Δpace + SC-active replacing the dead factors panel. Free.
+5. **Send to Strategy / from Strategy** (S) — cross-links both ways ("inspect this instrument" ↔ "convene the council"). URL-only.
+6. **Lap sweep for single-lap models** (M) — run Tyres (or Situation) across N laps sequentially (respects 20/min) → cliff-vs-lap curve; the pace-range treatment generalized. Client-side loop, progress per lap, cancelable.
+7. **Progressive pace streaming** (M, backend-additive) — SSE/NDJSON variant of `/pace-range` emitting per-lap rows → chart paints as it computes, killing the 45–60 s black box. Not parity; note the seam (`RunFrame` running-state accepts partial results).
+8. **Radio audio playback** (S, backend-additive) — corpus rows carry `audio_path`; a static-file route would enable a play button on `NlpMessageCard`.
+
+**Share vs keep distinct (Strategy's agent tabs = same 4 predictors):**
+- **SHARE:** result types (`lib/api/strategy.ts`), pure chart option-builders (`buildPaceChartOption`, `buildCliffRunway`, …), `Gauge`+threshold, `ActionBadge`/`CompoundPill`/`Pill` vocab, `StintRunway`, `NlpMessageCard` (also Race Analysis). Strategy's micro-tabs render the SAME builders at `size="micro"`; the Lab renders `size="full"`. One visual language for one model family — a tyre cliff looks identical everywhere.
+- **KEEP DISTINCT:** the page frames. Lab = run controls + history + education (you fire the model). Strategy tabs = read-only evidence of an orchestrator run (the council fired it). Merging them would blur *who ran what when* — precisely the provenance the stale-run contract protects.
+
+## 8. Better than Streamlit
+
+One relevant lap control instead of two always-on sliders · zero dead UI (empty factors panel gone) and **zero fabricated data** (invented 5/7-lap bars replaced by real baseline-lift) · one `/situation` run feeds two views instead of two divergent runs · stale results labelled instead of silently lying · thresholds ON the dials (a probability finally means something) · corrections + RCM events surfaced (dropped on the floor today) · 45–60 s run is cancelable, framed, and skeleton'd instead of a blind spinner · deep-linkable model+moment · run history makes MC variance a demo feature · model identity cards turn six forms into an instrument collection · one design system (no injected HTML badges/CSS).
+
+## Acceptance criteria (#38, condensed)
+
+§6.4 rows pass (with the documented SC-horizon amendment) · all six models runnable from one context in ≤3 interactions after page load · Overtake+SC provably share one request (network assert in test) · pace-range cancel leaves UI consistent + budget toast · stale banner appears on any context change post-run · `pred:null` laps gap the pace chart (fixture test) · REACTIVE_SC renders a designed badge (not the unknown fallback) · radio free-text round-trips without URL leakage · keyboard: rail is arrow-navigable tablist, Run reachable, disclosures toggle on Enter · reduced-motion: no pulse dots, no staged reveal.
+
+**Key files:** `frontend/pages/model_lab.py` (the source, 930 LOC) · `backend/api/v1/endpoints/strategy.py:398-870` (all endpoints) · output schemas `src/agents/{pace_agent.py:66, tire_agent.py:339, race_situation_agent.py:170, pit_strategy_agent.py:151, radio_agent.py:190}` · grammar `webapp/src/features/dashboard/{search.ts,store.ts,queries.ts,DashboardPage.tsx}` · `webapp/src/charts/Gauge.tsx` (exists — extend, don't rebuild) · sibling specs `docs/migration/design-specs/{strategy.md,comparison.md}` (shared vocab) · route stub `webapp/src/app/router.tsx:55-58`.

--- a/docs/migration/design-specs/race-analysis.md
+++ b/docs/migration/design-specs/race-analysis.md
@@ -1,0 +1,134 @@
+# Race Analysis — Design-First Spec (issues #36/#37)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Race Analysis tab's functionality and build the elevated migrated interface, NOT a port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts+F1_THEME, design-system primitives) and the shared decisions in `strategy.md` / `comparison.md` (CompoundPill, raw↔component URL boundary, state-tier contract, never-auto-fire-LLM rule).
+
+## 1. Purpose & the job
+
+Race Analysis is the **post-race debrief room**: the only surface that looks at a WHOLE race, whole field, through the engineered features the ML models trained on (fuel-adjusted degradation, deg rate, gap consistency — the featured parquet itself). Job: *"Load any 2025 race, pick up to 3 drivers, and reconstruct the strategic story: how the tyres died, where the pit windows opened, what the radio said, and what the rulebook allowed."* Dashboard = one lap's telemetry; Strategy = one lap's decision; Comparison = one lap head-to-head; **Race Analysis = the 60-lap narrative.**
+
+**THREE KEY DISCOVERIES (all fixable client-side, zero backend work):**
+1. **The radio lookup analyzes nothing.** `race_analysis.py` posts `/strategy/radio` with `lap_state` only and an EMPTY `radio_msgs` list — the agent needs the transcript IN `radio_msgs` (docstring `radio_agent.py:1106`; Model Lab does it right at `model_lab.py:838`). Today's tab runs the whole NLP stack on zero messages.
+2. **RAG citations never render.** Streamlit reads `data["sources"]` — the backend returns `{question, answer, chunks[{text,article,doc_type,year,score}], articles[]}` (`rag_agent.py:91`, `RegulationContext`). The `sources` key doesn't exist, so the citations expander is permanently empty while real article references sit unused in every response.
+3. **The NLP payload is half-discarded.** `run_pipeline` (`radio_agent.py:552`) returns `sentiment_score`, `intent_confidence`, entity `label`s and LLM `corrections[]` (the model auditing the NLP classifiers) — Streamlit drops all four. Also its intent icon map (`box_call`, `tyre_info`…) never matches the real vocab (`INFORMATION·PROBLEM·ORDER·WARNING·QUESTION`), so intent icons have never displayed.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" warning (`race_analysis.py:60`) | KEEP (demoted) | `2025 season` chip in the context bar, per strategy.md #1. |
+| 2 | GP selectbox + explicit "Load race data" button (`:70-95`) | KEEP + IMPROVE | GP `Combobox` URL-bound; **auto-fetch on selection** (TanStack Query kills the rerun-refetch reason the button existed for; picking from a combobox is already deliberate intent). The §6.3 "loader panel" = the context bar's loading state, cancellable. |
+| 3 | Manual CSV/parquet upload in expander (`:141`) | KEEP + IMPROVE | `FileDrop` (.csv/.parquet) inside a "Local data" disclosure of the context bar; becomes the offline/no-backend demo path. Sets a `Local dataset` pill; cleared by picking a GP. |
+| 4 | Driver multiselect max 3 filtering "all tabs" (`:99`) | KEEP + FIX the lie | Multi-`Combobox` cap 3 (Dashboard `MAX_DRIVERS` grammar), team-colour names, URL-bound. Truth today: it filters ONLY Tyres+Gaps (Radio has its own selector; Overview shows the unfiltered head(50)). Define the contract: filters Tyres+Gaps; Dataset gets an All/Selected toggle; Radio browser seeds from first selected driver. Filtering is **client-side over the cached frame — zero network**. |
+| 5 | "Viewing: GP · drivers · laps" caption (`:120-131`) | KEEP + IMPROVE | Proper context strip: GP · `2025` · N drivers · N laps + compounds seen (`CompoundPill` row) — absorbs half of Overview's metrics. |
+| 6 | Tab 1 Tyre deg: compound selectbox + 5 charts (`tire_charts.py`, `race_viz.py`) | KEEP all 5 | Chart switcher (segmented `Tabs`) + "Show all" stacked toggle per §6.3. Compound selector → `CompoundPill` toggle group (only compounds present). Driver-colour lines + compound dash encoding preserved verbatim. |
+| 7 | Tab 2 Gaps: 3 charts + 3-metric summary (`gap_charts.py`) | KEEP + IMPROVE | ECharts (zones → `markArea`, thresholds → labelled `markLine`); summary → 3 `StatCard`s **split per driver** (today the counts blur all selected drivers together) and clickable → highlights qualifying laps on the gap chart. |
+| 8 | Radio activation gate button (`:171-183`) | DROP (cause gone) | Existed to avoid corpus refetch on every Streamlit rerun/tab switch. TanStack Query fetches once on first tab open (`enabled`), cached forever. |
+| 9 | Radio driver/lap dropdowns (blind lap numbers) (`:196-224`) | IMPROVE hard | The `/radio-laps` response ALREADY ships transcript preview text per lap — Streamlit discards it and makes you pick a lap number blind. Build a **radio browser**: driver rail (team colours + message counts) → message list with transcript previews → select → Analyse. |
+| 10 | "Analyse radio" → `render_radio_panel(lap_state)` (`:230`) | KEEP + **FIX BUG** | Must post `radio_msgs=[{driver, lap, text}]` with the corpus transcript (discovery #1). Never pass `source` (crashes `RadioMessage`, per `model_lab.py:837`). |
+| 11 | Radio result: alerts + message cards + sentiment badge + intent + entity chips (`radio_panel.py`) | KEEP + IMPROVE | Premium NLP result card (§3): sentiment `Pill` + score, intent pill w/ correct-vocab lucide icon + confidence, **entities highlighted inline in the transcript**, alerts row, corrections footnote, reasoning disclosure. |
+| 12 | Radio "free text" expander with driver+lap inputs, NO text field (`:263-280`) | REPLACE | It's mislabelled and posts empty `radio_msgs` → analyzes nothing. Replace with a real free-text composer (textarea → `radio_msgs=[{driver:'UNK', lap:1, text}]`, Model Lab pattern) — one shared component that §6.4's Model Lab radio tab reuses. |
+| 13 | Radio JSON download (`:243`) | KEEP | Card header action, filename `radio_{gp}_{driver}_lap{lap}.json`. |
+| 14 | Tab 4 RAG: textarea + query button + answer markdown (`:283-300`) | KEEP + IMPROVE | Query card with suggested-question chips; answer via `Markdown`. |
+| 15 | RAG "Sources" expander (`:295`) | FIX (dead today) | Render `articles[]` as citation chips + `chunks[]` as expandable source passages with doc_type/year/similarity (discovery #2). |
+| 16 | RAG JSON download (`:305`) | KEEP | Card action, serializes the full result verbatim. |
+| 17 | Tab 5 Overview: 3 metrics + columns expander + `df.head(50)` + CSV export (`:315-345`) | KEEP + IMPROVE | Metrics absorbed into context strip; **full virtualized `DataTable`** (not head-50) with column-group presets (Timing / Tyres / Speeds / Gaps / Weather — 26 cols is too many at once); CSV export via DataTable's built-in `buildCsv`. |
+| 18 | Per-tab downloads (§6.3 row) | KEEP + EXTEND | Radio/RAG JSON as today; Dataset CSV; Tyres/Gaps get "Download series (CSV)" as a `ChartCard` action (new, cheap). |
+| 19 | Purple-border chart CSS injection (`:150`) | DROP | `ChartCard` + tokens carry the language (same verdict as strategy.md #21). |
+| 20 | `add_race_lap_column` on upload (`race_processing.py:12`) | KEEP (port) | Pure TS port (LapNumber from Stint+TyreAge cumulative), unit-tested; runs only on uploaded files missing `LapNumber`. |
+| 21 | Client `calculate_gap_consistency`/`calculate_strategic_windows` (`race_processing.py:44,99`) | KEEP (port, upload-only + windows) | `/race-data` already returns `consistent_gap_*`; port both as pure fns — consistency needed for uploads, strategic windows always derived client-side (trivial boolean masks). |
+
+**IA verdict — 5 flat tabs is the wrong grouping, keep 5 areas but in two families.** Tyres/Gaps/Dataset are views of ONE loaded frame; Radio needs only the GP (corpus, not parquet); Regulations needs NOTHING. Streamlit gates all five behind "Load race data" — the redesign gates only the three data tabs, enables Radio as soon as a GP is picked, and **never gates Regulations** (asking a rules question shouldn't require downloading a race).
+
+## 3. Layout & IA
+
+Route `/race` (stub exists, `router.tsx:49-51`).
+
+```
+┌ Header: "Race Analysis"                                  [🔗 Copy link] ┐
+│ ╔═ CONTEXT BAR (sticky, acrylic) ══════════════════════════════════════╗
+│ ║ (2025 · chip) [Grand Prix ▾ Spanish GP]  [Drivers ▾ VER✕ NOR✕ (max 3)]║
+│ ║ loaded strip:  1 182 rows · 20 drivers · 66 laps · 🛞 S M H          ║
+│ ║ ▸ Local data (FileDrop .csv/.parquet)        [Local dataset ✕] pill  ║
+│ ╚═══════════════════════════════════════════════════════════════════════╝
+│ ── Tabs (underline, URL-bound) ─────────────────────────────────────────
+│   TYRES   GAPS   DATASET   │   RADIO   REGULATIONS
+│   └── need loaded data ──┘     └ GP only┘ └ always on ┘
+│
+│ [TYRES]  CompoundPills (S)(M)(H) · switcher: Speed│Fuel-adj│Reg-vs-adj│Rate│% · [Show all]
+│   ┌ STINT GANTT (new): per driver, compound blocks across laps ────────┐
+│   │ VER ▓S▓▓▓│▓▓M▓▓▓▓▓│▓H▓▓   NOR ▓M▓▓▓▓│▓H▓▓▓▓▓                      │
+│   └ ChartCard: active chart (driver colour + compound dash) ───────────┘
+│ [GAPS]   ┌ Gap evolution ┐ ┌ Undercut zones (markArea) ┐
+│          └ Consistency bars ┘  StatCards/driver: Undercut 4 · Overcut 2 · Defend 3
+│ [RADIO]  ┌ browser: drivers rail → msg list w/ transcript previews ┐
+│          │ ▶ lap 23 "box box, we are…"  [Analyse]                  │
+│          └ NLP RESULT CARD: alerts row · blockquote transcript with │
+│            highlighted entities · sentiment+intent pills w/ conf %  │
+│            · corrections footnote · ▸ reasoning · [⬇ JSON]          │
+│          ▸ Free-text composer (shared w/ Model Lab)                 │
+│ [REGULATIONS] query card + suggested chips → ANSWER CARD:           │
+│            Markdown answer · citation chips ⚖ Art 48.3 ⚖ Art 55.1  │
+│            · ▸ source passages (doc_type · year · score) · [⬇ JSON] │
+│            · session Q&A history rail                               │
+│ [DATASET] column presets: Timing│Tyres│Speeds│Gaps│Weather · All/Selected
+│            virtualized DataTable (full frame) · [⬇ CSV]             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**States:** Idle (no GP: EmptyState hero + GP quick-pick from `available-gps` + FileDrop; only Regulations tab live) · Loading (context strip skeleton + tab-area `Skeleton`, cancellable AbortController) · Loaded (tabs enable, staged ≤300ms; no drivers selected → Tyres/Gaps show EmptyState with **podium quick-pick chips** — one click seeds the filter from final-lap `Position`) · Error (`/race-data` 404/500 → inline error card + Retry + FileDrop promoted as the fallback — its real job) · Upload-active (`Local dataset` pill; GP combobox cleared; radio/RAG unaffected) · Radio no-corpus (EmptyState "No radio corpus for this GP" + free-text composer still available) · RAG rate-limited (429 → Toast + button cooldown, burst capacity 5).
+
+## 4. Components
+
+Reuse: `Tabs` (underline top-level, segmented for the tyre chart switcher), `Combobox` (GP, drivers cap 3), `FileDrop`, `Pill` (+`compound` prop for tyre chips; tones for sentiment/intent/alerts), `DataTable`+`buildCsv`, `ChartCard` (collapse + actions slot), `StatCard`, `EmptyState`/`Skeleton`/`Toast`/`Tooltip`/`Button`/`Card`, `Markdown` (RAG answers, radio reasoning), ECharts+`F1_THEME`, `tireColors`, dashboard `lib/compounds.ts` (CompoundID→name map lives here) and `lib/drivers.ts` (lifted to `src/lib/` per strategy.md). Shared primitives from strategy.md: `CompoundPill` (stint gantt + compound toggles), `ConfidenceDial` at `sm` (sentiment/intent confidence).
+
+**No new SHARED primitives.** Feature-local (`features/race/components/`): `RaceContextBar` (selectors + loaded strip + FileDrop disclosure), `StintGantt` (SVG lap axis, compound blocks from Driver×Stint×Compound — doubles as the legend for compound dashes), `TyreChartSwitcher` (segmented + show-all; wraps the 5 ECharts builders), `GapCharts` (3 builders + `markArea` zones), `StrategicWindowCards`, `RadioBrowser` (driver rail + message list w/ previews), `RadioResultCard` (alerts + `TranscriptQuote` with entity `<mark>`s + pills + corrections + reasoning), `RadioFreeTextComposer` (**shared seam: Model Lab §6.4 imports this**), `RagQueryCard` + `RagAnswerCard` (+`CitationChip`, `SourcePassage` — Chat's future RAG rendering can lift them), `DatasetTable` (presets + toggle). Pure libs (`features/race/lib/`): `raceFrame.ts` (parse/normalize records, `addRaceLapColumn`, gap consistency + strategic windows ports — ALL unit-tested against Python behaviour), `tyreSeries.ts` / `gapSeries.ts` (frame → ECharts option builders, driver-colour + compound-dash encoding).
+
+## 5. Interactions & flows
+
+1. **Load** — pick GP → auto-fetch `/race-data` (staleTime Infinity) → strip fills, tabs enable. Upload path: FileDrop → parse client-side (CSV via Papa-style parser; parquet via `hyparquet`, lazy-loaded chunk) → normalize through `raceFrame.ts` → same downstream rendering, `Local dataset` pill.
+2. **Filter** — driver chips add/remove instantly (client-side slice of the cached frame, zero refetch). Cascade: GP change clears drivers + radio selection (URL boundary, Dashboard pattern).
+3. **Explore tyres** — compound pill filters chart 1; switcher flips between the 5 views; "Show all" stacks them (ChartCards, collapsible); stint gantt hover highlights that driver's series.
+4. **Explore gaps** — hover unified tooltip (axisPointer); click a window StatCard → `markPoint`s flag its laps; **"Analyse this lap in Strategy" context action** on chart click → deep-link `/strategy?gp&driver&laps=a-b` (prefilled, never auto-runs — coherence with strategy.md §6).
+5. **Radio** — open tab → corpus query fires once → browser renders; select message (URL `rdriver`/`rlap`) → Analyse → POST with the transcript in `radio_msgs` → result card staged reveal (alerts → transcript → pills → disclosure), `aria-live=polite`. Cached per (gp,driver,lap) — re-selecting a past message is instant. Free-text composer always one disclosure away.
+6. **Regulations** — type or tap a suggested chip → POST `/rag` → answer card; each Q&A appends to a session history rail (click restores). Deep link `?q=` prefills, never auto-fires.
+7. **Export** — per-tab: radio JSON, RAG JSON, dataset CSV, chart-series CSV.
+
+## 6. Data & migration notes
+
+Endpoints (all already in `lib/api/schema.ts` — typed client ready, zero backend work):
+- `GET /api/v1/strategy/available-gps?year=2025` (`strategy.py:235`) — GP list matching the featured parquet.
+- `GET /api/v1/telemetry/race-data?year&gp[&driver]` (`telemetry.py:226`) → `{race_data: Record[], count}`; 26 cols (`_RACE_DATA_COLS` + `TyreAge`): Driver, DriverNumber, LapNumber, Stint, SpeedI1/I2/FL/ST, Compound, TyreLife, FreshTyre, Team, Position, CompoundID, LapTime_s, FuelLoad, FuelAdjusted{LapTime,DegAbsolute,DegPercent}, DegradationRate, Air/TrackTemp, GP_Name, GapToCarAhead/Behind, consistent_gap_{ahead,behind}_laps. NaN→null already sanitized. Payload = whole field (~1-3 MB) → fetch once, filter client-side.
+- `GET /api/v1/strategy/radio-available-gps?year` (`strategy.py:746`) — badge radio availability on the GP combobox.
+- `GET /api/v1/strategy/radio-laps?gp&year[&driver]` (`:764`) → `{drivers:[{driver, driver_number, laps:[{lap, text, has_transcript, audio_path}]}]}` — **the browser's preview text is here**.
+- `POST /api/v1/strategy/radio {lap_state, radio_msgs, rcm_events}` (`:616`, rate 20/min) → `result: {radio_events[{message, timestamp, analysis:{sentiment, sentiment_score, intent, intent_confidence, entities[{text,label}], rcm}}], rcm_events[], alerts[{source,intent,message,driver}], reasoning, corrections[{driver, original_intent, suggested_intent, span, reason}]}`. **Contract: transcript goes IN `radio_msgs`** (discovery #1). Intent vocab: INFORMATION·PROBLEM·ORDER·WARNING·QUESTION; sentiment: negative/neutral/positive (normalize case).
+- `POST /api/v1/strategy/rag {question}` (`:656`, burst 5) → `result: {question, answer, chunks[{text, article, doc_type, year, score}], articles[]}` — cite from `articles`, never from answer prose (`rag_agent.py:84-88`: the LLM may hallucinate article numbers; chunk metadata is reliable).
+
+URL (`features/race/search.ts`, raw↔component boundary cloned from Dashboard): `/race?gp=Spanish Grand Prix&drivers=VER,NOR&tab=tyres[&compound=SOFT][&rdriver=VER&rlap=23][&q=...]`. `drivers` CSV upper/dedup/cap-3 (reuse `capDriversCsv` shape); `tab` enum tyres|gaps|dataset|radio|regs default tyres; year constant 2025. GP change cascades: clears drivers, rdriver/rlap, compound. Deep links reproduce selection; **POSTs never auto-fire.**
+
+State tiers: **URL** = gp/drivers/tab/compound/radio-selection/q-prefill · **TanStack Query** (staleTime Infinity) = race-data, radio-available-gps, radio-laps, and radio analyses as queries keyed `['strategy','agent','radio', gp, driver, lap]` enabled on Analyse (the agent-POST-as-query precedent from strategy.md §6 — caching per message for free, mirroring Streamlit's `radio_result_{gp}_{driver}_{lap}`) · **useMutation + Zustand history** = RAG Q&A (free-input generative → `features/race/store.ts`, `ragHistory` cap 10, not persisted) · **Zustand UI** = tyre show-all toggle, dataset column preset + All/Selected (ephemeral; only view-layout persists, Dashboard convention). Uploaded frames live in a non-persisted store slice (too big for storage), flagged `source:'upload'`.
+
+Gotchas: `race_analysis.py` maps codes↔numbers both ways — keep DriverNumber as the join key internally, codes in URL/UI · uploads may lack LapNumber → run `addRaceLapColumn` port · uploads lack gap-consistency cols → run the port before gap charts · `MAX_LAPS=66` clamp in every race_viz builder — preserve · compound dash map (solid/dash/dot/dashdot/longdash by CompoundID) is the established encoding, keep it · radio `laps[].has_transcript=false` entries: show greyed with "no transcript" (analysable only via Whisper on backend — out of scope, disable Analyse).
+
+## 7. New features (ranked)
+
+1. **Stint gantt** ⚡ (S) — the classic tyre-strategy graphic from Driver×Stint×Compound already in the frame; anchors the whole Tyres tab and legends the dash encoding. 
+2. **Entity-highlighted transcripts + confidence meters + corrections** ⚡ (S) — renders payload fields discarded today (`sentiment_score`, `intent_confidence`, entity labels, LLM `corrections[]` = "the model auditing the models", a thesis-demo gem).
+3. **RAG citations + source passages** ⚡ (S) — `articles[]` chips + `chunks[]` disclosures; fixes the permanently-empty Sources expander.
+4. **Radio browser with previews** (M) — transcript text already in `/radio-laps`; kills the blind lap dropdown.
+5. **Per-driver strategic-window cards + chart highlight** (S) — clickable counts → markPoints.
+6. **Cross-links with context** (S) — gap chart lap → `/strategy` prefilled; header "Ask AI about this race" → `/chat` (disabled-w/-tooltip until #39, comparison.md #15 pattern).
+7. **Podium quick-pick** (XS) — empty-filter EmptyState seeds top-3 from final `Position`.
+8. **Position/race-story chart** (M) — Position per lap is in the frame; a 6th "Race story" view (the `/race-data` docstring already envisions position evolution). Backlog, not parity.
+9. **Radio audio playback** (M + backend) — `audio_path` exists in the corpus but no serving endpoint; additive B1 if wanted.
+
+Recommended for the build issue: parity + ranks 1-5 (all client-side, mostly rendering data already in hand); 6-7 cheap follow-ups; 8-9 backlog.
+
+## 8. Better than Streamlit
+
+Radio analysis actually analyzes (the empty-`radio_msgs` bug is structurally impossible: the browser owns the transcript and the POST builder requires it) · RAG answers carry their citations (dead `sources` key → real `articles`/`chunks`) · the NLP result shows its confidence and its self-audit instead of discarding both · browse radio by transcript preview, not blind lap numbers · Regulations never gated behind a data load, Radio needs only the GP · driver filtering is instant and honest about scope (no fake "filters all tabs") · full virtualized table vs head(50) · every view deep-linkable (`tab`, `compound`, radio message in the URL) · no activation-gate ceremony, no injected CSS, one coherent chart language (ECharts F1_THEME, ChartCard, team colours everywhere).
+
+## Acceptance criteria (condensed)
+
+§6.3 parity rows all pass (5 tyre charts, 3 gap charts + summary, radio gate-flow superseded by lazy query + browser, RAG with citation, dataset + exports) · radio POST carries the corpus transcript in `radio_msgs` (regression test: never empty when a corpus message is selected) · RAG card renders `articles[]` when non-empty · `raceFrame.ts` ports (lap column, gap consistency, strategic windows) unit-tested against Python-derived fixtures · upload path: CSV + parquet round-trip renders all three data tabs · URL round-trip incl. `tab`/`rdriver`/`rlap` · Regulations usable with zero race data loaded · driver cap 3 enforced at the search boundary.
+
+**Key files:** `frontend/pages/race_analysis.py` · `frontend/components/race_analysis/{tire_charts,gap_charts,radio_panel}.py` · `frontend/utils/{race_viz,race_processing}.py` · `backend/api/v1/endpoints/telemetry.py:139-284` (`/race-data`) · `backend/api/v1/endpoints/strategy.py:616-871` (`/radio`, `/rag`, radio corpus GETs) · `src/agents/radio_agent.py:552` (pipeline schema) + `src/agents/rag_agent.py:62-111` (`RegulationContext`) · correct radio contract exemplar `frontend/pages/model_lab.py:832-841` · grammar `webapp/src/features/dashboard/{search,store,queries}.ts` + `webapp/src/components/{Tabs,DataTable,FileDrop,Pill,Markdown,ChartCard,StatCard,EmptyState}.tsx` + `charts/echartsTheme.ts` + `styles/tokens.css`.

--- a/docs/migration/design-specs/strategy.md
+++ b/docs/migration/design-specs/strategy.md
@@ -1,0 +1,114 @@
+# Strategy — Design-First Spec (issue #35)
+
+> Design-first blueprint (Fable, 2026-07-14). Take the Streamlit Strategy tab's functionality and build the elevated migrated interface, NOT a 1:1 port. Inherits the Dashboard grammar (URL=selectors, Zustand=UI, TanStack Query=data, ECharts, design-system primitives).
+
+## 1. Purpose & the job
+
+Strategy is the **pit-wall decision surface**: the UI of the N31 multi-agent orchestrator, the crown jewel of the TFG. Its job: *"Put me at any lap of any 2025 race, let me set my risk appetite, and give me a defensible strategy call — with the evidence trail (per-agent analysis, Monte Carlo scores, regulation basis) one click deep."*
+
+Streamlit treats this as a form → results dump. The migrated version = a **three-act experience**: configure a scenario → watch the agent council deliberate → read a decision brief. **KEY DISCOVERY: the orchestrator returns a 14-field v2 recommendation (`src/agents/strategy_orchestrator.py:319`) and Streamlit renders only 6.** The core move is surfacing the whole schema (pit plan, pace instruction, contingencies, key risks) — "a badge and prose" → a genuine strategy brief. Zero backend work.
+
+## 2. Functionality inventory (Streamlit → verdict)
+
+| # | Streamlit feature (file) | Verdict | Why / target |
+|---|---|---|---|
+| 1 | "Only 2025 season data" `st.warning` (`strategy.py:37`) | KEEP (demoted) | Info chip inside the scenario bar, not a full-width banner. §6.2. |
+| 2 | GP selector (`strategy.py:45`) | KEEP | `Combobox`, URL-bound. |
+| 3 | Driver selector, gated on GP (`strategy.py:60`) | KEEP | disabled until GP; cascading reset. |
+| 4 | Optional Rival selector (`strategy.py:70`) | KEEP + IMPROVE | Team-colour names; rival powers a "duel strip" with deltas. |
+| 5 | Lap-range dual slider + "analyses lap X (end of range)" (`strategy.py:94-100`) | KEEP + IMPROVE | `DualRangeSlider`; explicit "Analysing lap 28" chip; range = viewport of the Stint Timeline. |
+| 6 | Risk slider 0-1 + captions (`strategy.py:102-105`) | KEEP + IMPROVE | `Slider` with Conservative/Balanced/Aggressive tick labels + live zone label. |
+| 7 | Run button (`strategy.py:111`) | KEEP + IMPROVE | Primary CTA; disabled-with-reason; elapsed timer + cancel (client abort). |
+| 8 | `st.status` narrated stages (`strategy.py:210-230`) | KEEP + IMPROVE | `StatusStepper` → an **Agent Deliberation panel** (§5). Same scripted stages, premium choreography. |
+| 9 | Lap snapshot: compound/tyre age/gap/lap time/SC prob (`strategy.py:160-188`) | KEEP | 5 `StatCard`s; compound as `CompoundPill` in tyre colour. |
+| 10 | Rival snapshot (`strategy.py:120-157`) | KEEP + IMPROVE | Folded into the duel strip with computed deltas. |
+| 11 | Recommendation card (`strategy_card.py`) | KEEP + IMPROVE (the big one) | Glow `Card`. Surfaces the FULL v2 schema: `pace_mode`, `target_lap_time_s`, `pit_lap_target`, `compound_next`, `undercut_target`, `risk_posture`, `key_risks`, `contingencies`, `expected_stint_end` — all discarded by Streamlit today. |
+| 12 | Reasoning truncated to 800 chars (`strategy_card.py:65`) | DROP truncation | Full LLM prose via `Markdown` in an "Engineer's note" disclosure. |
+| 13 | `risk_level` metric (`strategy_card.py:59`) | DROP (superseded) | Render `risk_posture` (AGGRESSIVE/BALANCED/DEFENSIVE) pill; renderer stays tolerant if absent. |
+| 14 | Regulation context expander (`strategy_card.py:69`) | KEEP | Disclosure with lucide `Scale`, only when `regulation_context !== ""`. |
+| 15 | JSON download (`strategy.py:255`) | KEEP | Blob download as card header action; filename `strategy_{gp}_{driver}_lap{lap}.json`. |
+| 16 | Scenario score bars, winner in accent (`scenario_chart.py`) | KEEP + IMPROVE | ECharts bars, plot **E with P10-P90 whiskers** (backend returns `{E,P10,P90,score}`; Streamlit plots only `score`) + delta-to-winner. |
+| 17 | `EXTEND_STINT` in colour maps (`strategy_card.py:17`, `scenario_chart.py:14`) | DROP | v2 enum = `STAY_OUT｜PIT_NOW｜UNDERCUT｜OVERCUT｜ALERT`. Add ALERT (pulsing danger) + neutral fallback. |
+| 18 | 4 agent sub-tabs, lazy-fetch + cache (`agent_tabs.py`) | KEEP + IMPROVE | Segmented `Tabs`; lazy via TanStack Query `enabled`-on-first-open; cache free via queryKey; each tab gets a micro-chart. Optional 5th Radio tab (§7). |
+| 19 | Per-agent collapsible reasoning (`agent_tabs.py`) | KEEP | Disclosure per tab. |
+| 20 | Result persists (`st.session_state["strategy_result"]`) | KEEP + IMPROVE | Zustand run records; survives route changes; enables run history (§7). |
+| 21 | Purple-border chart CSS injection (`strategy.py:196`) | DROP | `ChartCard` + tokens carry the language. |
+| 22 | Centered "Strategy Advisor" title | KEEP (adapted) | Standard `Header title="Strategy"`. |
+
+## 3. Layout & IA
+
+IA: sticky Scenario Bar → Deliberation (transient) → Decision Brief (hero) → Evidence (scenario scores + timeline + agent tabs). Decision first, evidence below.
+
+```
+┌ Header: "Strategy"                        [⬇ JSON] [🔗 Copy scenario link] ┐
+│ ╔═ SCENARIO BAR (sticky; collapses to a chip row after a run) ═══════════╗ │
+│ ║ (2025 season · chip)                                                   ║ │
+│ ║ [Grand Prix ▾]   [Driver ▾ VER]   [Rival ▾ LEC (optional)]             ║ │
+│ ║ Lap window  ●━━━━━━━━━━● 8–28   → Analysing lap 28                     ║ │
+│ ║ Risk  ●━━━━○  0.55 · Balanced          [▶ Run strategy]                ║ │
+│ ╚════════════════════════════════════════════════════════════════════════╝ │
+│    collapsed after run:  ⟨Hungarian GP⟩ ⟨VER⟩ ⟨vs LEC⟩ ⟨Lap 28⟩ ⟨risk .55⟩ │
+│                                            [Edit scenario] [↻ Re-run]       │
+│ ── RUNNING (replaces zones below) ── Agent Deliberation: StatusStepper +   │
+│    5 pulsing agent chips (Pace·Tire·Pit·SC·Radio) + elapsed + [Cancel]      │
+│ ── COMPLETE ──                                                             │
+│ ┌ SITUATION STRIP: [● MEDIUM][Tyre 14][Gap +2.4s][Lap 78.912][SC 12%]     │
+│ │  duel row w/ rival: VER vs LEC : Δtyre −3, gap +2.4s, LEC HARD 79.1 ────┐│
+│ ┌ DECISION CARD (glow) ──────────────┐ ┌ SCENARIO SCORES ────────────────┐│
+│ │ ⛭ PIT NOW              ◔ 82%       │ │ PIT NOW ▓▓▓▓▓▓ .61 ─┼─          ││
+│ │ BALANCED · PUSH · target 78.450    │ │ STAY OUT ▓▓▓▓ .44  ─┼─          ││
+│ │ Plan: box lap 29 → MEDIUM · under- │ │ (E dot + P10–P90 bar)          ││
+│ │ cut SAI · ▸ Engineer's note        │ ├ STINT TIMELINE ────────────────┤│
+│ │ Key risks: • cliff P10 @ lap 22    │ │ 8══now 28═▒cliff▒═▲box 29 ⌁end │││
+│ │ Playbook: IF SC → PIT NOW (P1) …   │ └────────────────────────────────┘│
+│ │ ▸ ⚖ Regulation context             │                                   │
+│ └────────────────────────────────────┘                                    │
+│ ┌ AGENT BREAKDOWN — segmented Tabs: Pace|Tyres|Situation|Pit ────────────┐│
+│ │  MetricRow/StatCards + one micro-chart + ▸ reasoning disclosure         ││
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**States:** Idle (bar expanded + EmptyState with ghosted preview; progressive gating) · Running (bar locks, deliberation IS the loading state, no fake skeletons) · Complete (deliberation collapses, brief reveals staged, bar collapses to chips) · Error (lap-state 404 → inline pinned to bar; orchestrator 422/500 → error Card + Retry, config preserved; 429 rate-limit 5/min → Toast) · Stale (selector changed after a run → results stay but labelled "scenario has changed" + prominent Re-run).
+
+## 4. Components
+
+Reuse: `Combobox`, `DualRangeSlider`+`Slider`, `StatusStepper` (written for this pipeline), `Card` glow (decision — the one glow), `Card` resting, `Tabs` segmented, `StatCard`/`MetricRow`, `Pill`, `Markdown`, `ChartCard`, `Skeleton`/`EmptyState`/`Toast`/`Tooltip`/`Button`, ECharts+`F1_THEME`+`tireColors`. Lift `features/dashboard/lib/drivers.ts` → `src/lib/` (two features need it).
+
+**New shared primitives (3):** `ActionBadge` (action vocab at hero+sm sizes: STAY_OUT→CircleCheck/success · PIT_NOW→Wrench/danger · UNDERCUT→ArrowDownRight/warning · OVERCUT→ArrowUpRight/blue · ALERT→TriangleAlert/danger pulse · unknown→neutral) · `ConfidenceDial` (SVG radial %, tooltip "LLM self-assessed — qualitative, not calibrated") · `CompoundPill` (tyre chip from `tireColors`).
+
+**Feature-local (`features/strategy/components/`):** `ScenarioBar`, `AgentDeliberation`, `DecisionCard`, `ContingencyList` (playbook: IF trigger → ActionBadge (priority), renders `contingencies[≤4]`), `ScenarioScoresChart` (E bar + P10-P90 whisker + Δ-to-winner), `StintTimeline` (SVG lap axis: now marker, cliff zone from Tyre P10→P90, `pit_lap_target` ▲ + `compound_next` pill, `expected_stint_end`; degrades gracefully), `SituationStrip`+`RivalDuel`, `AgentTabs` (micro-charts per tab: Pace→CI band, Tyres→cliff P10/50/90 3-bar, Situation→2 ConfidenceDials, Pit→stop P05/50/95 range + undercut dial + CompoundPill).
+
+## 5. Interactions & flows
+
+1. **Configure** — progressive disclosure (GP→Driver→sliders+Run); risk slider live-labels zone; analysed-lap chip tracks the range's right thumb; Run disabled-with-reason.
+2. **Deliberate** — on Run, bar locks, deliberation mounts. StatusStepper stages (only 2 real backend boundaries): *Building lap state…* (real GET /lap-state) → *Running agents Pace·Tire·Pit·SC·Radio…* (real POST /recommend; 5 chips pulse 800ms looping, motion-safe) → *Scoring 500 Monte Carlo ×4…* (scripted timer ~60% elapsed) → *Synthesizing…* (until POST resolves). Elapsed mono; Cancel = AbortController; `aria-live=polite`.
+3. **Decide** — stepper→complete, panel collapses, brief enters staged (card fade+rise 250ms → strip → bars animate → timeline draws → tabs), <800ms, motion-safe. Bar collapses to sticky chips.
+4. **Audit** — confidence dial + qualitative tooltip; reasoning one disclosure away (full Markdown, no truncation); agent tabs lazy-fire on first open, cached; regulation disclosure only when non-empty.
+5. **Iterate** — nudge lap/risk → stale notice + Re-run; each run appends to session history → lap-by-lap walk.
+
+## 6. Data & migration notes
+
+Backend (`backend/api/v1/endpoints/strategy.py`, `/api/v1/strategy`): `GET /available-gps?year=2025` (235) · `GET /available-drivers?gp&year` (244) · `GET /lap-range?gp&driver&year` (254) · `GET /lap-state?gp&driver&lap&year` (269) · `POST /recommend {lap_state, gap_ahead_s, pace_delta_s:0, risk_tolerance}` → `{agent:"orchestrator", result: StrategyRecommendation}` (677; **rate-limit 5/min**) · `POST /pace|/tire|/situation|/pit {lap_state}` → typed results (398-614) · `POST /radio`,`GET /radio-*` (optional 5th tab) · `POST /simulate` SSE (899, NOT for #35 — future streaming race-mode seam).
+
+Type in `lib/api/strategy.ts`. Orchestrator v2 schema (`strategy_orchestrator.py:319`): `action` (5-enum incl ALERT), `reasoning`, `confidence`, `pit_lap_target?`, `compound_next?`, `undercut_target?`, `pace_mode`, `target_lap_time_s?`, `risk_posture`, `contingencies[≤4]{trigger,action,priority,rationale}`, `key_risks[≤5]`, `expected_stint_end?`, `scenario_scores: Record<string,{E,P10,P90,score}>`, `regulation_context`. **Every optional field renders conditionally — null-tolerant throughout** (a no-LLM run returns sparse fields).
+
+URL (`features/strategy/search.ts`, same raw↔component boundary as Dashboard): `/strategy?gp=...&driver=NOR&rival=PIA&laps=8-28&risk=0.55`. `laps` encoded "a-b"; `risk` clamped [0,1] default 0.5; `rival` dropped if == driver; year constant 2025. Cascade: gp→clears driver/rival/laps; driver→clears rival/laps. **Deep links reproduce config, NEVER auto-fire the run** (LLM call, rate-limited, non-deterministic) — land on prefilled idle w/ Run highlighted.
+
+State split: TanStack Query staleTime:Infinity for gps/drivers/lap-range/lap-state + the 4 agent POSTs as queries keyed `['strategy','agent',<name>,gp,driver,lap]` `enabled` on first tab open. `useMutation` for POST /recommend (non-deterministic, rate-limited). Zustand `features/strategy/store.ts` (not persisted / sessionStorage): `runs: RunRecord[]{id,config,lapState,result,ranAt}` (cap ~20), `activeRunId`, `pinnedRunId`. Mutation onSuccess appends → history + compare nearly free.
+
+Gotchas: map old→new vocab (EXTEND_STINT gone, ALERT new, risk_level→risk_posture); JSON download serializes full `result` verbatim; `gap_ahead_s` from `lap_state.driver.gap_ahead_s` w/ 2.0 fallback (as Streamlit).
+
+## 7. New features (ranked)
+
+1. **Full v2 decision brief** ⚡ — render pace_mode, target_lap_time_s (radio line `TARGET 78.450 — PUSH`), pit plan (pit_lap_target+compound_next+undercut_target in team colour), risk_posture, key_risks, contingencies. Data already in every response.
+2. **Scenario scores with uncertainty** ⚡ — E + P10-P90 whiskers + Δ-to-winner. Shows how close the call was.
+3. **Run history rail + lap-walk** — session strip of past runs; click restores; confidence-across-laps sparkline. Cheap (store holds records).
+4. **Pin & compare** — two-column diff of two runs.
+5. **Risk sweep** — fire /recommend at risk 0.25/0.5/0.75, show if the action flips. Burns 3/5 rate budget → explicit button, sequential, post-core.
+6. **Radio evidence tab (5th agent)** — POST /radio + radio GETs exist; share components w/ Race Analysis radio.
+7. **Race mode (streaming)** — POST /simulate streams SSE lap-by-lap. Out of scope; build deliberation+card as pure fns of a RunRecord so a streaming producer can drive them later. Note the seam.
+
+## 8. Better than Streamlit
+Whole recommendation not 40% of it (14 vs 6 fields, free) · uncertainty visible (P10-P90 whiskers, CI band) · shareable scenarios (URL=config) · deliberation moment vs spinner · stale-result honesty · untruncated reasoning · iteration as first-class loop · coherent system (shared grammar, no injected CSS/raw-HTML metric blocks).
+
+**Key files:** `frontend/pages/strategy.py` · `frontend/components/strategy/{strategy_card,agent_tabs,scenario_chart}.py` · `backend/api/v1/endpoints/strategy.py` (235-745) · `src/agents/strategy_orchestrator.py:319` (v2 schema, the centerpiece) · grammar `webapp/src/features/dashboard/*` + `webapp/src/components/{Card,StatusStepper,Tabs,Slider,StatCard,Pill}.tsx` + `charts/echartsTheme.ts` + `styles/tokens.css`.

--- a/webapp/bun.lock
+++ b/webapp/bun.lock
@@ -24,6 +24,7 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.6",
         "eventsource-parser": "^3.1.0",
+        "lucide-react": "^1.24.0",
         "openapi-fetch": "^0.17.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -540,6 +541,8 @@
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lucide-react": ["lucide-react@1.24.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -5,6 +5,15 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>F1 StratLab</title>
+    <script>
+      // FOUC guard: stamp the persisted theme before React mounts, so a
+      // light-theme user never sees one dark frame. zustand/persist stores
+      // { state: { theme, ... }, version } under the `f1sl.ui` key.
+      try {
+        var t = JSON.parse(localStorage.getItem('f1sl.ui')).state.theme
+        if (t) document.documentElement.dataset.theme = t
+      } catch (e) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -37,6 +37,7 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.6",
     "eventsource-parser": "^3.1.0",
+    "lucide-react": "^1.24.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -46,7 +46,12 @@ export default function App() {
           {TYRES.map(([label, bg]) => (
             <span
               key={label}
-              className={cn('rounded-full px-3 py-1 font-mono text-xs font-semibold text-bg-0', bg)}
+              // border-hairline (B3): keeps HARD's near-white chip visible
+              // against a white card once the light theme lands.
+              className={cn(
+                'rounded-full border border-hairline px-3 py-1 font-mono text-xs font-semibold text-bg-0',
+                bg,
+              )}
             >
               {label}
             </span>

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -19,7 +19,7 @@ export default function App() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-5xl flex-col gap-10 p-8 md:p-16">
       <header className="flex flex-col gap-2">
-        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+        <span className="font-body text-xs font-semibold uppercase tracking-widest text-purple-300">
           Migration epic #25
         </span>
         <h1 className="font-display text-5xl font-bold tracking-tight text-balance md:text-6xl">
@@ -55,7 +55,7 @@ export default function App() {
       </section>
 
       <section className="flex max-w-sm flex-col gap-2 rounded-2xl border border-purple-600/40 bg-bg-3 p-6 shadow-[var(--shadow-glow)]">
-        <span className="font-body text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
+        <span className="font-body text-xs font-semibold uppercase tracking-widest text-purple-300">
           Recommendation
         </span>
         <span className="font-display text-3xl font-bold text-balance">PIT, undercut</span>

--- a/webapp/src/app/Header.tsx
+++ b/webapp/src/app/Header.tsx
@@ -18,7 +18,7 @@ export function Header({ title, children }: HeaderProps) {
       style={{ zIndex: Z.header }}
       className="sticky top-0 flex h-14 items-center justify-between border-b border-divider bg-bg-1/80 px-6 backdrop-blur-md"
     >
-      <h1 className="font-display text-lg text-fg-1">{title}</h1>
+      <h1 className="font-display text-lg font-semibold tracking-tight text-fg-1">{title}</h1>
       {children && <div className="flex items-center gap-2">{children}</div>}
     </header>
   )

--- a/webapp/src/app/Header.tsx
+++ b/webapp/src/app/Header.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Z } from '@/lib/zIndex'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 export interface HeaderProps {
   title: string
@@ -11,6 +12,10 @@ export interface HeaderProps {
  * chips differ per screen — filters, driver pickers, export buttons), so
  * Shell does not mount this itself. Acrylic chrome: translucent + blurred,
  * per the acrylic law data surfaces (Card.tsx) never get this treatment.
+ *
+ * `ThemeToggle` always renders at the far right of the cluster, after the
+ * page's own `children`, so every routed page gets it for free even when it
+ * passes no children of its own (app-chrome-round2.md §2d).
  */
 export function Header({ title, children }: HeaderProps) {
   return (
@@ -19,7 +24,10 @@ export function Header({ title, children }: HeaderProps) {
       className="sticky top-0 flex h-14 items-center justify-between border-b border-divider bg-bg-1/80 px-6 backdrop-blur-md"
     >
       <h1 className="font-display text-lg font-semibold tracking-tight text-fg-1">{title}</h1>
-      {children && <div className="flex items-center gap-2">{children}</div>}
+      <div className="flex items-center gap-2">
+        {children}
+        <ThemeToggle />
+      </div>
     </header>
   )
 }

--- a/webapp/src/app/Rail.test.tsx
+++ b/webapp/src/app/Rail.test.tsx
@@ -9,6 +9,7 @@ import {
   Outlet,
 } from '@tanstack/react-router'
 import { Rail } from './Rail'
+import { TooltipProvider } from '@/components/Tooltip'
 import { useUiStore } from '@/stores/ui'
 
 // Rail owns the only non-trivial logic in the shell scaffold: toggling
@@ -27,8 +28,27 @@ function renderRail() {
     routeTree: rootRoute.addChildren([indexRoute]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   })
-  return render(<RouterProvider router={router} />)
+  // Rail's collapse button uses <Tooltip>, which throws outside a
+  // TooltipProvider — the real app mounts one in providers.tsx, so the test
+  // supplies its own (same as the router context above).
+  return render(
+    <TooltipProvider>
+      <RouterProvider router={router} />
+    </TooltipProvider>,
+  )
 }
+
+// The 7 nav links the redesigned rail must render, regardless of grouping —
+// name (accessible name of the <Link>) paired with its route.
+const NAV_LINKS: Array<[name: string, href: string]> = [
+  ['Home', '/'],
+  ['Dashboard', '/dashboard'],
+  ['Comparison', '/comparison'],
+  ['Lab', '/lab'],
+  ['Strategy', '/strategy'],
+  ['Race', '/race'],
+  ['Chat', '/chat'],
+]
 
 describe('Rail', () => {
   it('toggles railCollapsed in the UI store on click', async () => {
@@ -39,5 +59,62 @@ describe('Rail', () => {
     fireEvent.click(toggle)
 
     expect(useUiStore.getState().railCollapsed).toBe(true)
+  })
+
+  it('renders the brand block linking home', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    const brandLink = await screen.findByRole('link', { name: /f1 stratlab/i })
+    expect(brandLink).toHaveAttribute('href', '/')
+  })
+
+  it('renders all 7 nav links with their routes', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    for (const [name, href] of NAV_LINKS) {
+      const link = await screen.findByRole('link', { name })
+      expect(link).toHaveAttribute('href', href)
+    }
+  })
+
+  it('groups the nav under the Telemetry, Pit wall and Assist section labels', async () => {
+    useUiStore.setState({ railCollapsed: false })
+    renderRail()
+
+    expect(await screen.findByText('Telemetry')).toBeInTheDocument()
+    expect(screen.getByText('Pit wall')).toBeInTheDocument()
+    expect(screen.getByText('Assist')).toBeInTheDocument()
+  })
+
+  it('collapses section labels to a divider instead of rendering the text', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    // Section eyebrows are fully unmounted when collapsed (swapped for a
+    // plain divider rule), not just visually hidden — there's no room at
+    // 76px for the text, so the grouping survives as a rule instead.
+    await screen.findByRole('button', { name: /expand navigation/i })
+    expect(screen.queryByText('Telemetry')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pit wall')).not.toBeInTheDocument()
+    expect(screen.queryByText('Assist')).not.toBeInTheDocument()
+  })
+
+  it('hides text labels but keeps them mounted with a title tooltip when collapsed', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    const dashboardLink = await screen.findByRole('link', { name: 'Dashboard' })
+    expect(dashboardLink).toHaveAttribute('title', 'Dashboard')
+    expect(screen.getByText('Dashboard')).toHaveClass('hidden')
+    expect(screen.getByText('F1 StratLab')).toHaveClass('hidden')
+  })
+
+  it('shows the expand-navigation button when collapsed', async () => {
+    useUiStore.setState({ railCollapsed: true })
+    renderRail()
+
+    expect(await screen.findByRole('button', { name: /expand navigation/i })).toBeInTheDocument()
   })
 })

--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -1,153 +1,134 @@
 import type { ReactNode } from 'react'
+import {
+  type LucideIcon,
+  ArrowRightLeft,
+  Crosshair,
+  Flag,
+  FlaskConical,
+  House,
+  LayoutDashboard,
+  MessageSquare,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 import { useUiStore } from '@/stores/ui'
 import { Button } from '@/components/Button'
+import { Tooltip } from '@/components/Tooltip'
 
-// Shared Link styling (#33). `to` stays a literal string at each JSX call
-// site below (never threaded through a prop/array field) so TanStack
-// Router's `const TTo` generic can infer the exact route literal instead of
-// widening to `string` — that's what keeps `<Link to="...">` type-checked
-// against the real route tree. `className`'s are concatenated by the router
-// (not merged via cn/twMerge), so LINK_CLASS carries only the parts that
-// never change; color comes from ACTIVE/INACTIVE_PROPS.
-const LINK_CLASS = 'flex items-center gap-3 rounded-lg px-3 py-2.5 font-medium transition-colors'
-const ACTIVE_PROPS = { className: 'bg-bg-4 text-fg-1' }
-const INACTIVE_PROPS = { className: 'text-fg-3 hover:text-fg-1' }
-
-function NavIcon({ children }: { children: ReactNode }) {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-5 shrink-0"
-      aria-hidden="true"
-    >
-      {children}
-    </svg>
+// Shared Link styling (#33, redesigned round 2 per docs/migration/design-specs/
+// app-chrome-round2.md §3 — the docs-sidebar grammar instead of a generic flat
+// list). `to` stays a literal string at each JSX call site below (never
+// threaded through a prop/array field) so TanStack Router's `const TTo`
+// generic can infer the exact route literal instead of widening to `string`
+// — that's what keeps `<Link to="...">` type-checked against the real route
+// tree. `className`s are concatenated by the router (not merged via
+// cn/twMerge), so `itemClass()` carries only the parts that never change;
+// color comes from ACTIVE_PROPS/INACTIVE_PROPS below.
+function itemClass(collapsed: boolean): string {
+  return cn(
+    'relative flex h-9 items-center gap-3 rounded-lg text-sm transition-colors',
+    collapsed ? 'justify-center px-0' : 'px-3',
   )
 }
 
-function HomeIcon() {
-  return (
-    <NavIcon>
-      <path d="M3 9.5 10 4l7 5.5" />
-      <path d="M5 8.5V16h10V8.5" />
-    </NavIcon>
-  )
-}
-
-function DashboardIcon() {
-  return (
-    <NavIcon>
-      <rect x="3" y="3" width="6" height="6" rx="1" />
-      <rect x="11" y="3" width="6" height="6" rx="1" />
-      <rect x="3" y="11" width="6" height="6" rx="1" />
-      <rect x="11" y="11" width="6" height="6" rx="1" />
-    </NavIcon>
-  )
-}
-
-function StrategyIcon() {
-  return (
-    <NavIcon>
-      <circle cx="10" cy="10" r="6.5" />
-      <circle cx="10" cy="10" r="3" />
-      <circle cx="10" cy="10" r="0.5" fill="currentColor" stroke="none" />
-    </NavIcon>
-  )
-}
-
-function RaceIcon() {
-  return (
-    <NavIcon>
-      <path d="M5 3v14" />
-      <path d="M5 4h10l-2.5 3L15 10H5" />
-    </NavIcon>
-  )
-}
-
-function LabIcon() {
-  return (
-    <NavIcon>
-      <path d="M8 3h4" />
-      <path d="M9 3v5.5L4.7 14.8a1.4 1.4 0 0 0 1.2 2.2h8.2a1.4 1.4 0 0 0 1.2-2.2L11 8.5V3" />
-      <path d="M6.7 12.5h6.6" />
-    </NavIcon>
-  )
-}
-
-function ComparisonIcon() {
-  return (
-    <NavIcon>
-      <path d="M6 16V8" />
-      <path d="M14 16V4" />
-      <path d="M3 16h14" />
-    </NavIcon>
-  )
-}
-
-function ChatIcon() {
-  return (
-    <NavIcon>
-      <path d="M3.5 5.5A1.5 1.5 0 0 1 5 4h10a1.5 1.5 0 0 1 1.5 1.5v6A1.5 1.5 0 0 1 15 13H8l-3.5 3v-3H5a1.5 1.5 0 0 1-1.5-1.5v-6Z" />
-    </NavIcon>
-  )
-}
-
-/** Chevron toggle for the collapse button; rotates 180° (transform-only, so
- *  it stays cheap and respects prefers-reduced-motion) to flip meaning from
- *  "collapse" (points in) to "expand" (points out). */
-function CollapseIcon({ collapsed }: { collapsed: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      className={cn(
-        'size-4 transition-transform duration-200 ease-out motion-reduce:transition-none',
-        collapsed && 'rotate-180',
-      )}
-    >
-      <path d="M12.5 4.5 7 10l5.5 5.5" />
-    </svg>
-  )
-}
+const ACTIVE_PROPS = { className: 'text-fg-1 bg-[image:var(--grad-purple-soft)]' }
+const INACTIVE_PROPS = { className: 'text-fg-3 hover:text-fg-1 hover:bg-fg-1/[0.04]' }
 
 interface NavLinkContentProps {
-  icon: ReactNode
+  icon: LucideIcon
   label: string
   collapsed: boolean
+  isActive: boolean
 }
 
-/** Icon + label pair shared by every nav item. When the rail is collapsed the
- *  label is `hidden` (removed from the a11y tree too), so the Link's native
- *  `title` attribute becomes its accessible name and doubles as the hover
- *  tooltip — no Tooltip component needed for this scaffold. */
-function NavLinkContent({ icon, label, collapsed }: NavLinkContentProps) {
+/**
+ * Icon + label + active-indicator triple shared by every nav item. Rendering
+ * a different child per active state needs TanStack Link's children-as-
+ * function form (`{({ isActive }) => ...}`, wired up at each call site below)
+ * rather than `activeProps` classNames, since the left bar and the icon
+ * color both depend on `isActive`.
+ *
+ * The left bar is always mounted (never conditionally rendered) so its
+ * `scale-y` transition actually animates when a route becomes active instead
+ * of popping in — `isActive` only flips the scale, never the DOM presence.
+ *
+ * When the rail is collapsed the label is `hidden` (removed from the a11y
+ * tree too, since `display:none` drops it from the accessibility tree), so
+ * the Link's native `title` attribute becomes the accessible name and
+ * doubles as the hover tooltip — no Tooltip component needed here.
+ */
+function NavLinkContent({ icon: Icon, label, collapsed, isActive }: NavLinkContentProps) {
   return (
     <>
-      <span className="shrink-0">{icon}</span>
-      <span className={cn('truncate text-sm', collapsed && 'hidden')}>{label}</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'absolute inset-y-2 left-0 w-0.5 origin-center scale-y-0 rounded-full bg-purple-400',
+          'shadow-[0_0_8px_rgba(108,92,231,0.6)] transition-transform duration-150 ease-out motion-reduce:transition-none',
+          isActive && 'scale-y-100',
+        )}
+      />
+      <Icon
+        aria-hidden="true"
+        strokeWidth={1.75}
+        className={cn('size-4.5 shrink-0', isActive ? 'text-purple-300' : 'text-fg-4')}
+      />
+      <span className={cn('truncate', collapsed && 'hidden')}>{label}</span>
     </>
   )
 }
 
 /**
- * Acrylic left icon rail: 72px collapsed / 220px expanded, driven by the
- * shared `useUiStore` so the collapsed state survives navigation and reloads
- * (persisted under `f1sl.ui`). Width itself is never transitioned — baseline-ui
- * restricts animation to transform/opacity (cheap, compositor-only); a width
- * change is a layout property, so it snaps instantly instead.
+ * Section eyebrow above a group of nav items (docs-sidebar grammar): a tiny
+ * uppercase label with a purple tick when expanded. When the rail collapses
+ * to icon-only width there's no room for the label, so it swaps to a plain
+ * divider rule instead — the grouping survives the collapse rather than
+ * silently disappearing.
+ */
+function NavSectionLabel({ label, collapsed }: { label: string; collapsed: boolean }) {
+  if (collapsed) {
+    return <div aria-hidden="true" className="mx-3 my-4 border-t border-hairline" />
+  }
+  return (
+    <div className="mt-4 mb-1 flex items-center gap-2 px-3 font-display text-[10px] font-semibold tracking-widest text-fg-4 uppercase">
+      <span aria-hidden="true" className="size-1 shrink-0 rounded-full bg-purple-500" />
+      {label}
+    </div>
+  )
+}
+
+/** One labeled group of nav items (e.g. "Telemetry": Dashboard, Comparison,
+ *  Lab). Pairs the section eyebrow with its `<ul>` so `Rail`'s render reads
+ *  as a flat list of sections instead of repeating the label/list pairing
+ *  three times. */
+function NavSection({
+  label,
+  collapsed,
+  children,
+}: {
+  label: string
+  collapsed: boolean
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <NavSectionLabel label={label} collapsed={collapsed} />
+      <ul className="flex flex-col gap-1">{children}</ul>
+    </div>
+  )
+}
+
+/**
+ * Acrylic left icon rail, redesigned to carry F1 StratLab's brand vocabulary
+ * (docs-sidebar grouping + a brand block) instead of a generic flat list:
+ * 76px collapsed / 232px expanded, driven by the shared `useUiStore` so the
+ * collapsed state survives navigation and reloads (persisted under
+ * `f1sl.ui`). Width itself is never transitioned — baseline-ui restricts
+ * animation to transform/opacity (cheap, compositor-only); a width change is
+ * a layout property, so it snaps instantly instead.
  */
 export function Rail() {
   const railCollapsed = useUiStore((state) => state.railCollapsed)
@@ -158,105 +139,201 @@ export function Rail() {
       aria-label="Primary"
       style={{ zIndex: Z.rail }}
       className={cn(
-        'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/80 backdrop-blur-md',
-        railCollapsed ? 'w-[72px]' : 'w-[220px]',
+        'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/70 backdrop-blur-md',
+        railCollapsed ? 'w-19' : 'w-58',
       )}
     >
-      <ul className="flex flex-1 flex-col gap-1 overflow-y-auto p-3">
-        <li>
-          <Link
-            to="/"
-            activeOptions={{ exact: true }}
-            title={railCollapsed ? 'Home' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<HomeIcon />} label="Home" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/dashboard"
-            title={railCollapsed ? 'Dashboard' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<DashboardIcon />} label="Dashboard" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/strategy"
-            title={railCollapsed ? 'Strategy' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<StrategyIcon />} label="Strategy" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/race"
-            title={railCollapsed ? 'Race' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<RaceIcon />} label="Race" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/lab"
-            title={railCollapsed ? 'Lab' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<LabIcon />} label="Lab" collapsed={railCollapsed} />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/comparison"
-            title={railCollapsed ? 'Comparison' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent
-              icon={<ComparisonIcon />}
-              label="Comparison"
-              collapsed={railCollapsed}
-            />
-          </Link>
-        </li>
-        <li>
-          <Link
-            to="/chat"
-            title={railCollapsed ? 'Chat' : undefined}
-            activeProps={ACTIVE_PROPS}
-            inactiveProps={INACTIVE_PROPS}
-            className={LINK_CLASS}
-          >
-            <NavLinkContent icon={<ChatIcon />} label="Chat" collapsed={railCollapsed} />
-          </Link>
-        </li>
-      </ul>
-
-      <div className="border-t border-divider p-3">
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label={railCollapsed ? 'Expand navigation' : 'Collapse navigation'}
-          onClick={toggleRail}
-          className="w-full justify-center"
+      {/* Brand block. Aligns with Header's h-14 so rail + header form one
+          continuous chrome line across the top of the app. */}
+      <Link
+        to="/"
+        activeOptions={{ exact: true }}
+        className={cn(
+          'flex h-14 shrink-0 items-center gap-2.5 border-b border-hairline',
+          railCollapsed ? 'justify-center px-0' : 'px-4',
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[image:var(--grad-purple)] font-mono text-[10px] font-bold text-white"
         >
-          <CollapseIcon collapsed={railCollapsed} />
-        </Button>
+          F1
+        </span>
+        <span
+          className={cn(
+            'truncate font-display text-[15px] font-semibold tracking-tight text-fg-1',
+            railCollapsed && 'hidden',
+          )}
+        >
+          F1 StratLab
+        </span>
+      </Link>
+
+      <div className="flex flex-1 flex-col overflow-y-auto p-3">
+        <ul className="flex flex-col gap-1">
+          <li>
+            <Link
+              to="/"
+              activeOptions={{ exact: true }}
+              title={railCollapsed ? 'Home' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={House}
+                  label="Home"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </ul>
+
+        <NavSection label="Telemetry" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/dashboard"
+              title={railCollapsed ? 'Dashboard' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={LayoutDashboard}
+                  label="Dashboard"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/comparison"
+              title={railCollapsed ? 'Comparison' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={ArrowRightLeft}
+                  label="Comparison"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/lab"
+              title={railCollapsed ? 'Lab' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={FlaskConical}
+                  label="Lab"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+
+        <NavSection label="Pit wall" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/strategy"
+              title={railCollapsed ? 'Strategy' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={Crosshair}
+                  label="Strategy"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/race"
+              title={railCollapsed ? 'Race' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={Flag}
+                  label="Race"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+
+        <NavSection label="Assist" collapsed={railCollapsed}>
+          <li>
+            <Link
+              to="/chat"
+              title={railCollapsed ? 'Chat' : undefined}
+              className={itemClass(railCollapsed)}
+              activeProps={ACTIVE_PROPS}
+              inactiveProps={INACTIVE_PROPS}
+            >
+              {({ isActive }) => (
+                <NavLinkContent
+                  icon={MessageSquare}
+                  label="Chat"
+                  collapsed={railCollapsed}
+                  isActive={isActive}
+                />
+              )}
+            </Link>
+          </li>
+        </NavSection>
+      </div>
+
+      <div
+        className={cn(
+          'flex items-center border-t border-hairline p-3',
+          railCollapsed ? 'justify-center' : 'justify-between',
+        )}
+      >
+        <span className={cn('font-mono text-[10px] text-fg-4', railCollapsed && 'hidden')}>
+          v0.9
+        </span>
+        <Tooltip content={railCollapsed ? 'Expand navigation' : 'Collapse navigation'} side="right">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={railCollapsed ? 'Expand navigation' : 'Collapse navigation'}
+            onClick={toggleRail}
+            className="size-8 p-0"
+          >
+            {railCollapsed ? (
+              <PanelLeftOpen className="size-4" aria-hidden="true" />
+            ) : (
+              <PanelLeftClose className="size-4" aria-hidden="true" />
+            )}
+          </Button>
+        </Tooltip>
       </div>
     </nav>
   )

--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react'
 import {
   type LucideIcon,
   ArrowRightLeft,
@@ -14,9 +14,17 @@ import {
 import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
-import { useUiStore } from '@/stores/ui'
+import { RAIL_WIDTH_MAX, RAIL_WIDTH_MIN, useUiStore } from '@/stores/ui'
 import { Button } from '@/components/Button'
 import { Tooltip } from '@/components/Tooltip'
+
+// Fixed collapsed width (icon-only rail, never resizable) — the counterpart
+// to `railWidth` in stores/ui.ts, which only governs the expanded state.
+const RAIL_WIDTH_COLLAPSED = 76
+
+// Keyboard step for the resize handle (role="separator"), so the control is
+// operable without a pointer per the WAI-ARIA window-splitter pattern.
+const RAIL_RESIZE_STEP = 16
 
 // Shared Link styling (#33, redesigned round 2 per docs/migration/design-specs/
 // app-chrome-round2.md §3 — the docs-sidebar grammar instead of a generic flat
@@ -124,23 +132,75 @@ function NavSection({
 /**
  * Acrylic left icon rail, redesigned to carry F1 StratLab's brand vocabulary
  * (docs-sidebar grouping + a brand block) instead of a generic flat list:
- * 76px collapsed / 232px expanded, driven by the shared `useUiStore` so the
- * collapsed state survives navigation and reloads (persisted under
- * `f1sl.ui`). Width itself is never transitioned — baseline-ui restricts
- * animation to transform/opacity (cheap, compositor-only); a width change is
- * a layout property, so it snaps instantly instead.
+ * 76px collapsed / a user-resizable 200-360px expanded (default 232px),
+ * driven by the shared `useUiStore` so both the collapsed state and the
+ * chosen width survive navigation and reloads (persisted under `f1sl.ui`).
+ *
+ * Width now transitions on collapse/expand (`transition-[width]`, ~200ms,
+ * `motion-reduce`-guarded) — a deliberate, narrow exception to baseline-ui's
+ * transform/opacity-only rule: once the rail became resizable, a hard snap
+ * on toggle read as broken next to a draggable edge. The main content pane
+ * (Shell.tsx) never needs to mirror this explicitly — it's a `flex-1`
+ * sibling of this `<nav>`, so the browser recomputes its box on every frame
+ * of the rail's width transition for free; there's no second width value to
+ * keep in lockstep.
+ *
+ * The transition is suppressed (`transition-none`) while the resize handle
+ * is being dragged, so the edge tracks the pointer 1:1 instead of lagging
+ * behind an easing curve.
  */
 export function Rail() {
   const railCollapsed = useUiStore((state) => state.railCollapsed)
   const toggleRail = useUiStore((state) => state.toggleRail)
+  const railWidth = useUiStore((state) => state.railWidth)
+  const setRailWidth = useUiStore((state) => state.setRailWidth)
+
+  // Drag-to-resize. `dragStartRef` holds the pointer x + rail width at the
+  // moment the drag began, so `handleResizeMove` can compute an absolute
+  // target width from the total pointer delta rather than accumulating
+  // per-event deltas (which would drift under fast pointer moves).
+  const [isResizing, setIsResizing] = useState(false)
+  const dragStartRef = useRef({ x: 0, width: railWidth })
+
+  function handleResizeStart(event: PointerEvent<HTMLDivElement>) {
+    if (railCollapsed) return
+    event.currentTarget.setPointerCapture(event.pointerId)
+    dragStartRef.current = { x: event.clientX, width: railWidth }
+    setIsResizing(true)
+  }
+
+  function handleResizeMove(event: PointerEvent<HTMLDivElement>) {
+    if (!isResizing) return
+    const delta = event.clientX - dragStartRef.current.x
+    setRailWidth(dragStartRef.current.width + delta)
+  }
+
+  function handleResizeEnd(event: PointerEvent<HTMLDivElement>) {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    setIsResizing(false)
+  }
+
+  function handleResizeKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setRailWidth(railWidth - RAIL_RESIZE_STEP)
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setRailWidth(railWidth + RAIL_RESIZE_STEP)
+    }
+  }
 
   return (
     <nav
       aria-label="Primary"
-      style={{ zIndex: Z.rail }}
+      style={{ zIndex: Z.rail, width: railCollapsed ? RAIL_WIDTH_COLLAPSED : railWidth }}
       className={cn(
         'sticky top-0 flex h-dvh shrink-0 flex-col border-r border-divider bg-bg-2/70 backdrop-blur-md',
-        railCollapsed ? 'w-19' : 'w-58',
+        isResizing
+          ? 'transition-none'
+          : 'transition-[width] duration-200 ease-out motion-reduce:transition-none',
       )}
     >
       {/* Brand block. Aligns with Header's h-14 so rail + header form one
@@ -335,6 +395,34 @@ export function Rail() {
           </Button>
         </Tooltip>
       </div>
+
+      {/* Drag-to-resize handle. Absolutely positioned against the `sticky`
+          nav (a positioned element, so it's a valid containing block) and
+          rendered as the nav's last child, which — with no explicit z-index
+          on either side — is enough for it to paint above the normal-flow
+          content above it. Not rendered at all while collapsed: a collapsed
+          icon-only rail has no width worth dragging. */}
+      {!railCollapsed && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize navigation"
+          aria-valuenow={Math.round(railWidth)}
+          aria-valuemin={RAIL_WIDTH_MIN}
+          aria-valuemax={RAIL_WIDTH_MAX}
+          tabIndex={0}
+          onPointerDown={handleResizeStart}
+          onPointerMove={handleResizeMove}
+          onPointerUp={handleResizeEnd}
+          onPointerCancel={handleResizeEnd}
+          onKeyDown={handleResizeKeyDown}
+          className={cn(
+            'absolute inset-y-0 right-0 w-1.5 cursor-col-resize touch-none rounded-r-sm select-none',
+            'transition-colors hover:bg-purple-400/30 focus-visible:bg-purple-400/40 focus-visible:outline-none',
+            isResizing && 'bg-purple-400/40',
+          )}
+        />
+      )}
     </nav>
   )
 }

--- a/webapp/src/app/providers.tsx
+++ b/webapp/src/app/providers.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from './router'
 import { TooltipProvider } from '@/components/Tooltip'
 import { ToastProvider } from '@/components/Toast'
+import { useUiStore } from '@/stores/ui'
 
 // App-wide providers: TanStack Query (server-state cache) wraps TanStack Router
 // (typed routing). Race telemetry is immutable/historical, so a generous default
@@ -15,6 +17,15 @@ const queryClient = new QueryClient({
 })
 
 export function Providers() {
+  // Single source of truth for the active theme: mirror the persisted store
+  // onto <html data-theme>, which every token reads via :root[data-theme].
+  // The FOUC guard in index.html sets this before React mounts; this effect
+  // keeps it in sync on toggle.
+  const theme = useUiStore((state) => state.theme)
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+  }, [theme])
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>

--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -2,6 +2,8 @@ import { createRootRoute, createRoute, createRouter } from '@tanstack/react-rout
 import App from '@/App'
 import { Header } from './Header'
 import { Shell } from './Shell'
+import { DashboardPage } from '@/features/dashboard/DashboardPage'
+import { validateDashboardSearch } from '@/features/dashboard/search'
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
 // content plane, see Shell.tsx); the shell's <Outlet/> renders whichever leaf
@@ -34,7 +36,8 @@ function ComingSoon({ title }: { title: string }) {
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/dashboard',
-  component: () => <ComingSoon title="Dashboard" />,
+  validateSearch: validateDashboardSearch,
+  component: DashboardPage,
 })
 
 const strategyRoute = createRoute({
@@ -55,9 +58,12 @@ const labRoute = createRoute({
   component: () => <ComingSoon title="Lab" />,
 })
 
+// Comparison shares the Dashboard's selection shape so the "Go to comparison"
+// cross-link can carry year/gp/session/drivers forward (wired up in #36).
 const comparisonRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/comparison',
+  validateSearch: validateDashboardSearch,
   component: () => <ComingSoon title="Comparison" />,
 })
 

--- a/webapp/src/charts/Gauge.tsx
+++ b/webapp/src/charts/Gauge.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { EChartsOption } from 'echarts'
-import { registerF1Theme } from './registerEcharts'
-import { F1_THEME } from './echartsTheme'
+import { registerF1Theme, useChartTheme } from './registerEcharts'
+import { F1_LIGHT_THEME } from './echartsTheme'
 
 // Register the token theme at module load — before any chart's init runs.
 // (echarts-for-react inits with the `theme` prop in componentDidMount, which
@@ -15,10 +15,30 @@ registerF1Theme()
 // touch a raw ECharts option for this shape: pass a value, get a token-themed
 // arc back. Progress-only design (no needle) reads cleanly at small sizes.
 
-const PURPLE_600 = '#6c5ce7'
-const HAIRLINE = 'rgba(255,255,255,0.10)'
-const FG_1 = '#ffffff'
-const FG_3 = 'rgba(255,255,255,0.52)'
+// The gauge's track/detail/title colors are set per-series (ECharts merges a
+// series-level `itemStyle`/`color` over the registered theme's defaults), so
+// swapping the registered `theme` prop alone does not re-color them — they
+// need their own light/dark palette here, mirroring echartsTheme.ts's swap.
+const PURPLE_600 = '#6c5ce7' // identity color — same accent in both themes
+
+interface GaugePalette {
+  hairline: string
+  fg1: string
+  fg3: string
+}
+
+const DARK_GAUGE_PALETTE: GaugePalette = {
+  hairline: 'rgba(255,255,255,0.10)',
+  fg1: '#ffffff',
+  fg3: 'rgba(255,255,255,0.52)',
+}
+
+const LIGHT_GAUGE_PALETTE: GaugePalette = {
+  hairline: 'rgba(20,18,31,0.10)',
+  fg1: '#14121f',
+  fg3: 'rgba(20,18,31,0.58)',
+}
+
 const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 const DISPLAY = "'Space Grotesk Variable', system-ui, sans-serif"
 
@@ -36,13 +56,20 @@ interface GaugeOptionInput {
   max: number
   label: string | undefined
   formatValue: (value: number) => string
+  palette: GaugePalette
 }
 
 /** Build the ECharts gauge option: hairline full-circle track, purple
  *  progress arc, no pointer/anchor, and a mono center readout formatted via
  *  `formatValue`. Pulled out of the component so the option shape is easy to
  *  read independent of the render/effect wiring. */
-function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput): EChartsOption {
+function buildGaugeOption({
+  value,
+  max,
+  label,
+  formatValue,
+  palette,
+}: GaugeOptionInput): EChartsOption {
   return {
     series: [
       {
@@ -61,7 +88,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         axisLine: {
           lineStyle: {
             width: 10,
-            color: [[1, HAIRLINE]],
+            color: [[1, palette.hairline]],
           },
         },
         axisTick: { show: false },
@@ -71,7 +98,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         detail: {
           valueAnimation: true,
           formatter: (detailValue: number) => formatValue(detailValue),
-          color: FG_1,
+          color: palette.fg1,
           fontFamily: MONO,
           fontSize: 24,
           fontWeight: 600,
@@ -80,7 +107,7 @@ function buildGaugeOption({ value, max, label, formatValue }: GaugeOptionInput):
         title: {
           show: Boolean(label),
           offsetCenter: [0, '35%'],
-          color: FG_3,
+          color: palette.fg3,
           fontFamily: DISPLAY,
           fontSize: 12,
         },
@@ -111,10 +138,14 @@ export function Gauge({
   formatValue = defaultFormatValue,
   height = DEFAULT_HEIGHT_PX,
 }: GaugeProps) {
+  const chartTheme = useChartTheme()
+  const palette = chartTheme === F1_LIGHT_THEME ? LIGHT_GAUGE_PALETTE : DARK_GAUGE_PALETTE
   const option = useMemo(
-    () => buildGaugeOption({ value, max, label, formatValue }),
-    [value, max, label, formatValue],
+    () => buildGaugeOption({ value, max, label, formatValue, palette }),
+    [value, max, label, formatValue, palette],
   )
 
-  return <ReactECharts theme={F1_THEME} option={option} style={{ height }} notMerge />
+  return (
+    <ReactECharts theme={chartTheme} key={chartTheme} option={option} style={{ height }} notMerge />
+  )
 }

--- a/webapp/src/charts/echartsTheme.ts
+++ b/webapp/src/charts/echartsTheme.ts
@@ -1,49 +1,106 @@
 // ECharts theme built from the F1 StratLab brand tokens. Registered once when
-// the first chart mounts (issue #34): `echarts.registerTheme(F1_THEME, echartsTheme)`.
-// Kept as a plain object so #32 does not pull the heavy echarts dep into the
+// the first chart mounts (issue #34): `echarts.registerTheme(F1_THEME, ...)`.
+// Kept as plain objects so #32 does not pull the heavy echarts dep into the
 // bundle; #34 imports echarts and this together.
 //
 // Design: transparent background (charts sit on solid --bg cards), hairline
 // grid, blue data ramp + purple accent, JetBrains Mono axis labels, tabular
-// figures. Colors are the resolved token hex (a build-time JS module cannot read
-// CSS vars); keep them in sync with styles/tokens.css.
+// figures. Colors are the resolved token hex (a build-time JS module cannot
+// read CSS vars); keep them in sync with styles/tokens.css.
+//
+// Light theme (app-chrome-round2.md item 1(e)): a build-time module can't
+// react to the `data-theme` attribute the way CSS vars do, so instead of one
+// static theme object we build the theme per mode from two hardcoded
+// palettes (dark/light) that mirror tokens.css's `--fg-2/3`, `--divider`,
+// `--hairline` swap. The categorical series palette and tyre colors are
+// identity colors — unchanged across modes.
 
 export const F1_THEME = 'f1'
+export const F1_LIGHT_THEME = 'f1-light'
 
-const FG_2 = 'rgba(255,255,255,0.72)'
-const FG_3 = 'rgba(255,255,255,0.52)'
-const LINE = 'rgba(255,255,255,0.18)'
-const HAIRLINE = 'rgba(255,255,255,0.06)'
 const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 const DISPLAY = "'Space Grotesk Variable', system-ui, sans-serif"
 
-const axis = {
-  axisLine: { lineStyle: { color: LINE } },
-  axisTick: { lineStyle: { color: LINE } },
-  axisLabel: { color: FG_3, fontFamily: MONO },
-  splitLine: { lineStyle: { color: HAIRLINE } },
+// Categorical palette: blue (data) first, then purple accent, then
+// compound-ish greens/ambers. Identity colors — same in both themes.
+const SERIES_COLORS = ['#3385ff', '#6c5ce7', '#2dd47a', '#ffbd33', '#ff5733', '#60a5fa', '#a29bfe']
+
+interface ThemePalette {
+  /** Body/legend text (mirrors tokens.css `--fg-2`). */
+  fg2: string
+  /** Axis label text (mirrors `--fg-3`). */
+  fg3: string
+  /** Axis line/tick color (mirrors `--divider`). */
+  line: string
+  /** Split-line / grid border color (mirrors `--hairline`). */
+  hairline: string
+  titleColor: string
+  tooltipBg: string
+  tooltipBorder: string
+  tooltipText: string
 }
 
-export const echartsTheme = {
-  // Categorical palette: blue (data) first, then purple accent, then compound-ish greens/ambers.
-  color: ['#3385ff', '#6c5ce7', '#2dd47a', '#ffbd33', '#ff5733', '#60a5fa', '#a29bfe'],
-  backgroundColor: 'transparent',
-  textStyle: { fontFamily: MONO, color: FG_2 },
-  title: { textStyle: { color: '#ffffff', fontFamily: DISPLAY, fontWeight: 600 } },
-  legend: { textStyle: { color: FG_2, fontFamily: MONO } },
-  grid: { borderColor: HAIRLINE, containLabel: true },
-  categoryAxis: axis,
-  valueAxis: axis,
-  timeAxis: axis,
-  logAxis: axis,
-  tooltip: {
-    backgroundColor: '#17192b',
-    borderColor: 'rgba(255,255,255,0.10)',
-    textStyle: { color: '#ffffff', fontFamily: MONO },
-  },
+const DARK_PALETTE: ThemePalette = {
+  fg2: 'rgba(255,255,255,0.72)',
+  fg3: 'rgba(255,255,255,0.52)',
+  line: 'rgba(255,255,255,0.18)',
+  hairline: 'rgba(255,255,255,0.06)',
+  titleColor: '#ffffff',
+  tooltipBg: '#17192b',
+  tooltipBorder: 'rgba(255,255,255,0.10)',
+  tooltipText: '#ffffff',
+}
+
+const LIGHT_PALETTE: ThemePalette = {
+  fg2: 'rgba(20,18,31,0.75)',
+  fg3: 'rgba(20,18,31,0.58)',
+  line: 'rgba(20,18,31,0.18)',
+  hairline: 'rgba(20,18,31,0.06)',
+  titleColor: '#14121f',
+  tooltipBg: '#ffffff',
+  tooltipBorder: 'rgba(20,18,31,0.10)',
+  tooltipText: '#14121f',
+}
+
+/** Shared axis look (category/value/time/log all render the same way here)
+ *  for one palette — hairline line/tick, faint split line, mono labels. */
+function buildAxisStyle(palette: ThemePalette) {
+  return {
+    axisLine: { lineStyle: { color: palette.line } },
+    axisTick: { lineStyle: { color: palette.line } },
+    axisLabel: { color: palette.fg3, fontFamily: MONO },
+    splitLine: { lineStyle: { color: palette.hairline } },
+  }
+}
+
+/** Builds the full ECharts theme object for one app theme mode. A build-time
+ *  JS module can't read the `data-theme` CSS variable swap, so this is
+ *  called once per mode up front and both results are registered
+ *  (`registerEcharts.ts`) — the chart picks one by name via `useChartTheme()`. */
+export function buildEchartsTheme(mode: 'dark' | 'light') {
+  const palette = mode === 'light' ? LIGHT_PALETTE : DARK_PALETTE
+  const axis = buildAxisStyle(palette)
+  return {
+    color: SERIES_COLORS,
+    backgroundColor: 'transparent',
+    textStyle: { fontFamily: MONO, color: palette.fg2 },
+    title: { textStyle: { color: palette.titleColor, fontFamily: DISPLAY, fontWeight: 600 } },
+    legend: { textStyle: { color: palette.fg2, fontFamily: MONO } },
+    grid: { borderColor: palette.hairline, containLabel: true },
+    categoryAxis: axis,
+    valueAxis: axis,
+    timeAxis: axis,
+    logAxis: axis,
+    tooltip: {
+      backgroundColor: palette.tooltipBg,
+      borderColor: palette.tooltipBorder,
+      textStyle: { color: palette.tooltipText, fontFamily: MONO },
+    },
+  }
 }
 
 // F1 tyre-compound colors for series that encode compound (from tokens).
+// Identity colors — unchanged across themes.
 export const tireColors: Record<string, string> = {
   SOFT: '#ff2d3a',
   MEDIUM: '#ffcf2d',

--- a/webapp/src/charts/registerEcharts.ts
+++ b/webapp/src/charts/registerEcharts.ts
@@ -1,12 +1,24 @@
 import * as echarts from 'echarts'
-import { echartsTheme, F1_THEME } from './echartsTheme'
+import { useUiStore } from '@/stores/ui'
+import { buildEchartsTheme, F1_LIGHT_THEME, F1_THEME } from './echartsTheme'
 
 let registered = false
 
-/** Register the F1 ECharts theme once (idempotent). Call before mounting the
- *  first chart so every chart inherits the token theme. */
+/** Register both F1 ECharts themes once (idempotent) — dark (`F1_THEME`) and
+ *  light (`F1_LIGHT_THEME`). Call before mounting the first chart so every
+ *  chart can pick either theme by name (see `useChartTheme`). */
 export function registerF1Theme(): void {
   if (registered) return
-  echarts.registerTheme(F1_THEME, echartsTheme)
+  echarts.registerTheme(F1_THEME, buildEchartsTheme('dark'))
+  echarts.registerTheme(F1_LIGHT_THEME, buildEchartsTheme('light'))
   registered = true
+}
+
+/** The registered ECharts theme name matching the app's current light/dark
+ *  theme (`stores/ui.ts`), so every chart follows the header toggle. Callers
+ *  key their `<ReactECharts>` on this value to force a remount on toggle —
+ *  ECharts doesn't hot-swap a theme on an already-mounted instance. */
+export function useChartTheme(): string {
+  const theme = useUiStore((state) => state.theme)
+  return theme === 'light' ? F1_LIGHT_THEME : F1_THEME
 }

--- a/webapp/src/components/ChartCard.test.tsx
+++ b/webapp/src/components/ChartCard.test.tsx
@@ -33,7 +33,7 @@ describe('ChartCard', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('hides the body when the collapse button is clicked', () => {
+  it('keeps the body visible (no collapse affordance) — maximize is the only control', () => {
     render(
       <ChartCard title="Lap Times">
         <div>chart body</div>
@@ -41,7 +41,6 @@ describe('ChartCard', () => {
     )
 
     expect(screen.getByText('chart body')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /collapse chart/i }))
-    expect(screen.queryByText('chart body')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /collapse chart/i })).not.toBeInTheDocument()
   })
 })

--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -51,19 +51,24 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
-          onClick={() => setIsCollapsed((value) => !value)}
-          className="size-8 px-0 text-fg-3"
-        >
-          {isCollapsed ? (
-            <Plus className="size-4" aria-hidden="true" />
-          ) : (
-            <Minus className="size-4" aria-hidden="true" />
-          )}
-        </Button>
+        {/* Collapse is a grid-only affordance. In the maximized overlay it just
+            hides the body, stranding the user on an empty full-screen card with
+            no way back (Restore is the way out) — so it's not offered there. */}
+        {!isMaximized && (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
+            onClick={() => setIsCollapsed((value) => !value)}
+            className="size-8 px-0 text-fg-3"
+          >
+            {isCollapsed ? (
+              <Plus className="size-4" aria-hidden="true" />
+            ) : (
+              <Minus className="size-4" aria-hidden="true" />
+            )}
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -81,11 +86,15 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     </div>
   )
 
-  const body = isCollapsed ? null : <div className="flex-1 overflow-auto p-4">{children}</div>
+  // Maximizing always shows the content — a collapsed-in-grid chart still opens
+  // full-screen with its body (and Restore is the only exit), so there's no way
+  // to land on an empty maximized card.
+  const showBody = isMaximized || !isCollapsed
+  const body = showBody ? <div className="flex-1 overflow-auto p-4">{children}</div> : null
   const footerStrip =
-    isCollapsed || !footer ? null : (
+    showBody && footer ? (
       <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
-    )
+    ) : null
 
   if (isMaximized) {
     return createPortal(

--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -1,38 +1,52 @@
-import { forwardRef, useEffect, useState, type HTMLAttributes, type ReactNode } from 'react'
+import {
+  createContext,
+  forwardRef,
+  useEffect,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
-import { Maximize2, Minimize2, Minus, Plus } from 'lucide-react'
+import { Maximize2, Minimize2 } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 
-// Titled shell for a single chart: header (title + actions slot + maximize +
-// collapse), a scroll-contained body, and an optional footer strip. "Maximize"
-// portals the card to a full-viewport overlay so a chart can be inspected
-// without fighting a cramped dashboard grid cell; "collapse" just hides the
-// body (and footer) in place, for dashboards where a driver wants to fold a
-// chart they aren't using right now.
+// Titled shell for a single chart: header (title + actions slot + maximize), a
+// body, and an optional footer strip. "Maximize" portals the card to a
+// full-viewport overlay so a chart can be inspected without fighting a cramped
+// grid cell — the only per-chart control, since a full-screen view covers the
+// "look closer" need a collapse toggle used to.
+//
+// Charts read `ChartMaximizedContext` to FILL that overlay (rather than keeping
+// their fixed grid height and leaving dead space) and to key a remount so
+// ECharts re-measures at the new size — without it the canvas keeps its grid
+// dimensions and the hover/tooltip hit-testing lands in the wrong place.
 //
 // Acrylic-law exception: the overlay backdrop is chrome, not a data plane, so
 // `backdrop-blur` is allowed here even though data surfaces (the Card itself)
 // stay solid `--bg` with a hairline border, per Card.tsx.
+
+/** True while the chart is rendered inside the maximized full-viewport overlay.
+ *  Chart bodies read this to switch from their fixed grid height to filling the
+ *  overlay, and to key a remount so ECharts re-measures at the new size. */
+export const ChartMaximizedContext = createContext(false)
 
 export interface ChartCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string
   /** Right-aligned header slot, e.g. a range picker or a legend toggle. */
   actions?: ReactNode
   children?: ReactNode
-  /** Optional strip below the body (status / legend). Hidden while collapsed. */
+  /** Optional strip below the body (status / legend). */
   footer?: ReactNode
-  defaultCollapsed?: boolean
 }
 
 export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function ChartCard(
-  { title, actions, children, footer, defaultCollapsed = false, className, ...props },
+  { title, actions, children, footer, className, ...props },
   ref,
 ) {
   const [isMaximized, setIsMaximized] = useState(false)
-  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed)
 
   // Escape restores the maximized overlay, matching standard dialog behavior
   // even though this isn't a Radix Dialog (no focus trap needed here since
@@ -51,24 +65,6 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
-        {/* Collapse is a grid-only affordance. In the maximized overlay it just
-            hides the body, stranding the user on an empty full-screen card with
-            no way back (Restore is the way out) — so it's not offered there. */}
-        {!isMaximized && (
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label={isCollapsed ? 'Expand chart' : 'Collapse chart'}
-            onClick={() => setIsCollapsed((value) => !value)}
-            className="size-8 px-0 text-fg-3"
-          >
-            {isCollapsed ? (
-              <Plus className="size-4" aria-hidden="true" />
-            ) : (
-              <Minus className="size-4" aria-hidden="true" />
-            )}
-          </Button>
-        )}
         <Button
           variant="ghost"
           size="sm"
@@ -86,15 +82,18 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     </div>
   )
 
-  // Maximizing always shows the content — a collapsed-in-grid chart still opens
-  // full-screen with its body (and Restore is the only exit), so there's no way
-  // to land on an empty maximized card.
-  const showBody = isMaximized || !isCollapsed
-  const body = showBody ? <div className="flex-1 overflow-auto p-4">{children}</div> : null
-  const footerStrip =
-    showBody && footer ? (
-      <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
-    ) : null
+  const body = <div className="flex-1 overflow-auto p-4">{children}</div>
+  const footerStrip = footer ? (
+    <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
+  ) : null
+
+  const content = (
+    <ChartMaximizedContext.Provider value={isMaximized}>
+      {header}
+      {body}
+      {footerStrip}
+    </ChartMaximizedContext.Provider>
+  )
 
   if (isMaximized) {
     return createPortal(
@@ -110,9 +109,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           className={cn('flex h-full w-full flex-col', className)}
           {...props}
         >
-          {header}
-          {body}
-          {footerStrip}
+          {content}
         </Card>
       </div>,
       document.body,
@@ -121,9 +118,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
 
   return (
     <Card ref={ref} className={cn('flex flex-col', className)} {...props}>
-      {header}
-      {body}
-      {footerStrip}
+      {content}
     </Card>
   )
 })

--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -1,55 +1,34 @@
 import { forwardRef, useEffect, useState, type HTMLAttributes, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
+import { Maximize2, Minimize2, Minus, Plus } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import { Z } from '@/lib/zIndex'
 
 // Titled shell for a single chart: header (title + actions slot + maximize +
-// collapse) and a scroll-contained body. "Maximize" portals the card to a
-// full-viewport overlay so a chart can be inspected without fighting a
-// cramped dashboard grid cell; "collapse" just hides the body in place, for
-// dashboards where a driver wants to fold a chart they aren't using right now.
+// collapse), a scroll-contained body, and an optional footer strip. "Maximize"
+// portals the card to a full-viewport overlay so a chart can be inspected
+// without fighting a cramped dashboard grid cell; "collapse" just hides the
+// body (and footer) in place, for dashboards where a driver wants to fold a
+// chart they aren't using right now.
 //
 // Acrylic-law exception: the overlay backdrop is chrome, not a data plane, so
 // `backdrop-blur` is allowed here even though data surfaces (the Card itself)
 // stay solid `--bg` with a hairline border, per Card.tsx.
-//
-// No icon package is installed yet, so the maximize/restore glyphs are small
-// inline SVGs rather than a new dependency for two icons.
-
-function MaximizeGlyph() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-4" fill="none" aria-hidden="true">
-      <path
-        d="M2 6V2h4M10 2h4v4M14 10v4h-4M6 14H2v-4"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
-
-function RestoreGlyph() {
-  return (
-    <svg viewBox="0 0 16 16" className="size-4" fill="none" aria-hidden="true">
-      <path d="M4 4l8 8M12 4L4 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-    </svg>
-  )
-}
 
 export interface ChartCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string
   /** Right-aligned header slot, e.g. a range picker or a legend toggle. */
   actions?: ReactNode
   children?: ReactNode
+  /** Optional strip below the body (status / legend). Hidden while collapsed. */
+  footer?: ReactNode
   defaultCollapsed?: boolean
 }
 
 export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function ChartCard(
-  { title, actions, children, defaultCollapsed = false, className, ...props },
+  { title, actions, children, footer, defaultCollapsed = false, className, ...props },
   ref,
 ) {
   const [isMaximized, setIsMaximized] = useState(false)
@@ -68,7 +47,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
   }, [isMaximized])
 
   const header = (
-    <div className="flex shrink-0 items-center justify-between gap-3 border-b border-hairline px-4 py-3">
+    <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-hairline px-4 py-3">
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
@@ -79,7 +58,11 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           onClick={() => setIsCollapsed((value) => !value)}
           className="size-8 px-0 text-fg-3"
         >
-          {isCollapsed ? '+' : '–'}
+          {isCollapsed ? (
+            <Plus className="size-4" aria-hidden="true" />
+          ) : (
+            <Minus className="size-4" aria-hidden="true" />
+          )}
         </Button>
         <Button
           variant="ghost"
@@ -88,13 +71,21 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
           onClick={() => setIsMaximized((value) => !value)}
           className="size-8 px-0 text-fg-3"
         >
-          {isMaximized ? <RestoreGlyph /> : <MaximizeGlyph />}
+          {isMaximized ? (
+            <Minimize2 className="size-4" aria-hidden="true" />
+          ) : (
+            <Maximize2 className="size-4" aria-hidden="true" />
+          )}
         </Button>
       </div>
     </div>
   )
 
   const body = isCollapsed ? null : <div className="flex-1 overflow-auto p-4">{children}</div>
+  const footerStrip =
+    isCollapsed || !footer ? null : (
+      <div className="shrink-0 border-t border-hairline px-4 py-2.5">{footer}</div>
+    )
 
   if (isMaximized) {
     return createPortal(
@@ -112,6 +103,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
         >
           {header}
           {body}
+          {footerStrip}
         </Card>
       </div>,
       document.body,
@@ -122,6 +114,7 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
     <Card ref={ref} className={cn('flex flex-col', className)} {...props}>
       {header}
       {body}
+      {footerStrip}
     </Card>
   )
 })

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -114,11 +114,13 @@ export interface ComboboxProps {
   placeholder?: string
   disabled?: boolean
   className?: string
+  /** Accessible name for the trigger when the visible label lives elsewhere. */
+  ariaLabel?: string
 }
 
 /** Single-select typeahead combobox (e.g. "pick a circuit"). */
 export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, className },
+  { options, value, onChange, placeholder = 'Select...', disabled, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -136,6 +138,7 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Co
           ref={ref}
           type="button"
           disabled={disabled}
+          aria-label={ariaLabel}
           className={cn(
             'flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-hairline bg-bg-3 px-3 text-sm text-fg-1 transition-colors',
             'hover:bg-bg-4',
@@ -176,13 +179,15 @@ export interface MultiComboboxProps {
   /** Caps how many options can be selected at once (e.g. a 3-driver comparison). */
   max?: number
   className?: string
+  /** Accessible name for the trigger when the visible label lives elsewhere. */
+  ariaLabel?: string
 }
 
 /** Multi-select combobox. Selections render as removable chips in the
  *  trigger; once `max` is reached, remaining options render disabled in the
  *  list instead of silently doing nothing on select. */
 export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(function MultiCombobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, max, className },
+  { options, value, onChange, placeholder = 'Select...', disabled, max, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -220,6 +225,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
         <div
           ref={ref}
           role="combobox"
+          aria-label={ariaLabel}
           aria-expanded={!disabled && open}
           aria-haspopup="listbox"
           aria-disabled={disabled}

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -60,6 +60,18 @@ function XIcon({ className }: { className?: string }) {
   )
 }
 
+/** Small colour swatch shown before an option's label when `getOptionAccent`
+ *  is provided (e.g. a driver's team colour in the drivers multi-select). */
+function AccentDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block size-2 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+  )
+}
+
 const PANEL_CLASSNAME = cn(
   'w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl border border-divider bg-bg-4',
   'shadow-[var(--shadow-elev)] outline-none',
@@ -181,13 +193,26 @@ export interface MultiComboboxProps {
   className?: string
   /** Accessible name for the trigger when the visible label lives elsewhere. */
   ariaLabel?: string
+  /** When provided, renders a small colour dot before an option's label (both
+   *  the selected chips and the dropdown items) — e.g. a driver's team colour. */
+  getOptionAccent?: (value: string) => string | undefined
 }
 
 /** Multi-select combobox. Selections render as removable chips in the
  *  trigger; once `max` is reached, remaining options render disabled in the
  *  list instead of silently doing nothing on select. */
 export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(function MultiCombobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, max, className, ariaLabel },
+  {
+    options,
+    value,
+    onChange,
+    placeholder = 'Select...',
+    disabled,
+    max,
+    className,
+    ariaLabel,
+    getOptionAccent,
+  },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -240,26 +265,30 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
           )}
         >
           {selectedOptions.length === 0 && <span className="px-1 text-fg-3">{placeholder}</span>}
-          {selectedOptions.map((option) => (
-            <span
-              key={option.value}
-              className="flex items-center gap-1 rounded-full bg-bg-5 py-0.5 pl-2.5 pr-1 text-fg-1"
-            >
-              {option.label}
-              <button
-                type="button"
-                aria-label={`Remove ${option.label}`}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  removeValue(option.value)
-                }}
-                onPointerDown={(event) => event.stopPropagation()}
-                className="rounded-full p-0.5 text-fg-3 hover:bg-bg-4 hover:text-fg-1"
+          {selectedOptions.map((option) => {
+            const accent = getOptionAccent?.(option.value)
+            return (
+              <span
+                key={option.value}
+                className="flex items-center gap-1 rounded-full bg-bg-5 py-0.5 pl-2.5 pr-1 text-fg-1"
               >
-                <XIcon className="size-3" />
-              </button>
-            </span>
-          ))}
+                {accent && <AccentDot color={accent} />}
+                {option.label}
+                <button
+                  type="button"
+                  aria-label={`Remove ${option.label}`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    removeValue(option.value)
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  className="rounded-full p-0.5 text-fg-3 hover:bg-bg-4 hover:text-fg-1"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              </span>
+            )
+          })}
           <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
         </div>
       </Popover.Trigger>
@@ -267,6 +296,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
         {options.map((option) => {
           const selected = value.includes(option.value)
           const disabledItem = !selected && atMax
+          const accent = getOptionAccent?.(option.value)
           return (
             <Command.Item
               key={option.value}
@@ -275,7 +305,10 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
               onSelect={() => handleSelect(option.value)}
               className={cn(ITEM_CLASSNAME, !disabledItem && 'cursor-pointer')}
             >
-              <span className="truncate">{option.label}</span>
+              <span className="flex min-w-0 items-center gap-2">
+                {accent && <AccentDot color={accent} />}
+                <span className="truncate">{option.label}</span>
+              </span>
               {selected && <CheckIcon className="size-4 shrink-0 text-purple-400" />}
             </Command.Item>
           )

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -65,7 +65,12 @@ function XIcon({ className }: { className?: string }) {
  *  session) — distinguishes "working" from "disabled/unavailable". */
 function SpinnerIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 16 16" fill="none" className={cn('animate-spin', className)} aria-hidden="true">
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      className={cn('animate-spin', className)}
+      aria-hidden="true"
+    >
       <circle
         cx="8"
         cy="8"

--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -60,6 +60,25 @@ function XIcon({ className }: { className?: string }) {
   )
 }
 
+/** Spinner shown in place of the chevron while a combobox's options are
+ *  still loading (e.g. the drivers roster while the backend parses a FastF1
+ *  session) — distinguishes "working" from "disabled/unavailable". */
+function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className={cn('animate-spin', className)} aria-hidden="true">
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeDasharray="28 10"
+      />
+    </svg>
+  )
+}
+
 /** Small colour swatch shown before an option's label when `getOptionAccent`
  *  is provided (e.g. a driver's team colour in the drivers multi-select). */
 function AccentDot({ color }: { color: string }) {
@@ -125,6 +144,9 @@ export interface ComboboxProps {
   onChange: (value: string) => void
   placeholder?: string
   disabled?: boolean
+  /** Options are being fetched — shows a spinner instead of the chevron and
+   *  suspends interaction, without reading as `disabled` (opacity-50). */
+  loading?: boolean
   className?: string
   /** Accessible name for the trigger when the visible label lives elsewhere. */
   ariaLabel?: string
@@ -132,7 +154,7 @@ export interface ComboboxProps {
 
 /** Single-select typeahead combobox (e.g. "pick a circuit"). */
 export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, className, ariaLabel },
+  { options, value, onChange, placeholder = 'Select...', disabled, loading, className, ariaLabel },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -151,18 +173,24 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Co
           type="button"
           disabled={disabled}
           aria-label={ariaLabel}
+          aria-busy={loading || undefined}
           className={cn(
             'flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-hairline bg-bg-3 px-3 text-sm text-fg-1 transition-colors',
             'hover:bg-bg-4',
             'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0 focus-visible:outline-none',
             'disabled:pointer-events-none disabled:opacity-50',
+            loading && 'pointer-events-none opacity-80',
             className,
           )}
         >
           <span className={cn('truncate', !selectedLabel && 'text-fg-3')}>
             {selectedLabel ?? placeholder}
           </span>
-          <ChevronDownIcon className="size-4 shrink-0 text-fg-3" />
+          {loading ? (
+            <SpinnerIcon className="size-4 shrink-0 text-fg-3" />
+          ) : (
+            <ChevronDownIcon className="size-4 shrink-0 text-fg-3" />
+          )}
         </button>
       </Popover.Trigger>
       <ComboboxPanel>
@@ -188,6 +216,9 @@ export interface MultiComboboxProps {
   onChange: (value: string[]) => void
   placeholder?: string
   disabled?: boolean
+  /** Options are being fetched — shows a spinner instead of the chevron and
+   *  suspends interaction, without reading as `disabled` (opacity-50). */
+  loading?: boolean
   /** Caps how many options can be selected at once (e.g. a 3-driver comparison). */
   max?: number
   className?: string
@@ -208,6 +239,7 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
     onChange,
     placeholder = 'Select...',
     disabled,
+    loading,
     max,
     className,
     ariaLabel,
@@ -218,13 +250,14 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
   const [open, setOpen] = useState(false)
   const atMax = max !== undefined && value.length >= max
   const selectedOptions = options.filter((option) => value.includes(option.value))
+  const interactive = !disabled && !loading
 
   function handleOpenChange(next: boolean) {
-    if (!disabled) setOpen(next)
+    if (interactive) setOpen(next)
   }
 
   function handleTriggerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (disabled) return
+    if (!interactive) return
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       setOpen((current) => !current)
@@ -245,22 +278,24 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
   }
 
   return (
-    <Popover.Root open={!disabled && open} onOpenChange={handleOpenChange}>
+    <Popover.Root open={interactive && open} onOpenChange={handleOpenChange}>
       <Popover.Trigger asChild>
         <div
           ref={ref}
           role="combobox"
           aria-label={ariaLabel}
-          aria-expanded={!disabled && open}
+          aria-expanded={interactive && open}
           aria-haspopup="listbox"
           aria-disabled={disabled}
-          tabIndex={disabled ? -1 : 0}
+          aria-busy={loading || undefined}
+          tabIndex={interactive ? 0 : -1}
           onKeyDown={handleTriggerKeyDown}
           className={cn(
             'flex min-h-10 w-full flex-wrap items-center gap-1.5 rounded-lg border border-hairline bg-bg-3 px-2 py-1.5 text-sm transition-colors',
             'hover:bg-bg-4',
             'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0 focus-visible:outline-none',
             disabled && 'pointer-events-none opacity-50',
+            loading && !disabled && 'pointer-events-none opacity-80',
             className,
           )}
         >
@@ -289,7 +324,11 @@ export const MultiCombobox = forwardRef<HTMLDivElement, MultiComboboxProps>(func
               </span>
             )
           })}
-          <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          {loading ? (
+            <SpinnerIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          ) : (
+            <ChevronDownIcon className="ml-auto size-4 shrink-0 text-fg-3" />
+          )}
         </div>
       </Popover.Trigger>
       <ComboboxPanel>

--- a/webapp/src/components/ThemeToggle.tsx
+++ b/webapp/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { Moon, Sun } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { useUiStore } from '@/stores/ui'
+
+// Icon-only theme toggle, mounted in `app/Header.tsx`'s right cluster so
+// every routed page gets it for free. This component only flips the
+// two-state `theme` in `stores/ui.ts` — the `<html data-theme>` DOM stamping
+// and the FOUC guard already live in `providers.tsx` / `index.html`
+// (app-chrome-round2.md §2b-c), so ThemeToggle never touches the DOM
+// directly, it just reads/writes the store.
+
+/**
+ * Sun/Moon icon-only button. The icon always depicts the theme you're about
+ * to switch TO, not the one you're currently in — Sun while dark ("go
+ * light"), Moon while light ("go dark") — so the control reads as an action
+ * rather than a status indicator.
+ */
+export function ThemeToggle() {
+  const theme = useUiStore((state) => state.theme)
+  const toggleTheme = useUiStore((state) => state.toggleTheme)
+  const Icon = theme === 'dark' ? Sun : Moon
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+      onClick={toggleTheme}
+      className="size-8 px-0"
+    >
+      <Icon
+        aria-hidden="true"
+        className="size-4 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none"
+      />
+    </Button>
+  )
+}

--- a/webapp/src/components/ThemeToggle.tsx
+++ b/webapp/src/components/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import { Moon, Sun } from 'lucide-react'
+import type { MouseEvent } from 'react'
 import { Button } from '@/components/Button'
 import { useUiStore } from '@/stores/ui'
 
@@ -6,8 +7,94 @@ import { useUiStore } from '@/stores/ui'
 // every routed page gets it for free. This component only flips the
 // two-state `theme` in `stores/ui.ts` — the `<html data-theme>` DOM stamping
 // and the FOUC guard already live in `providers.tsx` / `index.html`
-// (app-chrome-round2.md §2b-c), so ThemeToggle never touches the DOM
-// directly, it just reads/writes the store.
+// (app-chrome-round2.md §2b-c). The one exception is `handleClick` below: it
+// also stamps `data-theme` itself, synchronously, inside the View Transition
+// callback — see `runThemeViewTransition` for why that duplication is
+// required rather than a DOM violation.
+
+const VIEW_TRANSITION_DURATION_MS = 480
+
+/** The subset of `ViewTransition` this component actually reads. */
+interface ViewTransitionLike {
+  ready: Promise<void>
+}
+
+/**
+ * `document` augmented with the View Transitions API. Declared locally
+ * (never `any`) because TypeScript's bundled DOM lib only gained
+ * `startViewTransition` typings in recent releases — this intersection type
+ * is structurally compatible whether or not `lib.dom.d.ts` already declares
+ * the method, so the cast below is safe either way (see summary handoff for
+ * the compatibility reasoning).
+ */
+type DocumentWithViewTransitions = Document & {
+  startViewTransition?: (callback: () => void) => ViewTransitionLike
+}
+
+function getViewTransitionDocument(): DocumentWithViewTransitions {
+  return document as DocumentWithViewTransitions
+}
+
+/** False when the browser lacks View Transitions or the user asked for reduced motion — the caller should fall back to an instant, unanimated toggle. */
+function canAnimateThemeSwitch(): boolean {
+  const supportsViewTransitions =
+    typeof getViewTransitionDocument().startViewTransition === 'function'
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  return supportsViewTransitions && !prefersReducedMotion
+}
+
+/**
+ * Expands a circular reveal of the new theme from `(x, y)` — the toggle
+ * button's own center — outward until it covers the viewport. `index.css`
+ * disables the browser's default cross-fade on `::view-transition-old/new`,
+ * so the old frame just sits still underneath while this clip-path animation
+ * wipes the new one over it (the theme-toggle.rdsx.dev technique).
+ */
+function animateThemeCircleReveal(x: number, y: number) {
+  const endRadius = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y),
+  )
+  document.documentElement.animate(
+    { clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${endRadius}px at ${x}px ${y}px)`] },
+    {
+      duration: VIEW_TRANSITION_DURATION_MS,
+      easing: 'ease-in-out',
+      pseudoElement: '::view-transition-new(root)',
+    },
+  )
+}
+
+/**
+ * Runs `applyTheme` inside `document.startViewTransition`, then drives the
+ * circular reveal once the new frame is ready.
+ *
+ * `applyTheme` MUST mutate the DOM synchronously: the View Transitions API
+ * snapshots the "old" frame before the callback runs and the "new" frame
+ * right after it returns, but `providers.tsx`'s theme effect only re-stamps
+ * `data-theme` asynchronously on the next React commit — too late for the
+ * snapshot. That's why `handleClick` sets `data-theme` itself inside the
+ * callback; the store update still happens too, so providers.tsx's effect
+ * re-stamps the same value afterwards as a no-op.
+ */
+function runThemeViewTransition(x: number, y: number, applyTheme: () => void) {
+  document.documentElement.style.setProperty('--theme-x', `${x}px`)
+  document.documentElement.style.setProperty('--theme-y', `${y}px`)
+
+  const transition = getViewTransitionDocument().startViewTransition?.(applyTheme)
+  if (!transition) {
+    applyTheme()
+    return
+  }
+
+  transition.ready
+    .then(() => animateThemeCircleReveal(x, y))
+    .catch(() => {
+      // `ready` can reject (e.g. the browser skipped the transition). The
+      // theme has already flipped synchronously above, so there's nothing to
+      // recover — just drop the reveal animation.
+    })
+}
 
 /**
  * Sun/Moon icon-only button. The icon always depicts the theme you're about
@@ -20,12 +107,29 @@ export function ThemeToggle() {
   const toggleTheme = useUiStore((state) => state.toggleTheme)
   const Icon = theme === 'dark' ? Sun : Moon
 
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+    if (!canAnimateThemeSwitch()) {
+      toggleTheme()
+      return
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect()
+    const x = rect.left + rect.width / 2
+    const y = rect.top + rect.height / 2
+    const nextTheme = theme === 'dark' ? 'light' : 'dark'
+
+    runThemeViewTransition(x, y, () => {
+      document.documentElement.dataset.theme = nextTheme
+      toggleTheme()
+    })
+  }
+
   return (
     <Button
       variant="ghost"
       size="sm"
       aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-      onClick={toggleTheme}
+      onClick={handleClick}
       className="size-8 px-0"
     >
       <Icon

--- a/webapp/src/features/dashboard/DashboardPage.tsx
+++ b/webapp/src/features/dashboard/DashboardPage.tsx
@@ -1,20 +1,27 @@
-// Dashboard page (issue #34) — the telemetry pilot screen, full §6.1 parity.
+// Dashboard page (issue #34 + elevation). The telemetry workspace.
 //
-// This component owns the URL (selector state) and threads it to every section:
-// it reads the validated search, exposes the component-facing array shape, and
-// applies the cascading reset (changing year clears GP/session/drivers, etc.).
-// Sections are dumb consumers of `search` — the lap chart writes loaded laps to
-// the dashboard store, the telemetry grid + circuit map read them.
+// This component owns the URL (selector state), threads it to every section,
+// and runs the workspace-level behaviours: prewarm the FastF1 session on
+// session-select, auto-load each driver's fastest lap when lap-times arrive
+// (so the telemetry charts fall in without a manual click), and reset loaded
+// laps when the session or drivers change. Sections are dumb consumers of
+// `search`; the lap chart writes loaded laps to the store, the telemetry grid
+// and circuit map read them.
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Link, getRouteApi } from '@tanstack/react-router'
+import { ArrowRightLeft, Gauge, TriangleAlert } from 'lucide-react'
 import { Header } from '@/app/Header'
 import { Button } from '@/components/Button'
+import { EmptyState } from '@/components/EmptyState'
+import { cn } from '@/lib/cn'
 import { SelectorsToolbar } from './components/SelectorsToolbar'
 import { LapChartSection } from './components/LapChartSection'
 import { CircuitDominationSection } from './components/CircuitDominationSection'
 import { TelemetryGrid } from './components/TelemetryGrid'
 import { useDashboardStore } from './store'
+import { useLapTimes, prewarmTelemetry } from './queries'
+import { fastestLapPerDriver } from './lib/fastestLap'
 import { fromRaw, toRaw, type DashboardSearch } from './search'
 
 const routeApi = getRouteApi('/dashboard')
@@ -23,32 +30,61 @@ export function DashboardPage() {
   const raw = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
   const search = fromRaw(raw)
+
   const pruneLaps = useDashboardStore((s) => s.pruneLaps)
   const clearLaps = useDashboardStore((s) => s.clearLaps)
+  const setLap = useDashboardStore((s) => s.setLap)
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
 
-  // A loaded lap only means something within one (year, GP, session). If any of
-  // those change — including via a Back/Forward jump or an incoming link that
-  // doesn't go through the selectors — drop every loaded lap, otherwise a stale
-  // driver→lap would be re-fetched against the NEW session's key.
+  const lapTimesQuery = useLapTimes(search)
+  const lapTimes = lapTimesQuery.data
+
+  // A loaded lap only means something within one (year, GP, session). Clear all
+  // loaded laps when the session context CHANGES — but NOT on the first mount,
+  // so navigating away and back (e.g. to Comparison) preserves what was loaded
+  // instead of silently resetting it to the fastest laps.
   const contextKey = `${search.year ?? ''}|${search.gp ?? ''}|${search.session ?? ''}`
+  const contextInitialized = useRef(false)
   useEffect(() => {
+    if (!contextInitialized.current) {
+      contextInitialized.current = true
+      return
+    }
     clearLaps()
   }, [contextKey, clearLaps])
 
-  // Within the same session, removing a driver prunes just their loaded lap
-  // (the other drivers' stay).
+  // Removing a driver prunes just their loaded lap (others stay).
   const driverKey = search.drivers.join(',')
   useEffect(() => {
     pruneLaps(driverKey ? driverKey.split(',') : [])
   }, [driverKey, pruneLaps])
 
+  // Auto-load the fastest lap for every selected driver that doesn't already
+  // have a loaded lap — so the telemetry charts appear without hunting for
+  // "click a point", AND adding a 2nd/3rd driver mid-session loads them too.
+  // MERGE, never replace: a manually-clicked lap (already in the map) is left
+  // untouched.
+  useEffect(() => {
+    if (!lapTimes || lapTimes.length === 0) return
+    const drivers = driverKey ? driverKey.split(',') : []
+    const missing = drivers.filter((driver) => !(driver in selectedLapsPerDriver))
+    if (missing.length === 0) return
+    const fastest = fastestLapPerDriver(lapTimes, missing)
+    for (const [driver, lap] of Object.entries(fastest)) setLap(driver, lap)
+  }, [lapTimes, driverKey, selectedLapsPerDriver, setLap])
+
   /** Patch the URL selection, applying the cascading reset of dependent levels. */
   const handleChange = (patch: Partial<DashboardSearch>) => {
-    // Re-picking the SAME value from a dropdown must not wipe the downstream
-    // selection (the combobox fires onChange even when the value is unchanged).
+    // Re-picking the SAME value must not wipe the downstream selection.
     if ('year' in patch && patch.year === search.year) return
     if ('gp' in patch && patch.gp === search.gp) return
     if ('session' in patch && patch.session === search.session) return
+
+    // Warm the session cache the moment a session is chosen — the parse runs
+    // while the user picks drivers, so the charts don't hang afterwards.
+    if ('session' in patch && patch.session && search.year != null && search.gp) {
+      prewarmTelemetry(search.year, search.gp, patch.session)
+    }
 
     const next: DashboardSearch = { ...search, ...patch }
     if ('year' in patch) {
@@ -64,21 +100,74 @@ export function DashboardPage() {
     void navigate({ search: toRaw(next) })
   }
 
+  const hasDrivers = search.drivers.length > 0
+  // Drivers are chosen but lap-times settled with no data (backend down, or no
+  // laps for these drivers this session): show ONE clear notice instead of a
+  // lap-chart banner contradicting seven telemetry loaders that never resolve.
+  const lapTimesFailed =
+    hasDrivers &&
+    !lapTimesQuery.isLoading &&
+    (lapTimesQuery.isError || (lapTimes?.length ?? 0) === 0)
+
   return (
     <>
       <Header title="Dashboard">
         <Link to="/comparison" search={toRaw(search)}>
           <Button variant="ghost" size="sm">
-            ⚖️ Go to comparison
+            <ArrowRightLeft className="size-4" aria-hidden="true" />
+            Go to comparison
           </Button>
         </Link>
       </Header>
 
-      <div className="flex flex-col gap-8">
-        <SelectorsToolbar value={search} onChange={handleChange} />
-        <LapChartSection search={search} />
-        <CircuitDominationSection search={search} />
-        <TelemetryGrid search={search} />
+      <div className="flex flex-col gap-6">
+        {/* Selector context bar — sticky under the header so the session you're
+            looking at stays visible while you scroll the charts. */}
+        <div
+          className={cn(
+            'sticky top-14 z-20 -mx-6 border-b border-hairline bg-bg-1/85 px-6 py-3 backdrop-blur',
+          )}
+        >
+          <SelectorsToolbar value={search} onChange={handleChange} />
+        </div>
+
+        {!hasDrivers ? (
+          <EmptyState
+            icon={<Gauge className="size-8 text-fg-3" aria-hidden="true" />}
+            title="Pick a session and up to three drivers"
+            description={
+              search.session
+                ? 'Choose up to three drivers above to load their lap times and telemetry.'
+                : 'Choose a year, Grand Prix and session above, then up to three drivers.'
+            }
+          />
+        ) : lapTimesFailed ? (
+          <div
+            role="status"
+            className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
+          >
+            <TriangleAlert className="size-5 shrink-0 text-warning" aria-hidden="true" />
+            <span>
+              No lap data for this selection. The backend may be unavailable, or these drivers set
+              no timed laps in this session — try another session or driver.
+            </span>
+          </div>
+        ) : (
+          <>
+            {/* Zone 1 — Session: lap chart (hero) beside the circuit map. */}
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+              <div className="min-w-0 xl:col-span-2">
+                <LapChartSection search={search} />
+              </div>
+              <div className="min-w-0 xl:col-span-1">
+                <CircuitDominationSection search={search} />
+              </div>
+            </div>
+
+            {/* Zone 2 — Lap inspector: the 7 telemetry channels. */}
+            <TelemetryGrid search={search} />
+          </>
+        )}
       </div>
     </>
   )

--- a/webapp/src/features/dashboard/DashboardPage.tsx
+++ b/webapp/src/features/dashboard/DashboardPage.tsx
@@ -1,0 +1,85 @@
+// Dashboard page (issue #34) — the telemetry pilot screen, full §6.1 parity.
+//
+// This component owns the URL (selector state) and threads it to every section:
+// it reads the validated search, exposes the component-facing array shape, and
+// applies the cascading reset (changing year clears GP/session/drivers, etc.).
+// Sections are dumb consumers of `search` — the lap chart writes loaded laps to
+// the dashboard store, the telemetry grid + circuit map read them.
+
+import { useEffect } from 'react'
+import { Link, getRouteApi } from '@tanstack/react-router'
+import { Header } from '@/app/Header'
+import { Button } from '@/components/Button'
+import { SelectorsToolbar } from './components/SelectorsToolbar'
+import { LapChartSection } from './components/LapChartSection'
+import { CircuitDominationSection } from './components/CircuitDominationSection'
+import { TelemetryGrid } from './components/TelemetryGrid'
+import { useDashboardStore } from './store'
+import { fromRaw, toRaw, type DashboardSearch } from './search'
+
+const routeApi = getRouteApi('/dashboard')
+
+export function DashboardPage() {
+  const raw = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const search = fromRaw(raw)
+  const pruneLaps = useDashboardStore((s) => s.pruneLaps)
+  const clearLaps = useDashboardStore((s) => s.clearLaps)
+
+  // A loaded lap only means something within one (year, GP, session). If any of
+  // those change — including via a Back/Forward jump or an incoming link that
+  // doesn't go through the selectors — drop every loaded lap, otherwise a stale
+  // driver→lap would be re-fetched against the NEW session's key.
+  const contextKey = `${search.year ?? ''}|${search.gp ?? ''}|${search.session ?? ''}`
+  useEffect(() => {
+    clearLaps()
+  }, [contextKey, clearLaps])
+
+  // Within the same session, removing a driver prunes just their loaded lap
+  // (the other drivers' stay).
+  const driverKey = search.drivers.join(',')
+  useEffect(() => {
+    pruneLaps(driverKey ? driverKey.split(',') : [])
+  }, [driverKey, pruneLaps])
+
+  /** Patch the URL selection, applying the cascading reset of dependent levels. */
+  const handleChange = (patch: Partial<DashboardSearch>) => {
+    // Re-picking the SAME value from a dropdown must not wipe the downstream
+    // selection (the combobox fires onChange even when the value is unchanged).
+    if ('year' in patch && patch.year === search.year) return
+    if ('gp' in patch && patch.gp === search.gp) return
+    if ('session' in patch && patch.session === search.session) return
+
+    const next: DashboardSearch = { ...search, ...patch }
+    if ('year' in patch) {
+      next.gp = undefined
+      next.session = undefined
+      next.drivers = []
+    } else if ('gp' in patch) {
+      next.session = undefined
+      next.drivers = []
+    } else if ('session' in patch) {
+      next.drivers = []
+    }
+    void navigate({ search: toRaw(next) })
+  }
+
+  return (
+    <>
+      <Header title="Dashboard">
+        <Link to="/comparison" search={toRaw(search)}>
+          <Button variant="ghost" size="sm">
+            ⚖️ Go to comparison
+          </Button>
+        </Link>
+      </Header>
+
+      <div className="flex flex-col gap-8">
+        <SelectorsToolbar value={search} onChange={handleChange} />
+        <LapChartSection search={search} />
+        <CircuitDominationSection search={search} />
+        <TelemetryGrid search={search} />
+      </div>
+    </>
+  )
+}

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -10,15 +10,21 @@
 // `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
 // scrubbing any one chart shows every driver's value at that distance.
 
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
-import type { EChartsOption, LineSeriesOption } from 'echarts'
+import type {
+  DefaultLabelFormatterCallbackParams,
+  EChartsOption,
+  LineSeriesOption,
+  TooltipComponentFormatterCallbackParams,
+} from 'echarts'
 import * as echarts from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
 import { F1_THEME } from '@/charts/echartsTheme'
 import type { LapTelemetry } from '@/lib/api/telemetry'
-import { getDriverColor } from '../lib/drivers'
+import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
+import { TelemetryLoader } from './TelemetryLoader'
 
 // Register the token theme at module load, before any chart's init runs
 // (echarts-for-react inits with the `theme` prop in componentDidMount, which
@@ -26,20 +32,69 @@ import type { ChannelConfig } from './channels'
 registerF1Theme()
 
 const CHART_HEIGHT = 320
+// DRS renders as a state band, not a full telemetry trace — a shorter card
+// keeps it from claiming as much vertical rhythm as Speed/RPM/etc.
+const BAND_CHART_HEIGHT = 180
+
+// Legend only earns its keep once there's something to disambiguate between —
+// a lone "— VER" floating atop a single-driver chart is noise, not
+// information. Hiding it frees the strip `grid.top` reserved for it.
+const LEGEND_GRID_TOP = 44
+const NO_LEGEND_GRID_TOP = 16
 
 // Every telemetry ECharts instance joins this group so `echarts.connect`
 // moves every chart's crosshair together when one is scrubbed. That's a
 // meaningful sync, not just a visual one: x is distance on all 7 charts.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
 
-const AXIS_TOOLTIP: EChartsOption['tooltip'] = { trigger: 'axis', axisPointer: { type: 'line' } }
+interface LegendEntry {
+  name: string
+  color: string
+}
 
-/** Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
- *  chart reuses; callers only supply the y-axis and series. The y-axis name is
- *  anchored to the left of the axis line (`align: 'left'`) so a label like
- *  "Throttle (%)" extends into the plot instead of half of it clipping off the
- *  container's left edge. */
-function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): EChartsOption {
+/**
+ * One tooltip row per hovered series: the driver code in its (readable) team
+ * colour, the value right-aligned in mono — turns ECharts' default
+ * left-aligned wall of numbers into something closer to a timing scoreboard.
+ * Shared by every telemetry chart (baseOption below), so drivers read the
+ * same way whether it's Speed, Delta, or the DRS band.
+ */
+function buildTooltipFormatter(year: number | undefined) {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
+    return items
+      .map(({ seriesName, value }) => {
+        if (!seriesName) return ''
+        const raw = Array.isArray(value) ? value[value.length - 1] : value
+        const display =
+          typeof raw === 'number'
+            ? Number.isInteger(raw)
+              ? String(raw) // gear / DRS are integers — no ".0"
+              : raw.toFixed(1)
+            : String(raw ?? '')
+        return `<div style="display:flex;justify-content:space-between;gap:20px;">
+  <span style="color:${getDriverTextColor(seriesName, year)}">${seriesName}</span>
+  <span style="font-family:'JetBrains Mono Variable',monospace">${display}</span>
+</div>`
+      })
+      .join('')
+  }
+}
+
+/**
+ * Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
+ * chart reuses; callers only supply the y-axis and series. Legend entries
+ * carry each driver's readable team colour so the driver name shows
+ * in-colour instead of plain white; with only one driver loaded the legend
+ * is dropped entirely (nothing to disambiguate) and the freed strip goes
+ * back to the plot via `grid.top`.
+ */
+function baseOption(
+  legendEntries: LegendEntry[],
+  yAxis: EChartsOption['yAxis'],
+  year: number | undefined,
+): EChartsOption {
+  const showLegend = legendEntries.length > 1
   const yAxisStyled = {
     // `scale: true` autoranges around the data instead of forcing a 0 baseline
     // (Plotly's default in the Streamlit original) — RPM/Speed/Delta would
@@ -47,16 +102,43 @@ function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): E
     // (throttle 0-100, gear, DRS) override this, so it only affects the
     // free-ranged ones.
     scale: true,
-    nameLocation: 'end' as const,
-    nameGap: 12,
-    nameTextStyle: { align: 'left' as const },
     ...(yAxis as object),
   }
   return {
-    tooltip: AXIS_TOOLTIP,
-    legend: { data: driversWithData, top: 0 },
-    grid: { top: 44, left: 8, right: 20, bottom: 8, containLabel: true },
-    xAxis: { type: 'value', name: 'Distance (m)', nameLocation: 'middle', nameGap: 28 },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      extraCssText: 'border-radius:12px;padding:10px 12px',
+      formatter: buildTooltipFormatter(year),
+    },
+    legend: showLegend
+      ? {
+          data: legendEntries.map(({ name, color }) => ({ name, textStyle: { color } })),
+          icon: 'roundRect',
+          itemWidth: 10,
+          itemHeight: 3,
+          top: 0,
+        }
+      : { show: false },
+    grid: {
+      top: showLegend ? LEGEND_GRID_TOP : NO_LEGEND_GRID_TOP,
+      left: 8,
+      right: 20,
+      bottom: 8,
+      containLabel: true,
+    },
+    // The y-axis drops its own `name` — each card's header already carries
+    // the channel's unit-bearing title (e.g. "Speed (km/h)"), so a second
+    // axis label would just repeat it a third time alongside the legend.
+    // `splitLine` is off too: dense multi-driver traces over a full grid
+    // read as moiré noise: a hairline axis alone is quieter.
+    xAxis: {
+      type: 'value',
+      name: 'Distance (m)',
+      nameLocation: 'middle',
+      nameGap: 28,
+      splitLine: { show: false },
+    },
     yAxis: yAxisStyled,
   }
 }
@@ -65,11 +147,15 @@ function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): E
  * One ECharts line series per loaded driver, coloured by team. `points`
  * returns a driver's [distance, value] pairs — the only thing that differs
  * between a plain channel (read one array) and Delta (diff two arrays).
+ * `band` fills the trace down to the axis at ~35% of the driver colour —
+ * used only by the DRS state chart, where a filled band reads as "engaged"
+ * more clearly than a thin stepped line does.
  */
 function buildDriverSeries(
   drivers: string[],
   year: number | undefined,
   stepped: boolean | undefined,
+  band: boolean | undefined,
   points: (driver: string) => Array<[number, number]>,
 ): LineSeriesOption[] {
   return drivers.map((driver) => ({
@@ -79,6 +165,7 @@ function buildDriverSeries(
     step: stepped ? 'end' : undefined,
     lineStyle: { width: 2, color: getDriverColor(driver, year) },
     itemStyle: { color: getDriverColor(driver, year) },
+    areaStyle: band ? { opacity: 0.35 } : undefined,
     data: points(driver),
   }))
 }
@@ -90,21 +177,28 @@ function buildChannelOption(
   channel: ChannelConfig,
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
-  const series = buildDriverSeries(loaded, year, channel.stepped, (driver) => {
+  const legendEntries = loaded.map((driver) => ({
+    name: driver,
+    color: getDriverTextColor(driver, year),
+  }))
+  const series = buildDriverSeries(loaded, year, channel.stepped, channel.band, (driver) => {
     const telemetry = byDriver[driver]
     const values = channel.transform(telemetry)
     return telemetry.distance.map((distance, i): [number, number] => [distance, values[i]])
   })
 
   return {
-    ...baseOption(loaded, {
-      type: 'value',
-      name: channel.yName,
-      min: channel.yAxis?.min,
-      max: channel.yAxis?.max,
-      interval: channel.yAxis?.interval,
-      axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
-    }),
+    ...baseOption(
+      legendEntries,
+      {
+        type: 'value',
+        min: channel.yAxis?.min,
+        max: channel.yAxis?.max,
+        interval: channel.yAxis?.interval,
+        axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
+      },
+      year,
+    ),
     series,
   }
 }
@@ -114,13 +208,21 @@ function buildChannelOption(
  * line chart and joins the crosshair group so scrubbing one channel moves
  * the vertical guide on all the others at the same distance.
  */
-function SyncedLineChart({ option, ariaLabel }: { option: EChartsOption; ariaLabel: string }) {
+function SyncedLineChart({
+  option,
+  ariaLabel,
+  height = CHART_HEIGHT,
+}: {
+  option: EChartsOption
+  ariaLabel: string
+  height?: number
+}) {
   return (
     <div role="img" aria-label={ariaLabel}>
       <ReactECharts
         theme={F1_THEME}
         option={option}
-        style={{ height: CHART_HEIGHT }}
+        style={{ height }}
         notMerge
         onChartReady={(instance) => {
           instance.group = CROSSHAIR_GROUP
@@ -140,14 +242,30 @@ export interface ChannelChartProps {
 }
 
 /** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
- *  ECharts line per loaded driver, x = distance in meters. */
-export function ChannelChart({ title, byDriver, drivers, year, channel }: ChannelChartProps) {
+ *  ECharts line per loaded driver, x = distance in meters. DRS renders as a
+ *  shorter, filled state band instead of the standard line height (see
+ *  `channel.band` in channels.ts). Memoized: 6 of these mount per grid, and
+ *  most re-renders (layout toggle, an unrelated driver's data settling)
+ *  don't change this channel's own `byDriver`/`drivers`/`year`. */
+export const ChannelChart = memo(function ChannelChart({
+  title,
+  byDriver,
+  drivers,
+  year,
+  channel,
+}: ChannelChartProps) {
   const option = useMemo(
     () => buildChannelOption(byDriver, drivers, year, channel),
     [byDriver, drivers, year, channel],
   )
-  return <SyncedLineChart option={option} ariaLabel={`${title} telemetry chart`} />
-}
+  return (
+    <SyncedLineChart
+      option={option}
+      ariaLabel={`${title} telemetry chart`}
+      height={channel.band ? BAND_CHART_HEIGHT : CHART_HEIGHT}
+    />
+  )
+})
 
 // ---- Delta: cross-driver, needs its own data prep --------------------------
 
@@ -205,10 +323,14 @@ function buildDeltaOption(
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const reference = findReferenceDriver(byDriver, loaded)
-  if (!reference) return baseOption([], { type: 'value', name: 'Delta (s)' })
+  if (!reference) return baseOption([], { type: 'value' }, year)
 
   const refTelemetry = byDriver[reference]
-  const series = buildDriverSeries(loaded, year, false, (driver) => {
+  const legendEntries = loaded.map((driver) => ({
+    name: driver,
+    color: getDriverTextColor(driver, year),
+  }))
+  const series = buildDriverSeries(loaded, year, false, false, (driver) => {
     const telemetry = byDriver[driver]
     return telemetry.distance.map((distance, i): [number, number] => {
       const refTime = interp(distance, refTelemetry.distance, refTelemetry.time)
@@ -230,27 +352,43 @@ function buildDeltaOption(
     }
   }
 
-  return { ...baseOption(loaded, { type: 'value', name: 'Delta (s)' }), series }
+  return { ...baseOption(legendEntries, { type: 'value' }, year), series }
 }
 
 export interface DeltaChartProps {
   byDriver: Record<string, LapTelemetry>
   drivers: string[]
   year: number | undefined
+  /** True while at least one selected lap is still loading (from
+   *  `useLapTelemetries`). Distinguishes "still fetching the 2nd driver"
+   *  from "nobody picked a 2nd driver yet" — without it, a 2-driver
+   *  selection mid-fetch shows the same "needs ≥2 drivers" note as the true
+   *  empty state, which reads as broken rather than in progress. */
+  isLoading: boolean
 }
 
 /**
  * Time delta vs. the fastest loaded driver, interpolated onto their distance
  * grid. Needs >=2 loaded drivers to have anyone to compare against —
- * `delta_graph.py` shows an `st.info` notice in the same case.
+ * `delta_graph.py` shows an `st.info` notice in the same case, unless a 2nd+
+ * driver is still loading, in which case the shared loader plays instead of
+ * a note that looks like a bug.
  */
-export function DeltaChart({ byDriver, drivers, year }: DeltaChartProps) {
+export const DeltaChart = memo(function DeltaChart({
+  byDriver,
+  drivers,
+  year,
+  isLoading,
+}: DeltaChartProps) {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
 
   if (loaded.length < MIN_DELTA_DRIVERS) {
+    if (drivers.length >= MIN_DELTA_DRIVERS && isLoading) {
+      return <TelemetryLoader />
+    }
     return <p className="px-2 py-12 text-center text-sm text-fg-3">Delta needs ≥2 drivers</p>
   }
 
   return <SyncedLineChart option={option} ariaLabel="Delta telemetry chart" />
-}
+})

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -1,0 +1,256 @@
+// Shared ECharts line chart for the TELEMETRY grid (issue #34, §6.1). One
+// component (`ChannelChart`) covers 6 of the 7 channels via `ChannelConfig`
+// (channels.ts); Delta is cross-driver — it needs a reference lap to diff
+// every other driver against, not a single telemetry array — so it gets its
+// own `DeltaChart` below. Both share `SyncedLineChart`, the thin ECharts
+// wrapper that joins every telemetry chart to one crosshair group.
+//
+// Streamlit parity: frontend/components/telemetry/*.py — same x-axis
+// (distance), one line per loaded driver in the team colour, and
+// `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
+// scrubbing any one chart shows every driver's value at that distance.
+
+import { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import * as echarts from 'echarts'
+import { registerF1Theme } from '@/charts/registerEcharts'
+import { F1_THEME } from '@/charts/echartsTheme'
+import type { LapTelemetry } from '@/lib/api/telemetry'
+import { getDriverColor } from '../lib/drivers'
+import type { ChannelConfig } from './channels'
+
+// Register the token theme at module load, before any chart's init runs
+// (echarts-for-react inits with the `theme` prop in componentDidMount, which
+// fires before a parent's passive effect — see charts/Gauge.tsx).
+registerF1Theme()
+
+const CHART_HEIGHT = 320
+
+// Every telemetry ECharts instance joins this group so `echarts.connect`
+// moves every chart's crosshair together when one is scrubbed. That's a
+// meaningful sync, not just a visual one: x is distance on all 7 charts.
+const CROSSHAIR_GROUP = 'telemetry-crosshair'
+
+const AXIS_TOOLTIP: EChartsOption['tooltip'] = { trigger: 'axis', axisPointer: { type: 'line' } }
+
+/** Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
+ *  chart reuses; callers only supply the y-axis and series. The y-axis name is
+ *  anchored to the left of the axis line (`align: 'left'`) so a label like
+ *  "Throttle (%)" extends into the plot instead of half of it clipping off the
+ *  container's left edge. */
+function baseOption(driversWithData: string[], yAxis: EChartsOption['yAxis']): EChartsOption {
+  const yAxisStyled = {
+    // `scale: true` autoranges around the data instead of forcing a 0 baseline
+    // (Plotly's default in the Streamlit original) — RPM/Speed/Delta would
+    // otherwise waste half the plot. Channels that set explicit min/max
+    // (throttle 0-100, gear, DRS) override this, so it only affects the
+    // free-ranged ones.
+    scale: true,
+    nameLocation: 'end' as const,
+    nameGap: 12,
+    nameTextStyle: { align: 'left' as const },
+    ...(yAxis as object),
+  }
+  return {
+    tooltip: AXIS_TOOLTIP,
+    legend: { data: driversWithData, top: 0 },
+    grid: { top: 44, left: 8, right: 20, bottom: 8, containLabel: true },
+    xAxis: { type: 'value', name: 'Distance (m)', nameLocation: 'middle', nameGap: 28 },
+    yAxis: yAxisStyled,
+  }
+}
+
+/**
+ * One ECharts line series per loaded driver, coloured by team. `points`
+ * returns a driver's [distance, value] pairs — the only thing that differs
+ * between a plain channel (read one array) and Delta (diff two arrays).
+ */
+function buildDriverSeries(
+  drivers: string[],
+  year: number | undefined,
+  stepped: boolean | undefined,
+  points: (driver: string) => Array<[number, number]>,
+): LineSeriesOption[] {
+  return drivers.map((driver) => ({
+    name: driver,
+    type: 'line',
+    showSymbol: false,
+    step: stepped ? 'end' : undefined,
+    lineStyle: { width: 2, color: getDriverColor(driver, year) },
+    itemStyle: { color: getDriverColor(driver, year) },
+    data: points(driver),
+  }))
+}
+
+function buildChannelOption(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+  year: number | undefined,
+  channel: ChannelConfig,
+): EChartsOption {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const series = buildDriverSeries(loaded, year, channel.stepped, (driver) => {
+    const telemetry = byDriver[driver]
+    const values = channel.transform(telemetry)
+    return telemetry.distance.map((distance, i): [number, number] => [distance, values[i]])
+  })
+
+  return {
+    ...baseOption(loaded, {
+      type: 'value',
+      name: channel.yName,
+      min: channel.yAxis?.min,
+      max: channel.yAxis?.max,
+      interval: channel.yAxis?.interval,
+      axisLabel: channel.yAxis?.formatter ? { formatter: channel.yAxis.formatter } : undefined,
+    }),
+    series,
+  }
+}
+
+/**
+ * ECharts wrapper shared by every telemetry chart: renders the F1-themed
+ * line chart and joins the crosshair group so scrubbing one channel moves
+ * the vertical guide on all the others at the same distance.
+ */
+function SyncedLineChart({ option, ariaLabel }: { option: EChartsOption; ariaLabel: string }) {
+  return (
+    <div role="img" aria-label={ariaLabel}>
+      <ReactECharts
+        theme={F1_THEME}
+        option={option}
+        style={{ height: CHART_HEIGHT }}
+        notMerge
+        onChartReady={(instance) => {
+          instance.group = CROSSHAIR_GROUP
+          echarts.connect(CROSSHAIR_GROUP)
+        }}
+      />
+    </div>
+  )
+}
+
+export interface ChannelChartProps {
+  title: string
+  byDriver: Record<string, LapTelemetry>
+  drivers: string[]
+  year: number | undefined
+  channel: ChannelConfig
+}
+
+/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
+ *  ECharts line per loaded driver, x = distance in meters. */
+export function ChannelChart({ title, byDriver, drivers, year, channel }: ChannelChartProps) {
+  const option = useMemo(
+    () => buildChannelOption(byDriver, drivers, year, channel),
+    [byDriver, drivers, year, channel],
+  )
+  return <SyncedLineChart option={option} ariaLabel={`${title} telemetry chart`} />
+}
+
+// ---- Delta: cross-driver, needs its own data prep --------------------------
+
+const MIN_DELTA_DRIVERS = 2
+
+/**
+ * Linear interpolation of `ys` at `x`, given a monotonically increasing `xs`
+ * (mirrors `numpy.interp`, used by the Streamlit original in
+ * `delta_graph.py::_calculate_deltas` to align a driver's time series onto
+ * the reference driver's distance grid). Values outside `[xs[0], xs[last]]`
+ * clamp to the nearest endpoint instead of extrapolating.
+ */
+function interp(x: number, xs: number[], ys: number[]): number {
+  const last = xs.length - 1
+  if (x <= xs[0]) return ys[0]
+  if (x >= xs[last]) return ys[last]
+
+  let lo = 0
+  let hi = last
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1
+    if (xs[mid] <= x) lo = mid
+    else hi = mid
+  }
+  const t = (x - xs[lo]) / (xs[hi] - xs[lo])
+  return ys[lo] + t * (ys[hi] - ys[lo])
+}
+
+/**
+ * The reference lap is the loaded driver with the smallest final cumulative
+ * time — the fastest lap among those currently loaded. `delta_graph.py`
+ * picks the same reference before diffing every other driver against it.
+ */
+function findReferenceDriver(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+): string | undefined {
+  let reference: string | undefined
+  let bestFinalTime = Infinity
+  for (const driver of drivers) {
+    const telemetry = byDriver[driver]
+    const finalTime = telemetry.time[telemetry.time.length - 1]
+    if (finalTime < bestFinalTime) {
+      bestFinalTime = finalTime
+      reference = driver
+    }
+  }
+  return reference
+}
+
+function buildDeltaOption(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+  year: number | undefined,
+): EChartsOption {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const reference = findReferenceDriver(byDriver, loaded)
+  if (!reference) return baseOption([], { type: 'value', name: 'Delta (s)' })
+
+  const refTelemetry = byDriver[reference]
+  const series = buildDriverSeries(loaded, year, false, (driver) => {
+    const telemetry = byDriver[driver]
+    return telemetry.distance.map((distance, i): [number, number] => {
+      const refTime = interp(distance, refTelemetry.distance, refTelemetry.time)
+      return [distance, telemetry.time[i] - refTime]
+    })
+  })
+
+  // Dashed y=0 reference guide — the reference driver's own delta line hugs
+  // it. ECharts attaches markLine per-series (no chart-level equivalent), so
+  // it rides on the first series (mutating in place; `firstSeries` is the
+  // same object as `series[0]`).
+  const firstSeries = series[0]
+  if (firstSeries) {
+    firstSeries.markLine = {
+      symbol: 'none',
+      silent: true,
+      lineStyle: { type: 'dashed', color: 'rgba(255,255,255,0.35)' },
+      data: [{ yAxis: 0 }],
+    }
+  }
+
+  return { ...baseOption(loaded, { type: 'value', name: 'Delta (s)' }), series }
+}
+
+export interface DeltaChartProps {
+  byDriver: Record<string, LapTelemetry>
+  drivers: string[]
+  year: number | undefined
+}
+
+/**
+ * Time delta vs. the fastest loaded driver, interpolated onto their distance
+ * grid. Needs >=2 loaded drivers to have anyone to compare against —
+ * `delta_graph.py` shows an `st.info` notice in the same case.
+ */
+export function DeltaChart({ byDriver, drivers, year }: DeltaChartProps) {
+  const loaded = drivers.filter((driver) => byDriver[driver])
+  const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
+
+  if (loaded.length < MIN_DELTA_DRIVERS) {
+    return <p className="px-2 py-12 text-center text-sm text-fg-3">Delta needs ≥2 drivers</p>
+  }
+
+  return <SyncedLineChart option={option} ariaLabel="Delta telemetry chart" />
+}

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -19,8 +19,8 @@ import type {
   TooltipComponentFormatterCallbackParams,
 } from 'echarts'
 import * as echarts from 'echarts'
-import { registerF1Theme } from '@/charts/registerEcharts'
-import { F1_THEME } from '@/charts/echartsTheme'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
 import type { LapTelemetry } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
@@ -48,6 +48,12 @@ const NO_LEGEND_GRID_TOP = 16
 // and, since dataZoom lives in `baseOption` below, a zoom/pan on one
 // propagates group-wide too.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
+
+// Delta's y=0 reference markLine (see buildDeltaOption) is a per-series
+// style, not governed by the registered ECharts theme — it needs its own
+// light/dark swap, mirroring echartsTheme.ts's fg/hairline palettes.
+const MARK_LINE_COLOR_DARK = 'rgba(255,255,255,0.35)'
+const MARK_LINE_COLOR_LIGHT = 'rgba(20,18,31,0.35)'
 
 interface LegendEntry {
   name: string
@@ -249,10 +255,12 @@ function SyncedLineChart({
   ariaLabel: string
   height?: number
 }) {
+  const chartTheme = useChartTheme()
   return (
     <div role="img" aria-label={ariaLabel}>
       <ReactECharts
-        theme={F1_THEME}
+        theme={chartTheme}
+        key={chartTheme}
         option={option}
         style={{ height }}
         notMerge
@@ -358,6 +366,7 @@ function buildDeltaOption(
   byDriver: Record<string, LapTelemetry>,
   drivers: string[],
   year: number | undefined,
+  markLineColor: string,
 ): EChartsOption {
   const loaded = drivers.filter((driver) => byDriver[driver])
   const reference = findReferenceDriver(byDriver, loaded)
@@ -379,13 +388,15 @@ function buildDeltaOption(
   // Dashed y=0 reference guide — the reference driver's own delta line hugs
   // it. ECharts attaches markLine per-series (no chart-level equivalent), so
   // it rides on the first series (mutating in place; `firstSeries` is the
-  // same object as `series[0]`).
+  // same object as `series[0]`). markLine styles aren't governed by the
+  // registered theme either (same reasoning as Gauge.tsx), so its color is
+  // threaded in per active theme mode.
   const firstSeries = series[0]
   if (firstSeries) {
     firstSeries.markLine = {
       symbol: 'none',
       silent: true,
-      lineStyle: { type: 'dashed', color: 'rgba(255,255,255,0.35)' },
+      lineStyle: { type: 'dashed', color: markLineColor },
       data: [{ yAxis: 0 }],
     }
   }
@@ -419,7 +430,12 @@ export const DeltaChart = memo(function DeltaChart({
   isLoading,
 }: DeltaChartProps) {
   const loaded = drivers.filter((driver) => byDriver[driver])
-  const option = useMemo(() => buildDeltaOption(byDriver, drivers, year), [byDriver, drivers, year])
+  const chartTheme = useChartTheme()
+  const markLineColor = chartTheme === F1_LIGHT_THEME ? MARK_LINE_COLOR_LIGHT : MARK_LINE_COLOR_DARK
+  const option = useMemo(
+    () => buildDeltaOption(byDriver, drivers, year, markLineColor),
+    [byDriver, drivers, year, markLineColor],
+  )
 
   if (loaded.length < MIN_DELTA_DRIVERS) {
     if (drivers.length >= MIN_DELTA_DRIVERS && isLoading) {

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -10,7 +10,7 @@
 // `hovermode='x unified'` becomes `tooltip.trigger: 'axis'` here, so
 // scrubbing any one chart shows every driver's value at that distance.
 
-import { memo, useMemo } from 'react'
+import { memo, useContext, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type {
   DefaultLabelFormatterCallbackParams,
@@ -21,6 +21,7 @@ import type {
 import * as echarts from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
 import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
+import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTelemetry } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import type { ChannelConfig } from './channels'
@@ -261,13 +262,19 @@ function SyncedLineChart({
   height?: number
 }) {
   const chartTheme = useChartTheme()
+  // Inside the maximized overlay, fill the card instead of holding the fixed
+  // grid height (which would leave dead space). The `key` folds in `maximized`
+  // so the chart REMOUNTS at the new size — echarts-for-react only auto-resizes
+  // on window resize, not on this container change, so a stale canvas would
+  // mis-place the hover crosshair otherwise.
+  const maximized = useContext(ChartMaximizedContext)
   return (
-    <div role="img" aria-label={ariaLabel}>
+    <div role="img" aria-label={ariaLabel} className={maximized ? 'h-full' : undefined}>
       <ReactECharts
         theme={chartTheme}
-        key={chartTheme}
+        key={`${chartTheme}-${maximized}`}
         option={option}
-        style={{ height }}
+        style={{ height: maximized ? '100%' : height }}
         notMerge
         onChartReady={(instance) => {
           instance.group = CROSSHAIR_GROUP

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -1,5 +1,5 @@
 // Shared ECharts line chart for the TELEMETRY grid (issue #34, §6.1). One
-// component (`ChannelChart`) covers 6 of the 7 channels via `ChannelConfig`
+// component (`ChannelChart`) covers 7 of the 8 channels via `ChannelConfig`
 // (channels.ts); Delta is cross-driver — it needs a reference lap to diff
 // every other driver against, not a single telemetry array — so it gets its
 // own `DeltaChart` below. Both share `SyncedLineChart`, the thin ECharts
@@ -44,7 +44,9 @@ const NO_LEGEND_GRID_TOP = 16
 
 // Every telemetry ECharts instance joins this group so `echarts.connect`
 // moves every chart's crosshair together when one is scrubbed. That's a
-// meaningful sync, not just a visual one: x is distance on all 7 charts.
+// meaningful sync, not just a visual one: x is distance on all 8 charts —
+// and, since dataZoom lives in `baseOption` below, a zoom/pan on one
+// propagates group-wide too.
 const CROSSHAIR_GROUP = 'telemetry-crosshair'
 
 interface LegendEntry {
@@ -82,12 +84,15 @@ function buildTooltipFormatter(year: number | undefined) {
 }
 
 /**
- * Shared option scaffolding (tooltip/legend/grid/x-axis) every telemetry
- * chart reuses; callers only supply the y-axis and series. Legend entries
- * carry each driver's readable team colour so the driver name shows
+ * Shared option scaffolding (tooltip/legend/grid/x-axis/zoom) every
+ * telemetry chart reuses; callers only supply the y-axis and series. Legend
+ * entries carry each driver's readable team colour so the driver name shows
  * in-colour instead of plain white; with only one driver loaded the legend
  * is dropped entirely (nothing to disambiguate) and the freed strip goes
- * back to the plot via `grid.top`.
+ * back to the plot via `grid.top`. Also wires drag-pan/zoom (`dataZoom`) and
+ * a Plotly-style box-zoom + reset (`toolbox`) — see the inline comments on
+ * each for why the specific settings, and `CROSSHAIR_GROUP` above for how
+ * a zoom on one chart propagates to the rest.
  */
 function baseOption(
   legendEntries: LegendEntry[],
@@ -140,6 +145,33 @@ function baseOption(
       splitLine: { show: false },
     },
     yAxis: yAxisStyled,
+    // Drag-pan + Shift+wheel zoom, inline (no visible slider). Plain wheel
+    // stays page scroll on purpose — 7-8 tall charts stacked in a column
+    // make unconditional wheel-capture a scroll trap. `filterMode: 'none'`
+    // keeps each chart's own y range stable while panning, so 8 charts
+    // synced on the same x don't rescale-jitter against each other.
+    dataZoom: [
+      {
+        type: 'inside',
+        xAxisIndex: 0,
+        filterMode: 'none',
+        zoomOnMouseWheel: 'shift',
+        moveOnMouseMove: true,
+        moveOnMouseWheel: false,
+      },
+    ],
+    // Toolbox box-zoom (x-only, via `yAxisIndex: 'none'`) is the
+    // click-drag-a-box gesture that matches the Streamlit/Plotly original;
+    // `restore` resets it. Both actions propagate through `CROSSHAIR_GROUP`
+    // (echarts.connect), so zooming one chart zooms every synced chart.
+    toolbox: {
+      right: 8,
+      top: 0,
+      feature: {
+        dataZoom: { yAxisIndex: 'none', filterMode: 'none' },
+        restore: {},
+      },
+    },
   }
 }
 
@@ -241,10 +273,10 @@ export interface ChannelChartProps {
   channel: ChannelConfig
 }
 
-/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/drs) as an
- *  ECharts line per loaded driver, x = distance in meters. DRS renders as a
- *  shorter, filled state band instead of the standard line height (see
- *  `channel.band` in channels.ts). Memoized: 6 of these mount per grid, and
+/** Renders one telemetry channel (speed/throttle/brake/rpm/gear/accel/drs)
+ *  as an ECharts line per loaded driver, x = distance in meters. DRS renders
+ *  as a shorter, filled state band instead of the standard line height (see
+ *  `channel.band` in channels.ts). Memoized: 7 of these mount per grid, and
  *  most re-renders (layout toggle, an unrelated driver's data settling)
  *  don't change this channel's own `byDriver`/`drivers`/`year`. */
 export const ChannelChart = memo(function ChannelChart({
@@ -258,13 +290,19 @@ export const ChannelChart = memo(function ChannelChart({
     () => buildChannelOption(byDriver, drivers, year, channel),
     [byDriver, drivers, year, channel],
   )
-  return (
+  const chart = (
     <SyncedLineChart
       option={option}
       ariaLabel={`${title} telemetry chart`}
       height={channel.band ? BAND_CHART_HEIGHT : CHART_HEIGHT}
     />
   )
+  if (!channel.band) return chart
+  // The DRS band is a fixed 180px chart inside a grid-stretched card shell
+  // (its row-mate is the full-height Accel line chart) — without this
+  // wrapper it hugs the card's top edge instead of sitting centered in the
+  // extra space the taller row-mate creates.
+  return <div className="flex h-full flex-col justify-center">{chart}</div>
 })
 
 // ---- Delta: cross-driver, needs its own data prep --------------------------

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -116,6 +116,11 @@ function baseOption(
     ...(yAxis as object),
   }
   return {
+    // No entrance/update animation on the telemetry traces. A timing-screen
+    // reads as an instrument, not a motion piece — and, practically, replaying
+    // the sweep on every driver toggle / data-settle (and twice under React
+    // StrictMode's dev double-mount) reads as a stutter, not polish.
+    animation: false,
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'line' },

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -24,8 +24,9 @@ export interface CircuitDominationSectionProps {
  *  no "dominance" to compare). */
 const MIN_DRIVERS_FOR_MAP = 2
 
-/** Matches the Streamlit figure's `height=360` (60% of its original 600px). */
-const MAP_HEIGHT_PX = 360
+/** Track height. Bumped past the Streamlit figure's 360 so the circuit reads
+ *  as the focal shape of the zone, with room for the coloured microsectors. */
+const MAP_HEIGHT_PX = 460
 
 /** Screen-pixel stroke width. Paired with `vector-effect="non-scaling-stroke"`
  *  on each segment so the line reads the same thickness regardless of how
@@ -109,17 +110,36 @@ interface CircuitMapProps {
   year: DashboardSearch['year']
 }
 
-/** The track SVG plus its driver legend, centered in a narrower column so it
- *  reads as a focal shape rather than stretching full-bleed (Streamlit
- *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
+/** Share of microsectors each driver was fastest through (0-100, rounded).
+ *  Derived from the same per-microsector colour array the segments are drawn
+ *  in, so the legend's "% dominated" always matches what's on the track. */
+function dominationShares(
+  colors: string[],
+  drivers: { driver: string; color: string }[],
+): Record<string, number> {
+  const total = colors.length
+  const shares: Record<string, number> = {}
+  if (total === 0) return shares
+  for (const { driver, color } of drivers) {
+    const count = colors.filter((segmentColor) => segmentColor === color).length
+    shares[driver] = Math.round((count / total) * 100)
+  }
+  return shares
+}
+
+/** The track SVG plus its driver legend. Fills its column so it reads as the
+ *  focal shape of the zone; each coloured microsector carries a `<title>` so
+ *  hovering the track reveals which driver was fastest through it. */
 function CircuitMap({ data, year }: CircuitMapProps) {
   const bounds = computeBounds(data.x, data.y)
   const viewBox = computeViewBox(bounds)
   const outlinePoints = buildOutlinePath(data.x, data.y)
   const segments = buildSegments(data.x, data.y, data.colors)
+  const colorToDriver = new Map(data.drivers.map((entry) => [entry.color, entry.driver]))
+  const shares = dominationShares(data.colors, data.drivers)
 
   return (
-    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-3xl flex-col gap-4 p-4')}>
+    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-4xl flex-col gap-4 p-4')}>
       <div
         role="img"
         aria-label="Circuit domination map: colored by fastest driver per microsector"
@@ -146,26 +166,32 @@ function CircuitMap({ data, year }: CircuitMapProps) {
               strokeWidth={SEGMENT_STROKE_PX}
               strokeLinecap="round"
               vectorEffect="non-scaling-stroke"
-            />
+              className="transition-opacity hover:opacity-60"
+            >
+              <title>{colorToDriver.get(segment.color) ?? 'Fastest'} fastest through here</title>
+            </line>
           ))}
         </svg>
       </div>
-      <CircuitLegend drivers={data.drivers} year={year} />
+      <CircuitLegend drivers={data.drivers} shares={shares} year={year} />
     </Card>
   )
 }
 
 interface CircuitLegendProps {
   drivers: { driver: string; color: string }[]
+  /** driver code -> % of microsectors that driver was fastest through. */
+  shares: Record<string, number>
   year: DashboardSearch['year']
 }
 
-/** Colour-dot legend, one swatch per driver — the SVG equivalent of the
- *  Streamlit figure's Plotly legend (invisible line traces named per driver).
- *  The dot keeps the data-driven `entry.color` (which may already carry
- *  contrast handling from the backend); the driver NAME is team-coloured via
- *  `getDriverTextColor` so it stays legible against the dark UI. */
-function CircuitLegend({ drivers, year }: CircuitLegendProps) {
+/** Colour-dot legend, one swatch per driver, with the driver's share of the
+ *  track (% of microsectors they were fastest through) in mono next to the
+ *  name — the SVG equivalent of the Streamlit figure's Plotly legend, plus the
+ *  at-a-glance "who dominated more" the coloured map only implies. The dot
+ *  keeps the data-driven `entry.color`; the NAME is team-coloured via
+ *  `getDriverTextColor` so it stays legible against the UI. */
+function CircuitLegend({ drivers, shares, year }: CircuitLegendProps) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
       {drivers.map((entry) => (
@@ -181,6 +207,11 @@ function CircuitLegend({ drivers, year }: CircuitLegendProps) {
           >
             {entry.driver}
           </span>
+          {shares[entry.driver] != null && (
+            <span className="font-mono text-xs tabular-nums text-fg-3">
+              {shares[entry.driver]}%
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -1,0 +1,161 @@
+// CIRCUIT DOMINATION section (issue #34 §6.1) — Streamlit parity for
+// `frontend/components/telemetry/circuit_domination.py`. The backend already
+// computes microsector dominance (track rotation/scaling + per-segment
+// fastest driver); this component only draws the returned x/y/colors as a
+// coloured polyline. Inline SVG is the simpler pick over canvas: the map is
+// a static shape that only changes when the query data changes, so there is
+// no imperative redraw loop to manage, and the browser handles resizing for
+// free via the `viewBox` + `preserveAspectRatio` contract (see circuitDraw.ts).
+import type { DashboardSearch } from '../search'
+import { useCircuitDomination } from '../queries'
+import type { CircuitDomination } from '@/lib/api/telemetry'
+import { TelemetryLoader } from './TelemetryLoader'
+import { Card } from '@/components/Card'
+import { cn } from '@/lib/cn'
+import { computeBounds, computeViewBox, buildSegments } from './circuitDraw'
+
+export interface CircuitDominationSectionProps {
+  search: DashboardSearch
+}
+
+/** Streamlit gates the map behind >=2 selected drivers (a single driver has
+ *  no "dominance" to compare). */
+const MIN_DRIVERS_FOR_MAP = 2
+
+/** Matches the Streamlit figure's `height=360` (60% of its original 600px). */
+const MAP_HEIGHT_PX = 360
+
+/** Screen-pixel stroke width. Paired with `vector-effect="non-scaling-stroke"`
+ *  on each segment so the line reads the same thickness regardless of how
+ *  large the track's coordinate range is (some circuits span thousands of
+ *  metres, others a few hundred). */
+const SEGMENT_STROKE_PX = 5
+
+const SECTION_TITLE_CLASSNAME =
+  'text-center text-lg font-display font-medium uppercase tracking-wide text-fg-2'
+
+/**
+ * CIRCUIT DOMINATION: a track outline coloured by whichever driver was
+ * fastest through each microsector. Reads the shared dashboard `search`
+ * (year/GP/session/drivers) and fetches via the frozen `useCircuitDomination`
+ * query — this component owns only presentation.
+ */
+export function CircuitDominationSection({ search }: CircuitDominationSectionProps) {
+  const hasSelection = search.year != null && !!search.gp && !!search.session
+  const hasEnoughDrivers = search.drivers.length >= MIN_DRIVERS_FOR_MAP
+  const query = useCircuitDomination(search)
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className={SECTION_TITLE_CLASSNAME}>Circuit Domination</h2>
+      <CircuitDominationBody
+        hasSelection={hasSelection}
+        hasEnoughDrivers={hasEnoughDrivers}
+        isLoading={query.isLoading}
+        data={query.data ?? null}
+      />
+    </section>
+  )
+}
+
+interface CircuitDominationBodyProps {
+  hasSelection: boolean
+  hasEnoughDrivers: boolean
+  isLoading: boolean
+  data: CircuitDomination | null
+}
+
+/** Picks which of the four states to render: no selection yet, selection but
+ *  too few drivers, still loading, or the resolved map (or a soft empty
+ *  state if the query settled with no data). */
+function CircuitDominationBody({
+  hasSelection,
+  hasEnoughDrivers,
+  isLoading,
+  data,
+}: CircuitDominationBodyProps) {
+  if (!hasSelection) {
+    return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
+  }
+  if (!hasEnoughDrivers) {
+    return (
+      <p className="py-8 text-center text-sm text-fg-3">
+        Select 2+ drivers to see circuit domination
+      </p>
+    )
+  }
+  if (isLoading) {
+    return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
+  }
+  if (!data) {
+    return (
+      <p className="py-8 text-center text-sm text-fg-3">
+        No circuit domination data available for this selection
+      </p>
+    )
+  }
+  return <CircuitMap data={data} />
+}
+
+interface CircuitMapProps {
+  data: CircuitDomination
+}
+
+/** The track SVG plus its driver legend, centered in a narrower column so it
+ *  reads as a focal shape rather than stretching full-bleed (Streamlit
+ *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
+function CircuitMap({ data }: CircuitMapProps) {
+  const bounds = computeBounds(data.x, data.y)
+  const viewBox = computeViewBox(bounds)
+  const segments = buildSegments(data.x, data.y, data.colors)
+
+  return (
+    <Card elevation="resting" className={cn('mx-auto flex w-full max-w-3xl flex-col gap-4 p-4')}>
+      <div
+        role="img"
+        aria-label="Circuit domination map: colored by fastest driver per microsector"
+        style={{ height: MAP_HEIGHT_PX }}
+      >
+        <svg viewBox={viewBox} width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+          {segments.map((segment, index) => (
+            <line
+              key={index}
+              x1={segment.x1}
+              y1={segment.y1}
+              x2={segment.x2}
+              y2={segment.y2}
+              stroke={segment.color}
+              strokeWidth={SEGMENT_STROKE_PX}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+        </svg>
+      </div>
+      <CircuitLegend drivers={data.drivers} />
+    </Card>
+  )
+}
+
+interface CircuitLegendProps {
+  drivers: { driver: string; color: string }[]
+}
+
+/** Colour-dot legend, one swatch per driver — the SVG equivalent of the
+ *  Streamlit figure's Plotly legend (invisible line traces named per driver). */
+function CircuitLegend({ drivers }: CircuitLegendProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+      {drivers.map((entry) => (
+        <div key={entry.driver} className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="inline-block size-3 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="font-mono text-xs tracking-wide text-fg-2">{entry.driver}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -10,9 +10,11 @@ import type { DashboardSearch } from '../search'
 import { useCircuitDomination } from '../queries'
 import type { CircuitDomination } from '@/lib/api/telemetry'
 import { TelemetryLoader } from './TelemetryLoader'
+import { SectionHeader } from './SectionHeader'
 import { Card } from '@/components/Card'
 import { cn } from '@/lib/cn'
-import { computeBounds, computeViewBox, buildSegments } from './circuitDraw'
+import { getDriverTextColor } from '../lib/drivers'
+import { computeBounds, computeViewBox, buildSegments, buildOutlinePath } from './circuitDraw'
 
 export interface CircuitDominationSectionProps {
   search: DashboardSearch
@@ -31,8 +33,10 @@ const MAP_HEIGHT_PX = 360
  *  metres, others a few hundred). */
 const SEGMENT_STROKE_PX = 5
 
-const SECTION_TITLE_CLASSNAME =
-  'text-center text-lg font-display font-medium uppercase tracking-wide text-fg-2'
+/** Faint continuous underlay tracing the whole track, drawn once beneath the
+ *  coloured microsector segments so the gaps between them don't read as a
+ *  broken circuit. */
+const OUTLINE_STROKE_COLOR = 'rgba(255,255,255,0.08)'
 
 /**
  * CIRCUIT DOMINATION: a track outline coloured by whichever driver was
@@ -47,12 +51,13 @@ export function CircuitDominationSection({ search }: CircuitDominationSectionPro
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className={SECTION_TITLE_CLASSNAME}>Circuit Domination</h2>
+      <SectionHeader title="Circuit Domination" />
       <CircuitDominationBody
         hasSelection={hasSelection}
         hasEnoughDrivers={hasEnoughDrivers}
         isLoading={query.isLoading}
         data={query.data ?? null}
+        year={search.year}
       />
     </section>
   )
@@ -63,6 +68,7 @@ interface CircuitDominationBodyProps {
   hasEnoughDrivers: boolean
   isLoading: boolean
   data: CircuitDomination | null
+  year: DashboardSearch['year']
 }
 
 /** Picks which of the four states to render: no selection yet, selection but
@@ -73,6 +79,7 @@ function CircuitDominationBody({
   hasEnoughDrivers,
   isLoading,
   data,
+  year,
 }: CircuitDominationBodyProps) {
   if (!hasSelection) {
     return <TelemetryLoader minHeight={MAP_HEIGHT_PX} />
@@ -94,19 +101,21 @@ function CircuitDominationBody({
       </p>
     )
   }
-  return <CircuitMap data={data} />
+  return <CircuitMap data={data} year={year} />
 }
 
 interface CircuitMapProps {
   data: CircuitDomination
+  year: DashboardSearch['year']
 }
 
 /** The track SVG plus its driver legend, centered in a narrower column so it
  *  reads as a focal shape rather than stretching full-bleed (Streamlit
  *  centers it in a 50%-width middle column via `st.columns([1, 2, 1])`). */
-function CircuitMap({ data }: CircuitMapProps) {
+function CircuitMap({ data, year }: CircuitMapProps) {
   const bounds = computeBounds(data.x, data.y)
   const viewBox = computeViewBox(bounds)
+  const outlinePoints = buildOutlinePath(data.x, data.y)
   const segments = buildSegments(data.x, data.y, data.colors)
 
   return (
@@ -117,6 +126,15 @@ function CircuitMap({ data }: CircuitMapProps) {
         style={{ height: MAP_HEIGHT_PX }}
       >
         <svg viewBox={viewBox} width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+          <polyline
+            points={outlinePoints}
+            fill="none"
+            stroke={OUTLINE_STROKE_COLOR}
+            strokeWidth={SEGMENT_STROKE_PX}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
           {segments.map((segment, index) => (
             <line
               key={index}
@@ -132,18 +150,22 @@ function CircuitMap({ data }: CircuitMapProps) {
           ))}
         </svg>
       </div>
-      <CircuitLegend drivers={data.drivers} />
+      <CircuitLegend drivers={data.drivers} year={year} />
     </Card>
   )
 }
 
 interface CircuitLegendProps {
   drivers: { driver: string; color: string }[]
+  year: DashboardSearch['year']
 }
 
 /** Colour-dot legend, one swatch per driver — the SVG equivalent of the
- *  Streamlit figure's Plotly legend (invisible line traces named per driver). */
-function CircuitLegend({ drivers }: CircuitLegendProps) {
+ *  Streamlit figure's Plotly legend (invisible line traces named per driver).
+ *  The dot keeps the data-driven `entry.color` (which may already carry
+ *  contrast handling from the backend); the driver NAME is team-coloured via
+ *  `getDriverTextColor` so it stays legible against the dark UI. */
+function CircuitLegend({ drivers, year }: CircuitLegendProps) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
       {drivers.map((entry) => (
@@ -153,7 +175,12 @@ function CircuitLegend({ drivers }: CircuitLegendProps) {
             className="inline-block size-3 rounded-full"
             style={{ backgroundColor: entry.color }}
           />
-          <span className="font-mono text-xs tracking-wide text-fg-2">{entry.driver}</span>
+          <span
+            className="font-mono text-xs tracking-wide"
+            style={{ color: getDriverTextColor(entry.driver, year) }}
+          >
+            {entry.driver}
+          </span>
         </div>
       ))}
     </div>

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -1,0 +1,86 @@
+// Tyre compound legend. Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::_render_tyre_compound_legend`.
+//
+// One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
+// each annotated with per-driver lap counts. Counts always come from the
+// FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
+// chart, not "how many laps did each driver run on this tyre".
+
+import { Pill } from '@/components/Pill'
+import type { LapTime } from '@/lib/api/telemetry'
+import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
+
+/** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
+ *  which excludes the 'unknown' compound from the legend entirely. */
+function countLapsByCompound(lapTimes: LapTime[]): Map<string, Map<string, number>> {
+  const counts = new Map<string, Map<string, number>>()
+  for (const lap of lapTimes) {
+    if (lap.compound.toLowerCase() === 'unknown') continue
+    const driverCounts = counts.get(lap.compound) ?? new Map<string, number>()
+    driverCounts.set(lap.driver, (driverCounts.get(lap.driver) ?? 0) + 1)
+    counts.set(lap.compound, driverCounts)
+  }
+  return counts
+}
+
+/** Compounds present, ordered per `COMPOUND_ORDER`; anything not in that
+ *  list (should not happen once 'unknown' is excluded) sorts last. */
+function orderedCompounds(counts: Map<string, Map<string, number>>): string[] {
+  return [...counts.keys()].sort((a, b) => {
+    const indexA = COMPOUND_ORDER.indexOf(a.toLowerCase())
+    const indexB = COMPOUND_ORDER.indexOf(b.toLowerCase())
+    return (
+      (indexA === -1 ? COMPOUND_ORDER.length : indexA) -
+      (indexB === -1 ? COMPOUND_ORDER.length : indexB)
+    )
+  })
+}
+
+/** "VER: 12 laps · LEC: 8 laps" for the drivers who ran this compound, in
+ *  selection order, singular "lap" for a count of exactly one. */
+function driverLapSummary(driverCounts: Map<string, number>, drivers: string[]): string {
+  return drivers
+    .map((driver) => ({ driver, count: driverCounts.get(driver) ?? 0 }))
+    .filter(({ count }) => count > 0)
+    .map(({ driver, count }) => `${driver}: ${count} lap${count === 1 ? '' : 's'}`)
+    .join(' · ')
+}
+
+export interface CompoundLegendProps {
+  /** FULL (unfiltered) lap times. */
+  lapTimes: LapTime[]
+  drivers: string[]
+}
+
+/** Per-compound Pill row with each driver's lap count on that tyre. Renders
+ *  nothing when no laps are loaded yet (matches the Streamlit early-return). */
+export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
+  const counts = countLapsByCompound(lapTimes)
+  const compounds = orderedCompounds(counts)
+
+  if (compounds.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="font-display text-sm uppercase tracking-wide text-fg-2">
+        🏎️ Tyre Compounds Used
+      </h3>
+      <div className="flex flex-wrap gap-4">
+        {compounds.map((compound) => {
+          const variant = compoundVariant(compound)
+          const summary = driverLapSummary(counts.get(compound) ?? new Map(), drivers)
+          return (
+            <div key={compound} className="flex flex-col items-start gap-1">
+              {variant ? (
+                <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+              ) : (
+                <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+              )}
+              {summary ? <span className="text-xs text-fg-3">{summary}</span> : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -9,6 +9,8 @@
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
+import { getDriverTextColor } from '../lib/drivers'
+import { SectionHeader } from './SectionHeader'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -36,25 +38,29 @@ function orderedCompounds(counts: Map<string, Map<string, number>>): string[] {
   })
 }
 
-/** "VER: 12 laps · LEC: 8 laps" for the drivers who ran this compound, in
- *  selection order, singular "lap" for a count of exactly one. */
-function driverLapSummary(driverCounts: Map<string, number>, drivers: string[]): string {
+/** Drivers who ran this compound with their lap counts, in selection order
+ *  (skips drivers who ran zero laps on it). */
+function driversWithCounts(
+  driverCounts: Map<string, number>,
+  drivers: string[],
+): { driver: string; count: number }[] {
   return drivers
     .map((driver) => ({ driver, count: driverCounts.get(driver) ?? 0 }))
     .filter(({ count }) => count > 0)
-    .map(({ driver, count }) => `${driver}: ${count} lap${count === 1 ? '' : 's'}`)
-    .join(' · ')
 }
 
 export interface CompoundLegendProps {
   /** FULL (unfiltered) lap times. */
   lapTimes: LapTime[]
   drivers: string[]
+  /** Season year — team colours changed lineups across seasons (`getDriverTextColor`). */
+  year?: number
 }
 
-/** Per-compound Pill row with each driver's lap count on that tyre. Renders
- *  nothing when no laps are loaded yet (matches the Streamlit early-return). */
-export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
+/** Per-compound Pill row with each driver's lap count on that tyre, the
+ *  driver code team-coloured. Renders nothing when no laps are loaded yet
+ *  (matches the Streamlit early-return). */
+export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
 
@@ -62,13 +68,11 @@ export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="font-display text-sm uppercase tracking-wide text-fg-2">
-        🏎️ Tyre Compounds Used
-      </h3>
+      <SectionHeader title="Tyre compounds" />
       <div className="flex flex-wrap gap-4">
         {compounds.map((compound) => {
           const variant = compoundVariant(compound)
-          const summary = driverLapSummary(counts.get(compound) ?? new Map(), drivers)
+          const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
           return (
             <div key={compound} className="flex flex-col items-start gap-1">
               {variant ? (
@@ -76,7 +80,22 @@ export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
               ) : (
                 <Pill tone="neutral">{compoundLabel(compound)}</Pill>
               )}
-              {summary ? <span className="text-xs text-fg-3">{summary}</span> : null}
+              {driverCounts.length > 0 ? (
+                <span className="text-xs text-fg-3">
+                  {driverCounts.map(({ driver, count }, index) => (
+                    <span key={driver}>
+                      {index > 0 ? ' · ' : ''}
+                      <span
+                        className="font-mono tabular-nums"
+                        style={{ color: getDriverTextColor(driver, year) }}
+                      >
+                        {driver}
+                      </span>{' '}
+                      {count}
+                    </span>
+                  ))}
+                </span>
+              ) : null}
             </div>
           )
         })}

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -4,13 +4,15 @@
 // One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
 // each annotated with per-driver lap counts. Counts always come from the
 // FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
-// chart, not "how many laps did each driver run on this tyre".
+// chart, not "how many laps did each driver run on this tyre". Renders as a
+// single inline row (round-2 fix #3) — it lives in the Lap Chart card's
+// footer now, not as its own titled block, so the pills self-label and don't
+// need a `SectionHeader` above them.
 
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
 import { getDriverTextColor } from '../lib/drivers'
-import { SectionHeader } from './SectionHeader'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -57,9 +59,9 @@ export interface CompoundLegendProps {
   year?: number
 }
 
-/** Per-compound Pill row with each driver's lap count on that tyre, the
- *  driver code team-coloured. Renders nothing when no laps are loaded yet
- *  (matches the Streamlit early-return). */
+/** Inline compound-Pill row, each pill followed by its per-driver lap counts
+ *  on the same line — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
+ *  laps are loaded yet (matches the Streamlit early-return). */
 export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
@@ -67,39 +69,36 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
   if (compounds.length === 0) return null
 
   return (
-    <div className="flex flex-col gap-3">
-      <SectionHeader title="Tyre compounds" />
-      <div className="flex flex-wrap gap-4">
-        {compounds.map((compound) => {
-          const variant = compoundVariant(compound)
-          const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
-          return (
-            <div key={compound} className="flex flex-col items-start gap-1">
-              {variant ? (
-                <Pill compound={variant}>{compoundLabel(compound)}</Pill>
-              ) : (
-                <Pill tone="neutral">{compoundLabel(compound)}</Pill>
-              )}
-              {driverCounts.length > 0 ? (
-                <span className="text-xs text-fg-3">
-                  {driverCounts.map(({ driver, count }, index) => (
-                    <span key={driver}>
-                      {index > 0 ? ' · ' : ''}
-                      <span
-                        className="font-mono tabular-nums"
-                        style={{ color: getDriverTextColor(driver, year) }}
-                      >
-                        {driver}
-                      </span>{' '}
-                      {count}
-                    </span>
-                  ))}
-                </span>
-              ) : null}
-            </div>
-          )
-        })}
-      </div>
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+      {compounds.map((compound) => {
+        const variant = compoundVariant(compound)
+        const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
+        return (
+          <div key={compound} className="flex items-center gap-1.5">
+            {variant ? (
+              <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+            ) : (
+              <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+            )}
+            {driverCounts.length > 0 ? (
+              <span className="text-xs text-fg-3">
+                {driverCounts.map(({ driver, count }, index) => (
+                  <span key={driver}>
+                    {index > 0 ? ' · ' : ''}
+                    <span
+                      className="font-mono tabular-nums"
+                      style={{ color: getDriverTextColor(driver, year) }}
+                    >
+                      {driver}
+                    </span>{' '}
+                    {count}
+                  </span>
+                ))}
+              </span>
+            ) : null}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -76,7 +76,12 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
         return (
           <div key={compound} className="flex items-center gap-1.5">
             {variant ? (
-              <Pill compound={variant}>{compoundLabel(compound)}</Pill>
+              // Permanent hairline border (B3): HARD is a near-white chip
+              // that vanishes on a white card in the light theme; the border
+              // is near-invisible in dark and load-bearing in light.
+              <Pill compound={variant} className="border border-hairline">
+                {compoundLabel(compound)}
+              </Pill>
             ) : (
               <Pill tone="neutral">{compoundLabel(compound)}</Pill>
             )}

--- a/webapp/src/features/dashboard/components/CompoundLegend.tsx
+++ b/webapp/src/features/dashboard/components/CompoundLegend.tsx
@@ -2,17 +2,22 @@
 // `frontend/components/dashboard/lap_graph.py::_render_tyre_compound_legend`.
 //
 // One Pill per compound actually used, in SOFT→MEDIUM→HARD→INTER→WET order,
-// each annotated with per-driver lap counts. Counts always come from the
-// FULL (unfiltered) lap times — the outlier/invalid toggles only affect the
-// chart, not "how many laps did each driver run on this tyre". Renders as a
-// single inline row (round-2 fix #3) — it lives in the Lap Chart card's
-// footer now, not as its own titled block, so the pills self-label and don't
-// need a `SectionHeader` above them.
+// each followed by per-driver lap counts. Counts always come from the FULL
+// (unfiltered) lap times — the outlier/invalid toggles only affect the chart,
+// not "how many laps did each driver run on this tyre". Renders as a single
+// inline row inside the Lap Chart card footer (round-2 #3), so the pills
+// self-label and don't need a `SectionHeader` above them.
+//
+// This is the RIGHT cluster of the timing-strip footer: its one accent is the
+// compound hue (on the pills); driver codes stay neutral (fg-3) — identity for
+// ≤3 drivers is unambiguous from the code text alone, and dropping team colour
+// here halves the strip's colour count and removes the worst light-theme
+// text-contrast offenders. The count is the mono, tabular, one-step-stronger
+// (fg-2) element — it's the datum.
 
 import { Pill } from '@/components/Pill'
 import type { LapTime } from '@/lib/api/telemetry'
 import { COMPOUND_ORDER, compoundLabel, compoundVariant } from '../lib/compounds'
-import { getDriverTextColor } from '../lib/drivers'
 
 /** compound (lowercase) -> driver -> lap count. Mirrors the Streamlit source,
  *  which excludes the 'unknown' compound from the legend entirely. */
@@ -55,14 +60,12 @@ export interface CompoundLegendProps {
   /** FULL (unfiltered) lap times. */
   lapTimes: LapTime[]
   drivers: string[]
-  /** Season year — team colours changed lineups across seasons (`getDriverTextColor`). */
-  year?: number
 }
 
-/** Inline compound-Pill row, each pill followed by its per-driver lap counts
- *  on the same line — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
+/** Inline compound-Pill row, each pill followed by its per-driver lap counts on
+ *  the same baseline — e.g. `[Medium] VER 53 · LEC 9`. Renders nothing when no
  *  laps are loaded yet (matches the Streamlit early-return). */
-export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps) {
+export function CompoundLegend({ lapTimes, drivers }: CompoundLegendProps) {
   const counts = countLapsByCompound(lapTimes)
   const compounds = orderedCompounds(counts)
 
@@ -72,31 +75,28 @@ export function CompoundLegend({ lapTimes, drivers, year }: CompoundLegendProps)
     <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
       {compounds.map((compound) => {
         const variant = compoundVariant(compound)
+        const label = compoundLabel(compound)
         const driverCounts = driversWithCounts(counts.get(compound) ?? new Map(), drivers)
+        const title = `${label}: ${driverCounts.map((d) => `${d.driver} ${d.count} laps`).join(', ')}`
         return (
-          <div key={compound} className="flex items-center gap-1.5">
+          <div key={compound} className="flex items-center gap-1.5" title={title}>
             {variant ? (
-              // Permanent hairline border (B3): HARD is a near-white chip
-              // that vanishes on a white card in the light theme; the border
-              // is near-invisible in dark and load-bearing in light.
+              // Permanent hairline border (B3): HARD is a near-white chip that
+              // vanishes on a white card in the light theme; the border is
+              // near-invisible in dark and load-bearing in light.
               <Pill compound={variant} className="border border-hairline">
-                {compoundLabel(compound)}
+                {label}
               </Pill>
             ) : (
-              <Pill tone="neutral">{compoundLabel(compound)}</Pill>
+              <Pill tone="neutral">{label}</Pill>
             )}
             {driverCounts.length > 0 ? (
-              <span className="text-xs text-fg-3">
+              <span className="font-mono text-fg-3">
                 {driverCounts.map(({ driver, count }, index) => (
                   <span key={driver}>
-                    {index > 0 ? ' · ' : ''}
-                    <span
-                      className="font-mono tabular-nums"
-                      style={{ color: getDriverTextColor(driver, year) }}
-                    >
-                      {driver}
-                    </span>{' '}
-                    {count}
+                    {index > 0 ? <span className="text-fg-4"> · </span> : ''}
+                    {driver} <span className="tabular-nums text-fg-2">{count}</span>
+                    <span className="sr-only"> laps</span>
                   </span>
                 ))}
               </span>

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -13,11 +13,12 @@
 // picker instead accepts any click within a 20px radius of the nearest
 // plotted point (round-2 fix, see `docs/migration/design-specs/dashboard-round2.md#1`).
 
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useContext, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ECharts, EChartsOption } from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
 import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
+import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTime } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import { compoundLabel, compoundVariant } from '../lib/compounds'
@@ -377,6 +378,10 @@ export interface LapChartProps {
  *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
 export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
   const chartTheme = useChartTheme()
+  // Fill the maximized overlay instead of the fixed 400px grid height, and fold
+  // `maximized` into the chart key so it remounts at the new size (keeps the
+  // nearest-point click picking + hover aligned — see ChartCard's context).
+  const maximized = useContext(ChartMaximizedContext)
   const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
@@ -407,12 +412,16 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
   }, [])
 
   return (
-    <div role="img" aria-label="Lap times by lap, per driver">
+    <div
+      role="img"
+      aria-label="Lap times by lap, per driver"
+      className={maximized ? 'h-full' : undefined}
+    >
       <ReactECharts
         theme={chartTheme}
-        key={chartTheme}
+        key={`${chartTheme}-${maximized}`}
         option={option}
-        style={{ height: 400 }}
+        style={{ height: maximized ? '100%' : 400 }}
         notMerge
         onChartReady={handleChartReady}
       />

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -190,6 +190,11 @@ function buildLapChartOption(
   axisNameStyle: { color: string; fontFamily: string },
 ): EChartsOption {
   return {
+    // Match the telemetry charts: no entrance/update animation. The lap chart
+    // rebuilds on every driver toggle and selected-lap change, so replaying the
+    // line-draw each time (and twice under StrictMode's dev double-mount) reads
+    // as a stutter rather than polish.
+    animation: false,
     tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
     legend: {
       data: buildLegendData(seriesList, year),

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -6,10 +6,16 @@
 // that lap's telemetry via `onLapClick`, which the section wires to the
 // dashboard store's `setLap` (click-to-load; this component never fetches
 // telemetry itself).
+//
+// Click picking runs on zrender directly (`bindNearestPointClick`), not
+// ECharts' `onEvents.click` — the plotted symbols are a de-cluttered 5px dot
+// (see `buildDriverSeries`), too small a hit target on a ~80-lap race. The
+// picker instead accepts any click within a 20px radius of the nearest
+// plotted point (round-2 fix, see `docs/migration/design-specs/dashboard-round2.md#1`).
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
-import type { EChartsOption } from 'echarts'
+import type { ECharts, EChartsOption } from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
 import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
@@ -31,11 +37,28 @@ const AXIS_NAME_STYLE = {
 }
 
 /** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
- *  alongside so the tooltip can show tyre info without a second lookup. */
+ *  alongside so the tooltip can show tyre info without a second lookup.
+ *  `symbolSize`/`itemStyle` are per-point overrides — only set on the
+ *  driver's currently-selected lap, to draw it as a visible ring (see
+ *  `SELECTED_LAP_SYMBOL_SIZE`). ECharts merges a per-data `itemStyle` on top
+ *  of the series-level one, so the ring keeps the driver's fill colour and
+ *  only adds the border. */
 interface LapPoint {
   value: [number, number]
   compound: string
+  symbolSize?: number
+  itemStyle?: { borderColor: string; borderWidth: number }
 }
+
+// Selected-lap ring: bigger symbol + white border, independent of the driver
+// colour underneath — a white ring reads on every team colour on the dark UI.
+const SELECTED_LAP_SYMBOL_SIZE = 11
+const SELECTED_LAP_RING_STYLE = { borderColor: '#fff', borderWidth: 2 }
+
+// Nearest-point click picking (item 1) — see the module docblock.
+const NEAREST_POINT_RADIUS_PX = 20
+// A real drag (pan/box-zoom, item 5) must not also register as a lap pick.
+const DRAG_CLICK_GUARD_PX = 4
 
 /** A single driver's series — kept as our own shape (not `echarts`'
  *  `LineSeriesOption`) so the extra `compound` field on each point never
@@ -83,11 +106,32 @@ function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
   return byDriver
 }
 
+/** One lap turned into a plotted point; the driver's currently-selected lap
+ *  (loaded telemetry) gets the ring override so it's visible on the chart
+ *  itself, not just in the footer caption below. */
+function buildLapPoint(lap: LapTime, selectedLap: number | undefined): LapPoint {
+  const isSelected = lap.lap_number === selectedLap
+  return {
+    value: [lap.lap_number, lap.lap_time],
+    compound: lap.compound,
+    ...(isSelected
+      ? { symbolSize: SELECTED_LAP_SYMBOL_SIZE, itemStyle: SELECTED_LAP_RING_STYLE }
+      : {}),
+  }
+}
+
 /** Build one driver's line+marker series, coloured by TEAM colour. Markers
  *  stay small (`symbolSize: 5`) and the line thin (`width: 1.5`) so a dense
  *  multi-driver plot doesn't bead into a wall of dots; `emphasis.scale` grows
- *  the hovered point back up so it's still an obvious click target. */
-function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
+ *  the hovered point back up so it's still an obvious click target. The hit
+ *  target for clicking, though, is decoupled from this visual size — see
+ *  `findNearestPoint`. */
+function buildDriverSeries(
+  driver: string,
+  laps: LapTime[],
+  color: string,
+  selectedLap: number | undefined,
+): DriverSeriesOption {
   return {
     name: driver,
     type: 'line',
@@ -95,7 +139,7 @@ function buildDriverSeries(driver: string, laps: LapTime[], color: string): Driv
     lineStyle: { color, width: 1.5 },
     itemStyle: { color },
     emphasis: { scale: 1.6 },
-    data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
+    data: laps.map((lap) => buildLapPoint(lap, selectedLap)),
   }
 }
 
@@ -171,26 +215,141 @@ function buildLapChartOption(
       scale: true,
     },
     series: seriesList,
+    // Drag-to-zoom (item 5): inside = click-drag pan + Shift+wheel zoom;
+    // plain wheel stays page scroll. `filterMode: 'none'` keeps zoom/pan from
+    // rescaling the y-axis. `x = lap number` here (unlike the telemetry
+    // charts' `x = distance`), so this chart is NOT joined to their
+    // `echarts.connect` crosshair group — its zoom stays independent.
+    dataZoom: [
+      {
+        type: 'inside',
+        xAxisIndex: 0,
+        filterMode: 'none',
+        zoomOnMouseWheel: 'shift',
+        moveOnMouseMove: true,
+        moveOnMouseWheel: false,
+      },
+    ],
+    // Toolbox box-zoom (Plotly-style, x-only via `yAxisIndex: 'none'`) + a
+    // reset button — the discoverable alternative to the shift-drag gesture.
+    toolbox: {
+      right: 8,
+      top: 0,
+      feature: {
+        dataZoom: { yAxisIndex: 'none', filterMode: 'none' },
+        restore: {},
+      },
+    },
   }
 }
 
-/** A driver code + lap number pulled off a click event, or null when the
- *  click missed a data point (background/axis click). */
-interface LapClickTarget {
+/** One driver's plotted points, exactly as handed to its ECharts series —
+ *  `seriesIndex` in the picker below is this array's index, since it's built
+ *  in lockstep with `option.series`. */
+interface PickerSeries {
   driver: string
-  lapNumber: number
+  points: LapPoint[]
 }
 
-function extractLapClick(raw: unknown): LapClickTarget | null {
-  if (!raw || typeof raw !== 'object') return null
-  const params = raw as { seriesName?: string; data?: unknown; value?: unknown }
-  const driver = params.seriesName
-  const fromData = isLapPoint(params.data) ? params.data.value[0] : undefined
-  const fromValue =
-    Array.isArray(params.value) && typeof params.value[0] === 'number' ? params.value[0] : undefined
-  const lapNumber = fromData ?? fromValue
-  if (!driver || lapNumber == null) return null
-  return { driver, lapNumber }
+/** What the zrender click handler reads on every click: the currently
+ *  plotted series (post-filter, so a filtered-out lap can't be picked) and
+ *  the latest `onLapClick` callback. Mirrored into a ref (see `LapChart`)
+ *  because the handler itself is bound once, in `onChartReady`. */
+interface PickerRefValue {
+  series: PickerSeries[]
+  onLapClick: (driver: string, lapNumber: number) => void
+}
+
+/** Minimal shape read off zrender's raw pointer events — the real event
+ *  (`ElementEvent`) carries plenty more, this is all the picker needs. */
+interface ZrPointerEvent {
+  offsetX: number
+  offsetY: number
+}
+
+/** One plotted point, resolved to its on-screen pixel position. */
+interface PixelPoint {
+  driver: string
+  lapNumber: number
+  px: number
+  py: number
+}
+
+/** Every plotted point across all series, converted once to pixel space via
+ *  `convertToPixel` — cheap even for a full ~80-lap x 3-driver grid (max
+ *  ~240 points per click). */
+function toPixelPoints(chart: ECharts, series: PickerSeries[]): PixelPoint[] {
+  const pixelPoints: PixelPoint[] = []
+  series.forEach((driverSeries, seriesIndex) => {
+    for (const point of driverSeries.points) {
+      const [px, py] = chart.convertToPixel({ seriesIndex }, point.value)
+      pixelPoints.push({ driver: driverSeries.driver, lapNumber: point.value[0], px, py })
+    }
+  })
+  return pixelPoints
+}
+
+function squaredPixelDistance(point: PixelPoint, clickX: number, clickY: number): number {
+  return (point.px - clickX) ** 2 + (point.py - clickY) ** 2
+}
+
+/** Nearest plotted point to a click, in PIXEL space (not data space) — pixel
+ *  distance is what a viewer actually judges as "the closest dot", which can
+ *  differ from data-space nearest when the y-axis spans wildly different lap
+ *  times (e.g. a rain-affected race). Returns null when nothing plotted is
+ *  within `NEAREST_POINT_RADIUS_PX`, so legend/axis-adjacent clicks stay
+ *  inert instead of snapping to a far-away point. */
+function findNearestPoint(
+  chart: ECharts,
+  series: PickerSeries[],
+  clickX: number,
+  clickY: number,
+): { driver: string; lapNumber: number } | null {
+  let nearest: PixelPoint | null = null
+  let nearestDistanceSq = Infinity
+
+  for (const point of toPixelPoints(chart, series)) {
+    const distanceSq = squaredPixelDistance(point, clickX, clickY)
+    if (distanceSq < nearestDistanceSq) {
+      nearestDistanceSq = distanceSq
+      nearest = point
+    }
+  }
+
+  if (!nearest || nearestDistanceSq > NEAREST_POINT_RADIUS_PX ** 2) return null
+  return { driver: nearest.driver, lapNumber: nearest.lapNumber }
+}
+
+/** Registers the nearest-point click picker directly on zrender, once per
+ *  chart instance (called from `onChartReady`, which — unlike `onEvents` —
+ *  only fires on mount, so this never double-binds across the option
+ *  rebuilds `notMerge` triggers on every data change).
+ *
+ *  Three guards, in order: (1) a real mousedown→click drag (pan or the
+ *  toolbox box-zoom, item 5) is ignored via the pixel-delta check, so
+ *  dragging never fires a phantom lap pick; (2) `containPixel` rejects
+ *  clicks outside the plot area (legend, axis, toolbox icons); (3)
+ *  `findNearestPoint`'s radius rejects clicks too far from any plotted dot. */
+function bindNearestPointClick(chart: ECharts, pickerRef: { current: PickerRefValue }): void {
+  const zr = chart.getZr()
+  let downPoint: { x: number; y: number } | null = null
+
+  zr.on('mousedown', (e: ZrPointerEvent) => {
+    downPoint = { x: e.offsetX, y: e.offsetY }
+  })
+
+  zr.on('click', (e: ZrPointerEvent) => {
+    const dragged =
+      downPoint != null &&
+      Math.hypot(e.offsetX - downPoint.x, e.offsetY - downPoint.y) >= DRAG_CLICK_GUARD_PX
+    downPoint = null
+    if (dragged) return
+    if (!chart.containPixel({ gridIndex: 0 }, [e.offsetX, e.offsetY])) return
+
+    const { series, onLapClick } = pickerRef.current
+    const nearest = findNearestPoint(chart, series, e.offsetX, e.offsetY)
+    if (nearest) onLapClick(nearest.driver, nearest.lapNumber)
+  })
 }
 
 export interface LapChartProps {
@@ -200,28 +359,41 @@ export interface LapChartProps {
   drivers: string[]
   year: number | undefined
   onLapClick: (driver: string, lapNumber: number) => void
+  /** driver code -> the lap number whose telemetry is currently loaded, so
+   *  that lap's point can be drawn as a visible ring on the chart. */
+  selectedLaps: Record<string, number>
 }
 
 /** Lap-time chart: one coloured-by-driver line per selected driver, with
- *  click-to-load and a compound-aware tooltip. */
-export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
-  const option = useMemo(() => {
+ *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
+export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
+  const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
       .filter((driver) => byDriver.has(driver))
       .map((driver) =>
-        buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
+        buildDriverSeries(
+          driver,
+          byDriver.get(driver) ?? [],
+          getDriverColor(driver, year),
+          selectedLaps[driver],
+        ),
       )
-    return buildLapChartOption(seriesList, year)
-  }, [laps, drivers, year])
+    return {
+      option: buildLapChartOption(seriesList, year),
+      pickerSeries: seriesList.map((series) => ({ driver: series.name, points: series.data })),
+    }
+  }, [laps, drivers, year, selectedLaps])
 
-  const handleClick = useCallback(
-    (raw: unknown) => {
-      const click = extractLapClick(raw)
-      if (click) onLapClick(click.driver, click.lapNumber)
-    },
-    [onLapClick],
-  )
+  // Latest-ref mirror: the zrender click handler is registered once (see
+  // `handleChartReady` below) and reads through this ref on every click, so
+  // it always sees the current laps/onLapClick without re-binding.
+  const pickerRef = useRef<PickerRefValue>({ series: pickerSeries, onLapClick })
+  pickerRef.current = { series: pickerSeries, onLapClick }
+
+  const handleChartReady = useCallback((chart: ECharts) => {
+    bindNearestPointClick(chart, pickerRef)
+  }, [])
 
   return (
     <div role="img" aria-label="Lap times by lap, per driver">
@@ -230,7 +402,7 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
         option={option}
         style={{ height: 400 }}
         notMerge
-        onEvents={{ click: handleClick }}
+        onChartReady={handleChartReady}
       />
     </div>
   )

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -16,8 +16,8 @@
 import { useCallback, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ECharts, EChartsOption } from 'echarts'
-import { registerF1Theme } from '@/charts/registerEcharts'
-import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
 import { getDriverColor, getDriverTextColor } from '../lib/drivers'
 import { compoundLabel, compoundVariant } from '../lib/compounds'
@@ -28,12 +28,15 @@ import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
 // in componentDidMount, which can fire before an effect-time registration).
 registerF1Theme()
 
-// Reuse the shared theme's axis-label color/font for axis NAMES ("Lap
-// Number", "Lap Time") so they read consistently with the tick labels
-// without duplicating the theme's magic color values here.
-const AXIS_NAME_STYLE = {
-  color: echartsTheme.valueAxis.axisLabel.color,
-  fontFamily: echartsTheme.valueAxis.axisLabel.fontFamily,
+/** Axis NAME style ("Lap Number", "Lap Time"), reusing the mode-aware theme's
+ *  axis-label color/font so the names read consistently with the tick labels
+ *  in both light and dark, without duplicating the theme's color values here. */
+function buildAxisNameStyle(mode: 'dark' | 'light') {
+  const theme = buildEchartsTheme(mode)
+  return {
+    color: theme.valueAxis.axisLabel.color,
+    fontFamily: theme.valueAxis.axisLabel.fontFamily,
+  }
 }
 
 /** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
@@ -184,6 +187,7 @@ function formatLapTooltip(year: number | undefined) {
 function buildLapChartOption(
   seriesList: DriverSeriesOption[],
   year: number | undefined,
+  axisNameStyle: { color: string; fontFamily: string },
 ): EChartsOption {
   return {
     tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
@@ -200,7 +204,7 @@ function buildLapChartOption(
       name: 'Lap Number',
       nameLocation: 'middle',
       nameGap: 26,
-      nameTextStyle: AXIS_NAME_STYLE,
+      nameTextStyle: axisNameStyle,
       scale: true,
     },
     yAxis: {
@@ -208,7 +212,7 @@ function buildLapChartOption(
       name: 'Lap Time',
       nameLocation: 'middle',
       nameGap: 48,
-      nameTextStyle: AXIS_NAME_STYLE,
+      nameTextStyle: axisNameStyle,
       axisLabel: { formatter: formatLapTimeAxis },
       // Autorange around the lap times (~78-95 s) instead of forcing a 0:00
       // baseline, which would squash every line into the top of the plot.
@@ -367,6 +371,7 @@ export interface LapChartProps {
 /** Lap-time chart: one coloured-by-driver line per selected driver, with
  *  click-to-load (nearest-point picking) and a compound-aware tooltip. */
 export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapChartProps) {
+  const chartTheme = useChartTheme()
   const { option, pickerSeries } = useMemo(() => {
     const byDriver = groupByDriver(laps)
     const seriesList = drivers
@@ -379,11 +384,12 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
           selectedLaps[driver],
         ),
       )
+    const mode = chartTheme === F1_LIGHT_THEME ? 'light' : 'dark'
     return {
-      option: buildLapChartOption(seriesList, year),
+      option: buildLapChartOption(seriesList, year, buildAxisNameStyle(mode)),
       pickerSeries: seriesList.map((series) => ({ driver: series.name, points: series.data })),
     }
-  }, [laps, drivers, year, selectedLaps])
+  }, [laps, drivers, year, selectedLaps, chartTheme])
 
   // Latest-ref mirror: the zrender click handler is registered once (see
   // `handleChartReady` below) and reads through this ref on every click, so
@@ -398,7 +404,8 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
   return (
     <div role="img" aria-label="Lap times by lap, per driver">
       <ReactECharts
-        theme={F1_THEME}
+        theme={chartTheme}
+        key={chartTheme}
         option={option}
         style={{ height: 400 }}
         notMerge

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -11,10 +11,10 @@ import { useCallback, useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { EChartsOption } from 'echarts'
 import { registerF1Theme } from '@/charts/registerEcharts'
-import { echartsTheme, F1_THEME } from '@/charts/echartsTheme'
+import { echartsTheme, F1_THEME, tireColors } from '@/charts/echartsTheme'
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverColor } from '../lib/drivers'
-import { compoundEmoji, compoundLabel } from '../lib/compounds'
+import { getDriverColor, getDriverTextColor } from '../lib/drivers'
+import { compoundLabel, compoundVariant } from '../lib/compounds'
 import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
 
 // Register the token theme at module load, before any chart's init runs
@@ -45,9 +45,18 @@ interface DriverSeriesOption {
   name: string
   type: 'line'
   symbolSize: number
-  lineStyle: { color: string }
+  lineStyle: { color: string; width: number }
   itemStyle: { color: string }
+  emphasis: { scale: number }
   data: LapPoint[]
+}
+
+/** One legend entry, team-coloured via `textStyle` — a bare string legend
+ *  entry shares ONE colour for every driver, so each entry needs its own
+ *  `DataItem` object instead (icon/size stay on the shared `legend` option). */
+interface LegendEntry {
+  name: string
+  textStyle: { color: string }
 }
 
 /** Runtime narrowing for whatever `unknown` an ECharts callback hands back. */
@@ -74,32 +83,73 @@ function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
   return byDriver
 }
 
-/** Build one driver's line+marker series, coloured by TEAM colour. */
+/** Build one driver's line+marker series, coloured by TEAM colour. Markers
+ *  stay small (`symbolSize: 5`) and the line thin (`width: 1.5`) so a dense
+ *  multi-driver plot doesn't bead into a wall of dots; `emphasis.scale` grows
+ *  the hovered point back up so it's still an obvious click target. */
 function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
   return {
     name: driver,
     type: 'line',
-    symbolSize: 7,
-    lineStyle: { color },
+    symbolSize: 5,
+    lineStyle: { color, width: 1.5 },
     itemStyle: { color },
+    emphasis: { scale: 1.6 },
     data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
   }
 }
 
-/** Tooltip text: `<emoji> DRIVER — Lap N — M:SS.mmm — Compound`. */
-function formatLapTooltip(raw: unknown): string {
-  if (!raw || typeof raw !== 'object') return ''
-  const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
-  if (!isLapPoint(data)) return ''
-  const [lapNumber, lapTime] = data.value
-  return `${compoundEmoji(data.compound)} ${seriesName ?? ''} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundLabel(data.compound)}`
+/** Legend entries, each carrying its own driver-team text colour (the shared
+ *  `legend.icon`/`itemWidth`/`itemHeight` options keep every swatch the same
+ *  shape/size — only the colour differs per driver). */
+function buildLegendData(
+  seriesList: DriverSeriesOption[],
+  year: number | undefined,
+): LegendEntry[] {
+  return seriesList.map((series) => ({
+    name: series.name,
+    textStyle: { color: getDriverTextColor(series.name, year) },
+  }))
+}
+
+/** 8px rounded compound-colour swatch for the tooltip, replacing the old emoji
+ *  marker. An unknown compound gets a neutral grey — NOT the medium yellow,
+ *  which would falsely read as a real tyre. */
+function compoundDotHtml(compound: string): string {
+  const variant = compoundVariant(compound)
+  const hex = variant ? tireColors[variant] : '#6b7280'
+  return `<span style="display:inline-block;width:8px;height:8px;border-radius:9999px;background:${hex};margin-right:4px;"></span>`
+}
+
+/** Tooltip HTML: team-coloured driver name — Lap N — M:SS.mmm — compound dot + label. */
+function formatLapTooltip(year: number | undefined) {
+  return (raw: unknown): string => {
+    if (!raw || typeof raw !== 'object') return ''
+    const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
+    if (!isLapPoint(data)) return ''
+    const [lapNumber, lapTime] = data.value
+    const driverName = seriesName ?? ''
+    const driverHtml = seriesName
+      ? `<b style="color:${getDriverTextColor(seriesName, year)}">${driverName}</b>`
+      : `<b>${driverName}</b>`
+    return `${driverHtml} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundDotHtml(data.compound)}${compoundLabel(data.compound)}`
+  }
 }
 
 /** Build the full chart option from the per-driver series list. */
-function buildLapChartOption(seriesList: DriverSeriesOption[]): EChartsOption {
+function buildLapChartOption(
+  seriesList: DriverSeriesOption[],
+  year: number | undefined,
+): EChartsOption {
   return {
-    tooltip: { trigger: 'item', formatter: formatLapTooltip },
-    legend: { data: seriesList.map((series) => series.name), top: 0 },
+    tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
+    legend: {
+      data: buildLegendData(seriesList, year),
+      icon: 'roundRect',
+      itemWidth: 10,
+      itemHeight: 3,
+      top: 0,
+    },
     grid: { top: 44, left: 56, right: 24, bottom: 44, containLabel: true },
     xAxis: {
       type: 'value',
@@ -162,7 +212,7 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
       .map((driver) =>
         buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
       )
-    return buildLapChartOption(seriesList)
+    return buildLapChartOption(seriesList, year)
   }, [laps, drivers, year])
 
   const handleClick = useCallback(
@@ -174,12 +224,14 @@ export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
   )
 
   return (
-    <ReactECharts
-      theme={F1_THEME}
-      option={option}
-      style={{ height: 400 }}
-      notMerge
-      onEvents={{ click: handleClick }}
-    />
+    <div role="img" aria-label="Lap times by lap, per driver">
+      <ReactECharts
+        theme={F1_THEME}
+        option={option}
+        style={{ height: 400 }}
+        notMerge
+        onEvents={{ click: handleClick }}
+      />
+    </div>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -1,0 +1,185 @@
+// Lap-time line chart (ECharts). Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::render_lap_graph`.
+//
+// One line+marker series PER DRIVER, coloured by TEAM colour (never by
+// compound — compound is tooltip-only information). Clicking a point loads
+// that lap's telemetry via `onLapClick`, which the section wires to the
+// dashboard store's `setLap` (click-to-load; this component never fetches
+// telemetry itself).
+
+import { useCallback, useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
+import { registerF1Theme } from '@/charts/registerEcharts'
+import { echartsTheme, F1_THEME } from '@/charts/echartsTheme'
+import type { LapTime } from '@/lib/api/telemetry'
+import { getDriverColor } from '../lib/drivers'
+import { compoundEmoji, compoundLabel } from '../lib/compounds'
+import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
+
+// Register the token theme at module load, before any chart's init runs
+// (mirrors charts/Gauge.tsx — echarts-for-react inits with the `theme` prop
+// in componentDidMount, which can fire before an effect-time registration).
+registerF1Theme()
+
+// Reuse the shared theme's axis-label color/font for axis NAMES ("Lap
+// Number", "Lap Time") so they read consistently with the tick labels
+// without duplicating the theme's magic color values here.
+const AXIS_NAME_STYLE = {
+  color: echartsTheme.valueAxis.axisLabel.color,
+  fontFamily: echartsTheme.valueAxis.axisLabel.fontFamily,
+}
+
+/** One plotted point: `[lapNumber, lapTime]`, with `compound` carried
+ *  alongside so the tooltip can show tyre info without a second lookup. */
+interface LapPoint {
+  value: [number, number]
+  compound: string
+}
+
+/** A single driver's series — kept as our own shape (not `echarts`'
+ *  `LineSeriesOption`) so the extra `compound` field on each point never
+ *  gets excess-property-checked against the library's stricter data type;
+ *  it is still structurally assignable into `EChartsOption.series`. */
+interface DriverSeriesOption {
+  name: string
+  type: 'line'
+  symbolSize: number
+  lineStyle: { color: string }
+  itemStyle: { color: string }
+  data: LapPoint[]
+}
+
+/** Runtime narrowing for whatever `unknown` an ECharts callback hands back. */
+function isLapPoint(data: unknown): data is LapPoint {
+  if (!data || typeof data !== 'object') return false
+  const candidate = data as { value?: unknown; compound?: unknown }
+  return (
+    Array.isArray(candidate.value) &&
+    candidate.value.length === 2 &&
+    typeof candidate.value[0] === 'number' &&
+    typeof candidate.value[1] === 'number' &&
+    typeof candidate.compound === 'string'
+  )
+}
+
+/** Group already-filtered laps by driver code, preserving lap order. */
+function groupByDriver(laps: LapTime[]): Map<string, LapTime[]> {
+  const byDriver = new Map<string, LapTime[]>()
+  for (const lap of laps) {
+    const list = byDriver.get(lap.driver) ?? []
+    list.push(lap)
+    byDriver.set(lap.driver, list)
+  }
+  return byDriver
+}
+
+/** Build one driver's line+marker series, coloured by TEAM colour. */
+function buildDriverSeries(driver: string, laps: LapTime[], color: string): DriverSeriesOption {
+  return {
+    name: driver,
+    type: 'line',
+    symbolSize: 7,
+    lineStyle: { color },
+    itemStyle: { color },
+    data: laps.map((lap) => ({ value: [lap.lap_number, lap.lap_time], compound: lap.compound })),
+  }
+}
+
+/** Tooltip text: `<emoji> DRIVER — Lap N — M:SS.mmm — Compound`. */
+function formatLapTooltip(raw: unknown): string {
+  if (!raw || typeof raw !== 'object') return ''
+  const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
+  if (!isLapPoint(data)) return ''
+  const [lapNumber, lapTime] = data.value
+  return `${compoundEmoji(data.compound)} ${seriesName ?? ''} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundLabel(data.compound)}`
+}
+
+/** Build the full chart option from the per-driver series list. */
+function buildLapChartOption(seriesList: DriverSeriesOption[]): EChartsOption {
+  return {
+    tooltip: { trigger: 'item', formatter: formatLapTooltip },
+    legend: { data: seriesList.map((series) => series.name), top: 0 },
+    grid: { top: 44, left: 56, right: 24, bottom: 44, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap Number',
+      nameLocation: 'middle',
+      nameGap: 26,
+      nameTextStyle: AXIS_NAME_STYLE,
+      scale: true,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Lap Time',
+      nameLocation: 'middle',
+      nameGap: 48,
+      nameTextStyle: AXIS_NAME_STYLE,
+      axisLabel: { formatter: formatLapTimeAxis },
+      // Autorange around the lap times (~78-95 s) instead of forcing a 0:00
+      // baseline, which would squash every line into the top of the plot.
+      scale: true,
+    },
+    series: seriesList,
+  }
+}
+
+/** A driver code + lap number pulled off a click event, or null when the
+ *  click missed a data point (background/axis click). */
+interface LapClickTarget {
+  driver: string
+  lapNumber: number
+}
+
+function extractLapClick(raw: unknown): LapClickTarget | null {
+  if (!raw || typeof raw !== 'object') return null
+  const params = raw as { seriesName?: string; data?: unknown; value?: unknown }
+  const driver = params.seriesName
+  const fromData = isLapPoint(params.data) ? params.data.value[0] : undefined
+  const fromValue =
+    Array.isArray(params.value) && typeof params.value[0] === 'number' ? params.value[0] : undefined
+  const lapNumber = fromData ?? fromValue
+  if (!driver || lapNumber == null) return null
+  return { driver, lapNumber }
+}
+
+export interface LapChartProps {
+  /** Laps already passed through `applyLapFilters` (the visible set). */
+  laps: LapTime[]
+  /** Selection order — controls series/legend order (Streamlit parity). */
+  drivers: string[]
+  year: number | undefined
+  onLapClick: (driver: string, lapNumber: number) => void
+}
+
+/** Lap-time chart: one coloured-by-driver line per selected driver, with
+ *  click-to-load and a compound-aware tooltip. */
+export function LapChart({ laps, drivers, year, onLapClick }: LapChartProps) {
+  const option = useMemo(() => {
+    const byDriver = groupByDriver(laps)
+    const seriesList = drivers
+      .filter((driver) => byDriver.has(driver))
+      .map((driver) =>
+        buildDriverSeries(driver, byDriver.get(driver) ?? [], getDriverColor(driver, year)),
+      )
+    return buildLapChartOption(seriesList)
+  }, [laps, drivers, year])
+
+  const handleClick = useCallback(
+    (raw: unknown) => {
+      const click = extractLapClick(raw)
+      if (click) onLapClick(click.driver, click.lapNumber)
+    },
+    [onLapClick],
+  )
+
+  return (
+    <ReactECharts
+      theme={F1_THEME}
+      option={option}
+      style={{ height: 400 }}
+      notMerge
+      onEvents={{ click: handleClick }}
+    />
+  )
+}

--- a/webapp/src/features/dashboard/components/LapChartFooter.tsx
+++ b/webapp/src/features/dashboard/components/LapChartFooter.tsx
@@ -1,18 +1,22 @@
-// Lap Chart card footer strip: telemetry-selection status (left) + tyre
-// compound legend (right), folded into the `ChartCard`'s `footer` slot so the
-// card reads as one unit — chart, controls, status — instead of a stack of
-// loose blocks below it (round-2 fix #3, see
-// `docs/migration/design-specs/dashboard-round2.md#3`). `LapChartSection`
-// only renders this once `lapTimes` is non-empty; both clusters are cheap to
-// compute off data it already has in hand.
+// Lap Chart card footer: a compact "timing-strip" — telemetry-selection status
+// (left) + tyre-compound legend (right), folded into the ChartCard footer slot
+// (round-2 #3, see docs/migration/design-specs/dashboard-round2.md#3). One row,
+// everything `text-xs` on a single baseline; hierarchy is carried by the fg
+// ramp (loaded lap = fg-1, code = fg-2, eyebrow = fg-3, hint = fg-4), not by
+// size. Team colour rides on a swatch DOT, never the code text: a filled dot
+// has no contrast floor, so it survives the light theme's white card where a
+// near-white team colour as text would be illegible — and the dot doubles as
+// the chart's line-colour key. `LapChartSection` renders this once `lapTimes`
+// is non-empty.
 
-import { Activity } from 'lucide-react'
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverTextColor } from '../lib/drivers'
+import { getDriverColor } from '../lib/drivers'
 import { CompoundLegend } from './CompoundLegend'
 
-/** `{ driver, lap }` pairs for the telemetry-status caption, in the store
- *  map's insertion order (click order / fastest-laps batch order). */
+const EYEBROW_CLASSNAME = 'font-medium uppercase tracking-widest text-fg-3'
+
+/** `{ driver, lap }` pairs for the status cluster, in the store map's insertion
+ *  order (click order / fastest-laps batch order). */
 function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
   return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
 }
@@ -27,10 +31,11 @@ export interface LapChartFooterProps {
   year: number | undefined
 }
 
-/** Left cluster: which lap's telemetry is loaded per driver, plus the
- *  click-to-switch hint (demoted here from its old standalone tip line).
- *  Right cluster: the inline tyre-compound legend. `flex-wrap` lets narrow
- *  cards stack the two clusters instead of overflowing. */
+/** Footer strip. Left cluster = "what you're looking at now" (a `Telemetry`
+ *  eyebrow + one dot·code·lap chip per loaded driver + a quiet click hint).
+ *  Right cluster = the stint reference (compound legend). Both clusters always
+ *  render, so a single-driver load never pins the legend to a lonely right
+ *  edge, and the hint is loudest exactly when nothing is loaded yet. */
 export function LapChartFooter({
   selectedLapsPerDriver,
   lapTimes,
@@ -38,31 +43,36 @@ export function LapChartFooter({
   year,
 }: LapChartFooterProps) {
   const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+  const hasSelection = captionParts.length > 0
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-      {captionParts.length > 0 ? (
-        <p className="flex items-center gap-2 text-sm text-fg-2">
-          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
-          <span>
-            Showing telemetry:{' '}
-            {captionParts.map((part, index) => (
-              <span key={part.driver}>
-                {index > 0 ? ', ' : ''}
-                <strong
-                  className="font-semibold"
-                  style={{ color: getDriverTextColor(part.driver, year) }}
-                >
-                  {part.driver}
-                </strong>{' '}
-                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
-              </span>
-            ))}
-            <span className="text-fg-3"> · click any point to switch lap</span>
+    <div className="flex flex-wrap items-center justify-between gap-x-8 gap-y-2 text-xs">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <span className={EYEBROW_CLASSNAME}>Telemetry</span>
+        {captionParts.map(({ driver, lap }) => (
+          <span
+            key={driver}
+            className="flex items-center gap-1.5"
+            title={`${driver} — Lap ${lap} telemetry loaded`}
+          >
+            <span
+              aria-hidden="true"
+              className="size-1.5 rounded-full ring-1 ring-inset ring-hairline"
+              style={{ backgroundColor: getDriverColor(driver, year) }}
+            />
+            <span className="font-mono font-medium text-fg-2">{driver}</span>
+            <span className="font-mono tabular-nums text-fg-1">
+              L{lap}
+              <span className="sr-only"> (lap {lap})</span>
+            </span>
           </span>
-        </p>
-      ) : null}
-      <CompoundLegend lapTimes={lapTimes} drivers={drivers} year={year} />
+        ))}
+        <span aria-hidden="true" className="hidden h-3 w-px bg-hairline sm:inline-block" />
+        <span className="hidden text-fg-4 sm:inline">
+          {hasSelection ? 'Click a point to switch lap' : 'Click a point to load telemetry'}
+        </span>
+      </div>
+      <CompoundLegend lapTimes={lapTimes} drivers={drivers} />
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChartFooter.tsx
+++ b/webapp/src/features/dashboard/components/LapChartFooter.tsx
@@ -1,0 +1,68 @@
+// Lap Chart card footer strip: telemetry-selection status (left) + tyre
+// compound legend (right), folded into the `ChartCard`'s `footer` slot so the
+// card reads as one unit — chart, controls, status — instead of a stack of
+// loose blocks below it (round-2 fix #3, see
+// `docs/migration/design-specs/dashboard-round2.md#3`). `LapChartSection`
+// only renders this once `lapTimes` is non-empty; both clusters are cheap to
+// compute off data it already has in hand.
+
+import { Activity } from 'lucide-react'
+import type { LapTime } from '@/lib/api/telemetry'
+import { getDriverTextColor } from '../lib/drivers'
+import { CompoundLegend } from './CompoundLegend'
+
+/** `{ driver, lap }` pairs for the telemetry-status caption, in the store
+ *  map's insertion order (click order / fastest-laps batch order). */
+function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
+  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
+}
+
+export interface LapChartFooterProps {
+  /** driver code -> the lap number whose telemetry is currently loaded. */
+  selectedLapsPerDriver: Record<string, number>
+  /** FULL (unfiltered) lap times — the compound legend's counts ignore the
+   *  outlier/invalid toggles, matching `LapControls`. */
+  lapTimes: LapTime[]
+  drivers: string[]
+  year: number | undefined
+}
+
+/** Left cluster: which lap's telemetry is loaded per driver, plus the
+ *  click-to-switch hint (demoted here from its old standalone tip line).
+ *  Right cluster: the inline tyre-compound legend. `flex-wrap` lets narrow
+ *  cards stack the two clusters instead of overflowing. */
+export function LapChartFooter({
+  selectedLapsPerDriver,
+  lapTimes,
+  drivers,
+  year,
+}: LapChartFooterProps) {
+  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+      {captionParts.length > 0 ? (
+        <p className="flex items-center gap-2 text-sm text-fg-2">
+          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
+          <span>
+            Showing telemetry:{' '}
+            {captionParts.map((part, index) => (
+              <span key={part.driver}>
+                {index > 0 ? ', ' : ''}
+                <strong
+                  className="font-semibold"
+                  style={{ color: getDriverTextColor(part.driver, year) }}
+                >
+                  {part.driver}
+                </strong>{' '}
+                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
+              </span>
+            ))}
+            <span className="text-fg-3"> · click any point to switch lap</span>
+          </span>
+        </p>
+      ) : null}
+      <CompoundLegend lapTimes={lapTimes} drivers={drivers} year={year} />
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -9,11 +9,14 @@
 // "what's plotted" and "what's counted".
 
 import { useMemo } from 'react'
+import { Activity, Info, MousePointerClick } from 'lucide-react'
 import type { DashboardSearch } from '../search'
 import { useLapTimes } from '../queries'
 import { useDashboardStore } from '../store'
 import { applyLapFilters } from '../lib/outliers'
+import { getDriverTextColor } from '../lib/drivers'
 import { Skeleton } from '@/components/Skeleton'
+import { ChartCard } from '@/components/ChartCard'
 import { LapChart } from './LapChart'
 import { LapControls } from './LapControls'
 import { CompoundLegend } from './CompoundLegend'
@@ -22,15 +25,17 @@ export interface LapChartSectionProps {
   search: DashboardSearch
 }
 
-/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`. */
+/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`.
+ *  Only reachable once drivers ARE selected but their lap-times came back empty;
+ *  the "no drivers yet" case is handled by the page-level `EmptyState`. */
 function NoLapDataBanner() {
   return (
     <div
       role="status"
       className="flex items-center gap-3 rounded-xl border border-hairline border-l-4 border-l-info bg-bg-3 px-4 py-3 text-sm text-fg-2"
     >
-      <span aria-hidden="true">ℹ️</span>
-      <span>No lap data available. Select drivers and ensure backend is running.</span>
+      <Info className="size-4 shrink-0 text-info" aria-hidden="true" />
+      <span>No laps to plot for this selection.</span>
     </div>
   )
 }
@@ -61,27 +66,28 @@ export function LapChartSection({ search }: LapChartSectionProps) {
     [lapTimes, showOutliers, showInvalidLaps],
   )
 
-  const isEmpty = search.drivers.length === 0 || lapTimes.length === 0
+  // Drivers are always present by the time this section renders (the page
+  // shows its own EmptyState otherwise) — this only guards the in-between
+  // moment where lap-times came back empty for the current selection.
+  const isEmpty = lapTimes.length === 0
   const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className="text-center font-display text-lg uppercase tracking-wide text-fg-2">
-        Lap Chart
-      </h2>
-
-      {lapTimesQuery.isLoading ? (
-        <Skeleton className="h-100 w-full" />
-      ) : isEmpty ? (
-        <NoLapDataBanner />
-      ) : (
-        <LapChart
-          laps={filterResult.visible}
-          drivers={search.drivers}
-          year={search.year}
-          onLapClick={setLap}
-        />
-      )}
+      <ChartCard title="Lap Chart">
+        {lapTimesQuery.isLoading ? (
+          <Skeleton className="h-100 w-full" />
+        ) : isEmpty ? (
+          <NoLapDataBanner />
+        ) : (
+          <LapChart
+            laps={filterResult.visible}
+            drivers={search.drivers}
+            year={search.year}
+            onLapClick={setLap}
+          />
+        )}
+      </ChartCard>
 
       <LapControls
         lapTimes={lapTimes}
@@ -95,23 +101,33 @@ export function LapChartSection({ search }: LapChartSectionProps) {
         onToggleInvalidLaps={toggleInvalidLaps}
       />
 
-      <p className="text-sm text-fg-3">
-        💡 Tip: Click on any point in the LAP CHART above to load that lap's telemetry
+      <p className="flex items-center gap-2 text-sm text-fg-3">
+        <MousePointerClick className="size-4 shrink-0" aria-hidden="true" />
+        Click a lap to inspect it — fastest laps load automatically.
       </p>
 
       {captionParts.length > 0 ? (
-        <p className="text-sm text-fg-2">
-          📊 Showing telemetry:{' '}
-          {captionParts.map((part, index) => (
-            <span key={part.driver}>
-              {index > 0 ? ', ' : ''}
-              <strong className="font-semibold text-fg-1">{part.driver}</strong> (Lap {part.lap})
-            </span>
-          ))}
+        <p className="flex items-center gap-2 text-sm text-fg-2">
+          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
+          <span>
+            Showing telemetry:{' '}
+            {captionParts.map((part, index) => (
+              <span key={part.driver}>
+                {index > 0 ? ', ' : ''}
+                <strong
+                  className="font-semibold"
+                  style={{ color: getDriverTextColor(part.driver, search.year) }}
+                >
+                  {part.driver}
+                </strong>{' '}
+                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
+              </span>
+            ))}
+          </span>
         </p>
       ) : null}
 
-      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} />
+      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} year={search.year} />
     </section>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -1,25 +1,31 @@
 // LAP CHART section. Streamlit parity: `frontend/components/dashboard/lap_graph.py`.
 //
-// Owns the data fetch (`useLapTimes`) and the store reads/writes; the three
-// sub-components (`LapChart`, `LapControls`, `CompoundLegend`) are dumb
-// renderers of whatever slice they're handed. The outlier/invalid filters are
-// applied here (client-side, no refetch — `applyLapFilters`) and only the
-// resulting `visible` laps are plotted; buttons and the legend keep working
-// off the FULL `lapTimes`, matching the Streamlit source's split between
-// "what's plotted" and "what's counted".
+// Owns the data fetch (`useLapTimes`) and the store reads/writes; `LapChart`,
+// `LapControls`, and `LapChartFooter` are dumb renderers of whatever slice
+// they're handed. The outlier/invalid filters are applied here (client-side,
+// no refetch — `applyLapFilters`) and only the resulting `visible` laps are
+// plotted; the controls and footer keep working off the FULL `lapTimes`,
+// matching the Streamlit source's split between "what's plotted" and "what's
+// counted".
+//
+// Everything the chart owns — controls, telemetry status, compound legend —
+// folds into the ONE `ChartCard`: controls sit in the header `actions` slot,
+// status + legend in the `footer` strip, so the card reads as a single unit
+// instead of a chart plus a stack of loose blocks below it (round-2 fix #3,
+// see `docs/migration/design-specs/dashboard-round2.md#3`).
 
 import { useMemo } from 'react'
-import { Activity, Info, MousePointerClick } from 'lucide-react'
+import { Info } from 'lucide-react'
 import type { DashboardSearch } from '../search'
 import { useLapTimes } from '../queries'
 import { useDashboardStore } from '../store'
 import { applyLapFilters } from '../lib/outliers'
-import { getDriverTextColor } from '../lib/drivers'
+import { useToast } from '@/components/Toast'
 import { Skeleton } from '@/components/Skeleton'
 import { ChartCard } from '@/components/ChartCard'
 import { LapChart } from './LapChart'
 import { LapControls } from './LapControls'
-import { CompoundLegend } from './CompoundLegend'
+import { LapChartFooter } from './LapChartFooter'
 
 export interface LapChartSectionProps {
   search: DashboardSearch
@@ -40,18 +46,13 @@ function NoLapDataBanner() {
   )
 }
 
-/** `{ driver, lap }` pairs for the "Showing telemetry" caption, in the
- *  store map's insertion order (click order / fastest-laps batch order). */
-function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
-  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
-}
-
-/** LAP CHART section: chart (or its loading/empty state), control buttons,
- *  a click-to-load tip, the current telemetry-selection caption, and the
- *  tyre compound legend, in that order. */
+/** LAP CHART section: one `ChartCard` — the chart body (or its loading/empty
+ *  state), the fastest-laps/outlier/invalid controls in the header, and the
+ *  telemetry-status + compound-legend strip in the footer. */
 export function LapChartSection({ search }: LapChartSectionProps) {
   const lapTimesQuery = useLapTimes(search)
   const lapTimes = useMemo(() => lapTimesQuery.data ?? [], [lapTimesQuery.data])
+  const { toast } = useToast()
 
   const showOutliers = useDashboardStore((s) => s.showOutliers)
   const showInvalidLaps = useDashboardStore((s) => s.showInvalidLaps)
@@ -70,11 +71,53 @@ export function LapChartSection({ search }: LapChartSectionProps) {
   // shows its own EmptyState otherwise) — this only guards the in-between
   // moment where lap-times came back empty for the current selection.
   const isEmpty = lapTimes.length === 0
-  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  /** Click-to-load, with feedback that the click actually landed: an
+   *  already-loaded lap gets an info toast (no store write, no refetch); a
+   *  new lap gets a success toast once the fetch is queued. Compensates for
+   *  the chart's ring marker (see `LapChart`) being easy to miss when the
+   *  telemetry grid it feeds is below the fold. */
+  function handleLapClick(driver: string, lap: number) {
+    if (selectedLapsPerDriver[driver] === lap) {
+      toast({ title: `${driver} lap ${lap}`, description: 'Already showing this lap.', tone: 'info' })
+      return
+    }
+    setLap(driver, lap)
+    toast({
+      title: `${driver} lap ${lap} loaded`,
+      description: 'Telemetry updated below.',
+      tone: 'success',
+    })
+  }
 
   return (
     <section className="flex flex-col gap-4">
-      <ChartCard title="Lap Chart">
+      <ChartCard
+        title="Lap Chart"
+        actions={
+          <LapControls
+            lapTimes={lapTimes}
+            drivers={search.drivers}
+            showOutliers={showOutliers}
+            showInvalidLaps={showInvalidLaps}
+            outlierCount={filterResult.outlierCount}
+            invalidCount={filterResult.invalidCount}
+            onSelectFastestLaps={setFastestLaps}
+            onToggleOutliers={toggleOutliers}
+            onToggleInvalidLaps={toggleInvalidLaps}
+          />
+        }
+        footer={
+          lapTimes.length > 0 ? (
+            <LapChartFooter
+              selectedLapsPerDriver={selectedLapsPerDriver}
+              lapTimes={lapTimes}
+              drivers={search.drivers}
+              year={search.year}
+            />
+          ) : undefined
+        }
+      >
         {lapTimesQuery.isLoading ? (
           <Skeleton className="h-100 w-full" />
         ) : isEmpty ? (
@@ -84,50 +127,11 @@ export function LapChartSection({ search }: LapChartSectionProps) {
             laps={filterResult.visible}
             drivers={search.drivers}
             year={search.year}
-            onLapClick={setLap}
+            selectedLaps={selectedLapsPerDriver}
+            onLapClick={handleLapClick}
           />
         )}
       </ChartCard>
-
-      <LapControls
-        lapTimes={lapTimes}
-        drivers={search.drivers}
-        showOutliers={showOutliers}
-        showInvalidLaps={showInvalidLaps}
-        outlierCount={filterResult.outlierCount}
-        invalidCount={filterResult.invalidCount}
-        onSelectFastestLaps={setFastestLaps}
-        onToggleOutliers={toggleOutliers}
-        onToggleInvalidLaps={toggleInvalidLaps}
-      />
-
-      <p className="flex items-center gap-2 text-sm text-fg-3">
-        <MousePointerClick className="size-4 shrink-0" aria-hidden="true" />
-        Click a lap to inspect it — fastest laps load automatically.
-      </p>
-
-      {captionParts.length > 0 ? (
-        <p className="flex items-center gap-2 text-sm text-fg-2">
-          <Activity className="size-4 shrink-0 text-fg-3" aria-hidden="true" />
-          <span>
-            Showing telemetry:{' '}
-            {captionParts.map((part, index) => (
-              <span key={part.driver}>
-                {index > 0 ? ', ' : ''}
-                <strong
-                  className="font-semibold"
-                  style={{ color: getDriverTextColor(part.driver, search.year) }}
-                >
-                  {part.driver}
-                </strong>{' '}
-                (Lap <span className="font-mono tabular-nums">{part.lap}</span>)
-              </span>
-            ))}
-          </span>
-        </p>
-      ) : null}
-
-      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} year={search.year} />
     </section>
   )
 }

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -79,7 +79,11 @@ export function LapChartSection({ search }: LapChartSectionProps) {
    *  telemetry grid it feeds is below the fold. */
   function handleLapClick(driver: string, lap: number) {
     if (selectedLapsPerDriver[driver] === lap) {
-      toast({ title: `${driver} lap ${lap}`, description: 'Already showing this lap.', tone: 'info' })
+      toast({
+        title: `${driver} lap ${lap}`,
+        description: 'Already showing this lap.',
+        tone: 'info',
+      })
       return
     }
     setLap(driver, lap)

--- a/webapp/src/features/dashboard/components/LapChartSection.tsx
+++ b/webapp/src/features/dashboard/components/LapChartSection.tsx
@@ -1,0 +1,117 @@
+// LAP CHART section. Streamlit parity: `frontend/components/dashboard/lap_graph.py`.
+//
+// Owns the data fetch (`useLapTimes`) and the store reads/writes; the three
+// sub-components (`LapChart`, `LapControls`, `CompoundLegend`) are dumb
+// renderers of whatever slice they're handed. The outlier/invalid filters are
+// applied here (client-side, no refetch — `applyLapFilters`) and only the
+// resulting `visible` laps are plotted; buttons and the legend keep working
+// off the FULL `lapTimes`, matching the Streamlit source's split between
+// "what's plotted" and "what's counted".
+
+import { useMemo } from 'react'
+import type { DashboardSearch } from '../search'
+import { useLapTimes } from '../queries'
+import { useDashboardStore } from '../store'
+import { applyLapFilters } from '../lib/outliers'
+import { Skeleton } from '@/components/Skeleton'
+import { LapChart } from './LapChart'
+import { LapControls } from './LapControls'
+import { CompoundLegend } from './CompoundLegend'
+
+export interface LapChartSectionProps {
+  search: DashboardSearch
+}
+
+/** Subtle inline banner — Streamlit parity for `st.info("No lap data available...")`. */
+function NoLapDataBanner() {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-3 rounded-xl border border-hairline border-l-4 border-l-info bg-bg-3 px-4 py-3 text-sm text-fg-2"
+    >
+      <span aria-hidden="true">ℹ️</span>
+      <span>No lap data available. Select drivers and ensure backend is running.</span>
+    </div>
+  )
+}
+
+/** `{ driver, lap }` pairs for the "Showing telemetry" caption, in the
+ *  store map's insertion order (click order / fastest-laps batch order). */
+function telemetryCaptionParts(selectedLapsPerDriver: Record<string, number>) {
+  return Object.entries(selectedLapsPerDriver).map(([driver, lap]) => ({ driver, lap }))
+}
+
+/** LAP CHART section: chart (or its loading/empty state), control buttons,
+ *  a click-to-load tip, the current telemetry-selection caption, and the
+ *  tyre compound legend, in that order. */
+export function LapChartSection({ search }: LapChartSectionProps) {
+  const lapTimesQuery = useLapTimes(search)
+  const lapTimes = useMemo(() => lapTimesQuery.data ?? [], [lapTimesQuery.data])
+
+  const showOutliers = useDashboardStore((s) => s.showOutliers)
+  const showInvalidLaps = useDashboardStore((s) => s.showInvalidLaps)
+  const toggleOutliers = useDashboardStore((s) => s.toggleOutliers)
+  const toggleInvalidLaps = useDashboardStore((s) => s.toggleInvalidLaps)
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
+  const setLap = useDashboardStore((s) => s.setLap)
+  const setFastestLaps = useDashboardStore((s) => s.setFastestLaps)
+
+  const filterResult = useMemo(
+    () => applyLapFilters(lapTimes, showOutliers, showInvalidLaps),
+    [lapTimes, showOutliers, showInvalidLaps],
+  )
+
+  const isEmpty = search.drivers.length === 0 || lapTimes.length === 0
+  const captionParts = telemetryCaptionParts(selectedLapsPerDriver)
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-center font-display text-lg uppercase tracking-wide text-fg-2">
+        Lap Chart
+      </h2>
+
+      {lapTimesQuery.isLoading ? (
+        <Skeleton className="h-100 w-full" />
+      ) : isEmpty ? (
+        <NoLapDataBanner />
+      ) : (
+        <LapChart
+          laps={filterResult.visible}
+          drivers={search.drivers}
+          year={search.year}
+          onLapClick={setLap}
+        />
+      )}
+
+      <LapControls
+        lapTimes={lapTimes}
+        drivers={search.drivers}
+        showOutliers={showOutliers}
+        showInvalidLaps={showInvalidLaps}
+        outlierCount={filterResult.outlierCount}
+        invalidCount={filterResult.invalidCount}
+        onSelectFastestLaps={setFastestLaps}
+        onToggleOutliers={toggleOutliers}
+        onToggleInvalidLaps={toggleInvalidLaps}
+      />
+
+      <p className="text-sm text-fg-3">
+        💡 Tip: Click on any point in the LAP CHART above to load that lap's telemetry
+      </p>
+
+      {captionParts.length > 0 ? (
+        <p className="text-sm text-fg-2">
+          📊 Showing telemetry:{' '}
+          {captionParts.map((part, index) => (
+            <span key={part.driver}>
+              {index > 0 ? ', ' : ''}
+              <strong className="font-semibold text-fg-1">{part.driver}</strong> (Lap {part.lap})
+            </span>
+          ))}
+        </p>
+      ) : null}
+
+      <CompoundLegend lapTimes={lapTimes} drivers={search.drivers} />
+    </section>
+  )
+}

--- a/webapp/src/features/dashboard/components/LapControls.tsx
+++ b/webapp/src/features/dashboard/components/LapControls.tsx
@@ -2,47 +2,47 @@
 // `frontend/components/dashboard/lap_graph.py::render_control_buttons` /
 // `_display_filter_status`.
 //
-// Pure presentational + one pure computation (fastest lap per driver); all
+// Pure presentational; the fastest-lap computation is the shared
+// `../lib/fastestLap` helper (also used by the page's auto-load effect). All
 // store writes happen in the caller (`LapChartSection`) so this component
 // never touches Zustand directly.
 
+import { Eye, EyeOff, Timer } from 'lucide-react'
 import { Button } from '@/components/Button'
+import { cn } from '@/lib/cn'
 import type { LapTime } from '@/lib/api/telemetry'
+import { fastestLapPerDriver } from '../lib/fastestLap'
 
-/** Each driver's fastest lap (by `lap_time`), computed from the FULL
- *  (unfiltered) lap times — the outlier/invalid toggles must not hide a
- *  driver's genuine fastest lap from this shortcut. */
-function fastestLapPerDriver(lapTimes: LapTime[], drivers: string[]): Record<string, number> {
-  const fastest: Record<string, number> = {}
-  for (const driver of drivers) {
-    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
-    if (driverLaps.length === 0) continue
-    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
-    fastest[driver] = quickest.lap_number
-  }
-  return fastest
-}
-
-/** "Showing/Hiding N outlier laps | Hiding N invalid laps" status line,
- *  matching `_display_filter_status`'s message assembly exactly. */
-function buildFilterStatus(
-  outlierCount: number,
-  invalidCount: number,
-  showOutliers: boolean,
-  showInvalidLaps: boolean,
-): string {
-  const parts: string[] = []
-  if (outlierCount > 0) {
-    parts.push(
-      showOutliers
-        ? `📊 Showing ${outlierCount} outlier laps`
-        : `🚫 Hiding ${outlierCount} outlier laps`,
-    )
-  }
-  if (invalidCount > 0 && !showInvalidLaps) {
-    parts.push(`🚫 Hiding ${invalidCount} invalid laps`)
-  }
-  return parts.join(' | ')
+/** Pressed/unpressed toggle chip for a lap-visibility filter, with the
+ *  affected lap count embedded in the label — replaces the old standalone
+ *  filter-status line, which duplicated these same counts as plain text. */
+function FilterChip({
+  label,
+  count,
+  pressed,
+  onToggle,
+}: {
+  label: string
+  count: number
+  pressed: boolean
+  onToggle: () => void
+}) {
+  const Icon = pressed ? Eye : EyeOff
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onToggle}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0',
+        pressed ? 'bg-bg-4 text-fg-1' : 'text-fg-3 hover:bg-bg-4 hover:text-fg-2',
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+      {label} · {count}
+    </button>
+  )
 }
 
 export interface LapControlsProps {
@@ -58,8 +58,9 @@ export interface LapControlsProps {
   onToggleInvalidLaps: () => void
 }
 
-/** Fastest-laps shortcut + outlier/invalid visibility toggles, plus the
- *  resulting filter-status line. */
+/** Fastest-laps shortcut + outlier/invalid visibility toggle chips, in a
+ *  left-aligned auto-width row (not a full-width grid — these are compact
+ *  controls, not equal-weight destinations). */
 export function LapControls({
   lapTimes,
   drivers,
@@ -71,8 +72,6 @@ export function LapControls({
   onToggleOutliers,
   onToggleInvalidLaps,
 }: LapControlsProps) {
-  const filterStatus = buildFilterStatus(outlierCount, invalidCount, showOutliers, showInvalidLaps)
-
   /** Load each driver's fastest lap — no-op when there are no laps yet, so the
    *  button can't wipe the current selection with an empty map. */
   const handleSelectFastest = () => {
@@ -81,19 +80,23 @@ export function LapControls({
   }
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <Button variant="ghost" onClick={handleSelectFastest}>
-          🏁 SELECT FASTEST LAPS
-        </Button>
-        <Button variant="ghost" onClick={onToggleOutliers}>
-          {showOutliers ? 'HIDE OUTLIERS' : 'SHOW OUTLIERS'}
-        </Button>
-        <Button variant="ghost" onClick={onToggleInvalidLaps}>
-          {showInvalidLaps ? 'HIDE INVALID LAPS' : 'SHOW INVALID LAPS'}
-        </Button>
-      </div>
-      {filterStatus ? <p className="text-sm text-fg-3">{filterStatus}</p> : null}
+    <div className="flex flex-wrap items-center gap-2">
+      <Button variant="ghost" size="sm" onClick={handleSelectFastest}>
+        <Timer className="size-4" aria-hidden="true" />
+        Select fastest laps
+      </Button>
+      <FilterChip
+        label="Outliers"
+        count={outlierCount}
+        pressed={showOutliers}
+        onToggle={onToggleOutliers}
+      />
+      <FilterChip
+        label="Invalid"
+        count={invalidCount}
+        pressed={showInvalidLaps}
+        onToggle={onToggleInvalidLaps}
+      />
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/LapControls.tsx
+++ b/webapp/src/features/dashboard/components/LapControls.tsx
@@ -1,0 +1,99 @@
+// Lap-chart control row. Streamlit parity:
+// `frontend/components/dashboard/lap_graph.py::render_control_buttons` /
+// `_display_filter_status`.
+//
+// Pure presentational + one pure computation (fastest lap per driver); all
+// store writes happen in the caller (`LapChartSection`) so this component
+// never touches Zustand directly.
+
+import { Button } from '@/components/Button'
+import type { LapTime } from '@/lib/api/telemetry'
+
+/** Each driver's fastest lap (by `lap_time`), computed from the FULL
+ *  (unfiltered) lap times — the outlier/invalid toggles must not hide a
+ *  driver's genuine fastest lap from this shortcut. */
+function fastestLapPerDriver(lapTimes: LapTime[], drivers: string[]): Record<string, number> {
+  const fastest: Record<string, number> = {}
+  for (const driver of drivers) {
+    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
+    if (driverLaps.length === 0) continue
+    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
+    fastest[driver] = quickest.lap_number
+  }
+  return fastest
+}
+
+/** "Showing/Hiding N outlier laps | Hiding N invalid laps" status line,
+ *  matching `_display_filter_status`'s message assembly exactly. */
+function buildFilterStatus(
+  outlierCount: number,
+  invalidCount: number,
+  showOutliers: boolean,
+  showInvalidLaps: boolean,
+): string {
+  const parts: string[] = []
+  if (outlierCount > 0) {
+    parts.push(
+      showOutliers
+        ? `📊 Showing ${outlierCount} outlier laps`
+        : `🚫 Hiding ${outlierCount} outlier laps`,
+    )
+  }
+  if (invalidCount > 0 && !showInvalidLaps) {
+    parts.push(`🚫 Hiding ${invalidCount} invalid laps`)
+  }
+  return parts.join(' | ')
+}
+
+export interface LapControlsProps {
+  /** FULL (unfiltered) lap times — fastest-lap selection ignores the toggles. */
+  lapTimes: LapTime[]
+  drivers: string[]
+  showOutliers: boolean
+  showInvalidLaps: boolean
+  outlierCount: number
+  invalidCount: number
+  onSelectFastestLaps: (laps: Record<string, number>) => void
+  onToggleOutliers: () => void
+  onToggleInvalidLaps: () => void
+}
+
+/** Fastest-laps shortcut + outlier/invalid visibility toggles, plus the
+ *  resulting filter-status line. */
+export function LapControls({
+  lapTimes,
+  drivers,
+  showOutliers,
+  showInvalidLaps,
+  outlierCount,
+  invalidCount,
+  onSelectFastestLaps,
+  onToggleOutliers,
+  onToggleInvalidLaps,
+}: LapControlsProps) {
+  const filterStatus = buildFilterStatus(outlierCount, invalidCount, showOutliers, showInvalidLaps)
+
+  /** Load each driver's fastest lap — no-op when there are no laps yet, so the
+   *  button can't wipe the current selection with an empty map. */
+  const handleSelectFastest = () => {
+    const fastest = fastestLapPerDriver(lapTimes, drivers)
+    if (Object.keys(fastest).length > 0) onSelectFastestLaps(fastest)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Button variant="ghost" onClick={handleSelectFastest}>
+          🏁 SELECT FASTEST LAPS
+        </Button>
+        <Button variant="ghost" onClick={onToggleOutliers}>
+          {showOutliers ? 'HIDE OUTLIERS' : 'SHOW OUTLIERS'}
+        </Button>
+        <Button variant="ghost" onClick={onToggleInvalidLaps}>
+          {showInvalidLaps ? 'HIDE INVALID LAPS' : 'SHOW INVALID LAPS'}
+        </Button>
+      </div>
+      {filterStatus ? <p className="text-sm text-fg-3">{filterStatus}</p> : null}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/SectionHeader.tsx
+++ b/webapp/src/features/dashboard/components/SectionHeader.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+/**
+ * One consistent section header for the whole Dashboard: left-aligned, uppercase
+ * eyebrow with a brand-purple tick, and an optional right slot for section-level
+ * controls (e.g. the grid/stack toggle). Replaces the mix of centered/left
+ * titles the migrated sections started with.
+ */
+export function SectionHeader({ title, children }: { title: string; children?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <h2 className="flex items-center gap-2 font-display text-sm font-medium uppercase tracking-widest text-fg-3">
+        <span aria-hidden="true" className="inline-block h-4 w-0.5 rounded-full bg-purple-600" />
+        {title}
+      </h2>
+      {children ? <div className="flex items-center gap-2">{children}</div> : null}
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -1,0 +1,106 @@
+// Cascading Year → GP → Session → Drivers toolbar (Streamlit parity, see
+// `frontend/components/dashboard/data_selectors.py`). This component is a
+// dumb renderer: it only reads `value` and fires single-key patches via
+// `onChange`. The page (`DashboardPage`) owns the URL and applies the
+// cascading reset when an upstream selector changes.
+import type { ReactNode } from 'react'
+import type { DashboardSearch } from '../search'
+import { MAX_DRIVERS } from '../search'
+import { useGps, useSessions, useDrivers } from '../queries'
+import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
+import { cn } from '@/lib/cn'
+
+export interface SelectorsToolbarProps {
+  value: DashboardSearch
+  /** Patch the URL search (page merges + navigates). Passing a key resets its dependents. */
+  onChange: (patch: Partial<DashboardSearch>) => void
+}
+
+// Streamlit hardcodes this same list — no `/years` endpoint exists.
+const YEAR_OPTIONS: ComboboxOption[] = [2025, 2024, 2023].map((year) => ({
+  value: String(year),
+  label: String(year),
+}))
+
+const EYEBROW_CLASSNAME = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+
+/** A labelled selector cell: the small uppercase eyebrow above its control,
+ *  matching `StatCard`'s eyebrow styling so the toolbar reads as one system. */
+function SelectorField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className={EYEBROW_CLASSNAME}>{label}</span>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Horizontal toolbar of the 4 cascading dashboard selectors. Each selector is
+ * disabled until its upstream dependency is chosen, and options come from the
+ * live telemetry API (`useGps`/`useSessions`/`useDrivers`) rather than a
+ * hardcoded roster, so the driver list always matches who actually ran.
+ */
+export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
+  const gpsQuery = useGps(value.year)
+  const sessionsQuery = useSessions(value.year, value.gp)
+  const driversQuery = useDrivers(value.year, value.gp, value.session)
+
+  const gpOptions: ComboboxOption[] = (gpsQuery.data ?? []).map((gp) => ({ value: gp, label: gp }))
+  const sessionOptions: ComboboxOption[] = (sessionsQuery.data ?? []).map((session) => ({
+    value: session,
+    label: session,
+  }))
+  const driverOptions: ComboboxOption[] = (driversQuery.data ?? []).map((driver) => ({
+    value: driver.code,
+    label: driver.code,
+  }))
+
+  return (
+    <div className={cn('grid grid-cols-1 gap-4', 'sm:grid-cols-2', 'lg:grid-cols-4')}>
+      <SelectorField label="Year">
+        <Combobox
+          ariaLabel="Year"
+          options={YEAR_OPTIONS}
+          value={value.year != null ? String(value.year) : undefined}
+          onChange={(year) => onChange({ year: Number(year) })}
+          placeholder="Select year"
+        />
+      </SelectorField>
+
+      <SelectorField label="GP">
+        <Combobox
+          ariaLabel="Grand Prix"
+          options={gpOptions}
+          value={value.gp}
+          onChange={(gp) => onChange({ gp })}
+          placeholder="Select GP"
+          disabled={value.year == null || gpsQuery.isLoading}
+        />
+      </SelectorField>
+
+      <SelectorField label="Session">
+        <Combobox
+          ariaLabel="Session"
+          options={sessionOptions}
+          value={value.session}
+          onChange={(session) => onChange({ session })}
+          placeholder="Select session"
+          disabled={!value.gp || sessionsQuery.isLoading}
+        />
+      </SelectorField>
+
+      <SelectorField label="Drivers">
+        <MultiCombobox
+          ariaLabel="Drivers (max 3)"
+          options={driverOptions}
+          value={value.drivers}
+          onChange={(drivers) => onChange({ drivers })}
+          placeholder="Select drivers (max 3)"
+          disabled={!value.session || driversQuery.isLoading}
+          max={MAX_DRIVERS}
+        />
+      </SelectorField>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -23,10 +23,12 @@ const YEAR_OPTIONS: ComboboxOption[] = [2025, 2024, 2023].map((year) => ({
   label: String(year),
 }))
 
-const EYEBROW_CLASSNAME = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+const EYEBROW_CLASSNAME = 'text-center text-xs font-medium uppercase tracking-widest text-fg-3'
 
-/** A labelled selector cell: the small uppercase eyebrow above its control,
- *  matching `StatCard`'s eyebrow styling so the toolbar reads as one system. */
+/** A labelled selector cell: the small uppercase eyebrow centered over its
+ *  control, matching `StatCard`'s eyebrow styling so the toolbar reads as one
+ *  system. Centered (not left) so each label sits over the middle of its wide
+ *  field instead of orphaned in the top-left corner of it. */
 function SelectorField({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-1.5">

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -76,7 +76,8 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           value={value.gp}
           onChange={(gp) => onChange({ gp })}
           placeholder="Select GP"
-          disabled={value.year == null || gpsQuery.isLoading}
+          disabled={value.year == null}
+          loading={gpsQuery.isLoading}
         />
       </SelectorField>
 
@@ -87,7 +88,8 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           value={value.session}
           onChange={(session) => onChange({ session })}
           placeholder="Select session"
-          disabled={!value.gp || sessionsQuery.isLoading}
+          disabled={!value.gp}
+          loading={sessionsQuery.isLoading}
         />
       </SelectorField>
 
@@ -97,8 +99,15 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           options={driverOptions}
           value={value.drivers}
           onChange={(drivers) => onChange({ drivers })}
-          placeholder="Select drivers (max 3)"
-          disabled={!value.session || driversQuery.isLoading}
+          placeholder={
+            driversQuery.isLoading
+              ? 'Loading drivers…'
+              : driversQuery.isError
+                ? "Couldn't load drivers — reselect the session"
+                : 'Select drivers (max 3)'
+          }
+          disabled={!value.session}
+          loading={driversQuery.isLoading}
           max={MAX_DRIVERS}
           getOptionAccent={(code) => getDriverColor(code, value.year)}
         />

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react'
 import type { DashboardSearch } from '../search'
 import { MAX_DRIVERS } from '../search'
 import { useGps, useSessions, useDrivers } from '../queries'
+import { getDriverColor } from '../lib/drivers'
 import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
 import { cn } from '@/lib/cn'
 
@@ -99,6 +100,7 @@ export function SelectorsToolbar({ value, onChange }: SelectorsToolbarProps) {
           placeholder="Select drivers (max 3)"
           disabled={!value.session || driversQuery.isLoading}
           max={MAX_DRIVERS}
+          getOptionAccent={(code) => getDriverColor(code, value.year)}
         />
       </SelectorField>
     </div>

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -1,0 +1,159 @@
+// TELEMETRY section (issue #34, §6.1): 7 per-channel charts — Speed, Delta,
+// Throttle, Brake, RPM, Gear, DRS, matching the render order in
+// frontend/pages/dashboard.py — in a grid<->stack layout, each plotting one
+// line per loaded driver against distance. Delta is cross-driver (needs a
+// reference lap) so it renders through the dedicated `DeltaChart`; the other
+// 6 channels share the generic `ChannelChart`, driven by `channels.ts`.
+//
+// Data comes from `useLapTelemetries`, keyed by the store's
+// `selectedLapsPerDriver` (the lap chart writes to it on click-to-load).
+// Until at least one lap has loaded, every card shows `TelemetryLoader`
+// instead of a chart — Víctor's hard requirement, see TelemetryLoader.tsx.
+
+import type { ReactNode } from 'react'
+import { ChartCard } from '@/components/ChartCard'
+import { Button } from '@/components/Button'
+import { cn } from '@/lib/cn'
+import type { DashboardSearch } from '../search'
+import { useLapTelemetries } from '../queries'
+import { useDashboardStore, type ChartLayout } from '../store'
+import { TelemetryLoader } from './TelemetryLoader'
+import { ChannelChart, DeltaChart } from './ChannelChart'
+import { CHANNELS, DELTA_TITLE } from './channels'
+
+export interface TelemetryGridProps {
+  search: DashboardSearch
+}
+
+const LAYOUT_CLASSNAMES: Record<ChartLayout, string> = {
+  grid: 'grid grid-cols-1 gap-4 xl:grid-cols-2',
+  stack: 'flex flex-col gap-4',
+}
+
+/** One ChartCard: its chart once at least one lap has loaded, the shared
+ *  loader before that. Keeps the loader-vs-chart branch in a single place
+ *  instead of repeating it per card. */
+function TelemetryCard({
+  title,
+  hasAny,
+  children,
+}: {
+  title: string
+  hasAny: boolean
+  children: ReactNode
+}) {
+  return <ChartCard title={title}>{hasAny ? children : <TelemetryLoader />}</ChartCard>
+}
+
+/** Human note for laps that came back without telemetry (pit / out / incomplete
+ *  laps return an empty body). Mirrors the Streamlit tip that told the user to
+ *  pick a different lap instead of leaving them staring at a spinner. */
+function noTelemetryMessage(failedDrivers: string[]): string {
+  const who = failedDrivers.length > 0 ? failedDrivers.join(', ') : 'the selected lap(s)'
+  return `No telemetry for ${who} — pit, out and incomplete laps have no telemetry data. Click a different lap in the chart above (or use SELECT FASTEST LAPS).`
+}
+
+/** Full-width notice shown when every selected lap settled with no telemetry —
+ *  replaces a grid of loaders that would otherwise never resolve. */
+function NoTelemetryNotice({ failedDrivers }: { failedDrivers: string[] }) {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
+    >
+      <span aria-hidden="true">⚠️</span>
+      <span>{noTelemetryMessage(failedDrivers)}</span>
+    </div>
+  )
+}
+
+function LayoutToggle({ layout, onToggle }: { layout: ChartLayout; onToggle: () => void }) {
+  const modes: { mode: ChartLayout; label: string }[] = [
+    { mode: 'grid', label: 'Grid' },
+    { mode: 'stack', label: 'Stack' },
+  ]
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-hairline p-1">
+      {modes.map(({ mode, label }) => (
+        <Button
+          key={mode}
+          variant={layout === mode ? 'primary' : 'ghost'}
+          size="sm"
+          aria-pressed={layout === mode}
+          onClick={() => layout !== mode && onToggle()}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+export function TelemetryGrid({ search }: TelemetryGridProps) {
+  const selectedLapsPerDriver = useDashboardStore((s) => s.selectedLapsPerDriver)
+  const chartLayout = useDashboardStore((s) => s.chartLayout)
+  const toggleChartLayout = useDashboardStore((s) => s.toggleChartLayout)
+  const { byDriver, hasAny, isLoading, hasSelection, failedDrivers } = useLapTelemetries(
+    search,
+    selectedLapsPerDriver,
+  )
+  const { drivers, year } = search
+
+  // Every selected lap settled with no telemetry → show one notice instead of
+  // a grid of loaders that would never resolve. A PARTIAL failure (some driver
+  // loaded, another didn't) still renders the charts, with a note on top.
+  const settledEmpty = hasSelection && !isLoading && !hasAny
+  const showPartialNote = hasAny && failedDrivers.length > 0
+
+  // Speed leads, Delta is hardcoded second (cross-driver, not part of
+  // CHANNELS), then the rest of CHANNELS in their declared order — matches
+  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs).
+  const [speedChannel, ...restChannels] = CHANNELS
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-display text-lg tracking-wide text-fg-2 uppercase">Telemetry</h2>
+        <LayoutToggle layout={chartLayout} onToggle={toggleChartLayout} />
+      </div>
+
+      {settledEmpty ? (
+        <NoTelemetryNotice failedDrivers={failedDrivers} />
+      ) : (
+        <>
+          {showPartialNote ? (
+            <p className="text-sm text-warning">{noTelemetryMessage(failedDrivers)}</p>
+          ) : null}
+
+          <div className={cn(LAYOUT_CLASSNAMES[chartLayout])}>
+            <TelemetryCard title={speedChannel.title} hasAny={hasAny}>
+              <ChannelChart
+                title={speedChannel.title}
+                byDriver={byDriver}
+                drivers={drivers}
+                year={year}
+                channel={speedChannel}
+              />
+            </TelemetryCard>
+
+            <TelemetryCard title={DELTA_TITLE} hasAny={hasAny}>
+              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} />
+            </TelemetryCard>
+
+            {restChannels.map((channel) => (
+              <TelemetryCard key={channel.key} title={channel.title} hasAny={hasAny}>
+                <ChannelChart
+                  title={channel.title}
+                  byDriver={byDriver}
+                  drivers={drivers}
+                  year={year}
+                  channel={channel}
+                />
+              </TelemetryCard>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -1,9 +1,12 @@
-// TELEMETRY section (issue #34, §6.1): 7 per-channel charts — Speed, Delta,
-// Throttle, Brake, RPM, Gear, DRS, matching the render order in
-// frontend/pages/dashboard.py — in a grid<->stack layout, each plotting one
-// line per loaded driver against distance. Delta is cross-driver (needs a
-// reference lap) so it renders through the dedicated `DeltaChart`; the other
-// 6 channels share the generic `ChannelChart`, driven by `channels.ts`.
+// TELEMETRY section (issue #34, §6.1; round 2 adds Accel): 8 per-channel
+// charts — Speed, Delta, Throttle, Brake, RPM, Gear, Accel, DRS — in a
+// grid<->stack layout, each plotting one line per loaded driver against
+// distance. The first 7 (everything but Accel) match the render order in
+// frontend/pages/dashboard.py; Accel has no Streamlit precedent, inserted
+// between Gear and DRS (channels.ts) to fill the grid's lonely last-row DRS
+// slot. Delta is cross-driver (needs a reference lap) so it renders through
+// the dedicated `DeltaChart`; the other 7 channels share the generic
+// `ChannelChart`, driven by `channels.ts`.
 //
 // Data comes from `useLapTelemetries`, keyed by the store's
 // `selectedLapsPerDriver` (the lap chart writes to it on click-to-load).
@@ -109,7 +112,9 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
 
   // Speed leads, Delta is hardcoded second (cross-driver, not part of
   // CHANNELS), then the rest of CHANNELS in their declared order — matches
-  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs).
+  // dashboard.py's render order (speed/delta/throttle/brake/rpm/gear/drs)
+  // with Accel (round 2) inserted before drs, yielding 8 grid slots:
+  // [Speed·Delta] [Throttle·Brake] [RPM·Gear] [Accel·DRS].
   const [speedChannel, ...restChannels] = CHANNELS
 
   return (

--- a/webapp/src/features/dashboard/components/TelemetryGrid.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryGrid.tsx
@@ -11,12 +11,14 @@
 // instead of a chart — Víctor's hard requirement, see TelemetryLoader.tsx.
 
 import type { ReactNode } from 'react'
+import { TriangleAlert } from 'lucide-react'
 import { ChartCard } from '@/components/ChartCard'
 import { Button } from '@/components/Button'
 import { cn } from '@/lib/cn'
 import type { DashboardSearch } from '../search'
 import { useLapTelemetries } from '../queries'
 import { useDashboardStore, type ChartLayout } from '../store'
+import { SectionHeader } from './SectionHeader'
 import { TelemetryLoader } from './TelemetryLoader'
 import { ChannelChart, DeltaChart } from './ChannelChart'
 import { CHANNELS, DELTA_TITLE } from './channels'
@@ -61,7 +63,7 @@ function NoTelemetryNotice({ failedDrivers }: { failedDrivers: string[] }) {
       role="status"
       className="flex items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-6 text-sm text-fg-2"
     >
-      <span aria-hidden="true">⚠️</span>
+      <TriangleAlert className="size-5 shrink-0 text-warning" aria-hidden="true" />
       <span>{noTelemetryMessage(failedDrivers)}</span>
     </div>
   )
@@ -112,10 +114,9 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <h2 className="font-display text-lg tracking-wide text-fg-2 uppercase">Telemetry</h2>
+      <SectionHeader title="Telemetry">
         <LayoutToggle layout={chartLayout} onToggle={toggleChartLayout} />
-      </div>
+      </SectionHeader>
 
       {settledEmpty ? (
         <NoTelemetryNotice failedDrivers={failedDrivers} />
@@ -126,7 +127,7 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
           ) : null}
 
           <div className={cn(LAYOUT_CLASSNAMES[chartLayout])}>
-            <TelemetryCard title={speedChannel.title} hasAny={hasAny}>
+            <TelemetryCard title={speedChannel.yName} hasAny={hasAny}>
               <ChannelChart
                 title={speedChannel.title}
                 byDriver={byDriver}
@@ -137,11 +138,11 @@ export function TelemetryGrid({ search }: TelemetryGridProps) {
             </TelemetryCard>
 
             <TelemetryCard title={DELTA_TITLE} hasAny={hasAny}>
-              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} />
+              <DeltaChart byDriver={byDriver} drivers={drivers} year={year} isLoading={isLoading} />
             </TelemetryCard>
 
             {restChannels.map((channel) => (
-              <TelemetryCard key={channel.key} title={channel.title} hasAny={hasAny}>
+              <TelemetryCard key={channel.key} title={channel.yName} hasAny={hasAny}>
                 <ChannelChart
                   title={channel.title}
                   byDriver={byDriver}

--- a/webapp/src/features/dashboard/components/TelemetryLoader.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryLoader.tsx
@@ -1,0 +1,50 @@
+// The "Waiting for telemetry data…" loader, kept 1:1 from Streamlit (a
+// ScaleLoader — 5 purple bars pulsing on a staggered delay). Shown by the
+// telemetry charts and the circuit map before a lap's telemetry is loaded.
+// Víctor's hard requirement: preserve this loading state before charts render.
+
+interface TelemetryLoaderProps {
+  /** Message under the bars. Defaults to the Streamlit copy. */
+  label?: string
+  /** Container min-height in px (charts use 400, matching Streamlit). */
+  minHeight?: number
+}
+
+const BAR_COLOR = '#a78bfa'
+const BAR_COUNT = 5
+
+export function TelemetryLoader({
+  label = 'Waiting for telemetry data...',
+  minHeight = 400,
+}: TelemetryLoaderProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-hairline"
+      style={{ minHeight }}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-end gap-1.5" aria-hidden="true">
+        {Array.from({ length: BAR_COUNT }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              display: 'inline-block',
+              width: 6,
+              height: 35,
+              background: BAR_COLOR,
+              borderRadius: 2,
+              animation: 'f1-scaleloader 1s ease-in-out infinite',
+              animationDelay: `${i * 0.1}s`,
+            }}
+          />
+        ))}
+      </div>
+      <p className="text-sm text-fg-2">{label}</p>
+      <style>{`@keyframes f1-scaleloader {
+        0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
+        20% { transform: scaleY(1); opacity: 1; }
+      }`}</style>
+    </div>
+  )
+}

--- a/webapp/src/features/dashboard/components/TelemetryLoader.tsx
+++ b/webapp/src/features/dashboard/components/TelemetryLoader.tsx
@@ -2,6 +2,27 @@
 // ScaleLoader — 5 purple bars pulsing on a staggered delay). Shown by the
 // telemetry charts and the circuit map before a lap's telemetry is loaded.
 // Víctor's hard requirement: preserve this loading state before charts render.
+//
+// The `@keyframes` are injected ONCE at module load (guarded by a DOM id, not
+// just a JS boolean, so a Vite HMR re-evaluation of this module can't leave a
+// duplicate behind) rather than per mount — up to 7 TelemetryGrid cards can
+// render this loader at the same time while laps are still loading, and a
+// `<style>` tag per instance would mean 7 copies of the same rule.
+
+const KEYFRAMES_ID = 'f1-telemetry-loader-keyframes'
+
+function ensureKeyframesInjected(): void {
+  if (typeof document === 'undefined' || document.getElementById(KEYFRAMES_ID)) return
+  const style = document.createElement('style')
+  style.id = KEYFRAMES_ID
+  style.textContent = `@keyframes f1-scaleloader {
+    0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
+    20% { transform: scaleY(1); opacity: 1; }
+  }`
+  document.head.appendChild(style)
+}
+
+ensureKeyframesInjected()
 
 interface TelemetryLoaderProps {
   /** Message under the bars. Defaults to the Streamlit copy. */
@@ -10,7 +31,7 @@ interface TelemetryLoaderProps {
   minHeight?: number
 }
 
-const BAR_COLOR = '#a78bfa'
+const BAR_COLOR = 'var(--purple-300)'
 const BAR_COUNT = 5
 
 export function TelemetryLoader({
@@ -26,25 +47,25 @@ export function TelemetryLoader({
     >
       <div className="flex items-end gap-1.5" aria-hidden="true">
         {Array.from({ length: BAR_COUNT }).map((_, i) => (
+          // The animation itself lives in a class (not inline style) so
+          // `motion-reduce:animate-none` can win outright — a static bar,
+          // not just a faster one — for anyone with reduced-motion set.
+          // Only the per-bar stagger (`animationDelay`) needs to stay inline.
           <span
             key={i}
+            className="animate-[f1-scaleloader_1s_ease-in-out_infinite] motion-reduce:animate-none"
             style={{
               display: 'inline-block',
               width: 6,
               height: 35,
               background: BAR_COLOR,
               borderRadius: 2,
-              animation: 'f1-scaleloader 1s ease-in-out infinite',
               animationDelay: `${i * 0.1}s`,
             }}
           />
         ))}
       </div>
       <p className="text-sm text-fg-2">{label}</p>
-      <style>{`@keyframes f1-scaleloader {
-        0%, 40%, 100% { transform: scaleY(0.4); opacity: 0.6; }
-        20% { transform: scaleY(1); opacity: 1; }
-      }`}</style>
     </div>
   )
 }

--- a/webapp/src/features/dashboard/components/accel.test.ts
+++ b/webapp/src/features/dashboard/components/accel.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { longitudinalAccelG } from './channels'
+import type { LapTelemetry } from '@/lib/api/telemetry'
+
+/** Builds a minimal `LapTelemetry` fixture — `longitudinalAccelG` only reads
+ *  `speed`/`time`, the other channels are filled with zeros to satisfy the
+ *  interface. */
+function telemetry(speed: number[], time: number[]): LapTelemetry {
+  return {
+    driver: 'VER',
+    lap_number: 1,
+    distance: speed.map((_, i) => i),
+    time,
+    speed,
+    throttle: speed.map(() => 0),
+    brake: speed.map(() => 0),
+    rpm: speed.map(() => 0),
+    gear: speed.map(() => 0),
+    drs: speed.map(() => 0),
+  }
+}
+
+describe('longitudinalAccelG', () => {
+  it('reads ~1g on a constant-acceleration ramp', () => {
+    // 5 Hz-ish sampling (dt = 0.2s), speed climbing at exactly 1g the whole way.
+    const dt = 0.2
+    const accelStepKmh = 9.81 * 3.6 * dt // km/h gained per sample at 1g
+    const time = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    const speed = time.map((_, i) => i * accelStepKmh)
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    expect(g).toHaveLength(6)
+    for (const value of g) {
+      expect(value).toBeCloseTo(1, 5)
+    }
+  })
+
+  it('reads ~0g on a flat speed trace', () => {
+    const time = [0, 0.2, 0.4, 0.6, 0.8]
+    const speed = time.map(() => 220)
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    for (const value of g) {
+      expect(value).toBeCloseTo(0, 5)
+    }
+  })
+
+  it('carries the previous value through a repeated timestamp instead of NaN/Infinity', () => {
+    // time[3] === time[1] makes the central-difference dt at i=2 zero.
+    const time = [0, 0.2, 0.2, 0.2, 0.4]
+    const speed = [100, 110, 112, 115, 120]
+
+    const g = longitudinalAccelG(telemetry(speed, time))
+
+    expect(g).toHaveLength(5)
+    for (const value of g) {
+      expect(Number.isFinite(value)).toBe(true)
+      expect(Number.isNaN(value)).toBe(false)
+    }
+  })
+
+  it('returns an empty array for empty telemetry', () => {
+    expect(longitudinalAccelG(telemetry([], []))).toEqual([])
+  })
+})

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -33,6 +33,11 @@ export interface ChannelConfig {
    *  gear and DRS are discrete states (gear_graph.py / drs_graph.py both use
    *  a step shape for this reason), not continuous quantities. */
   stepped?: boolean
+  /** Renders as a filled state band (shorter chart, ~35%-opacity area under
+   *  the line) instead of the standard telemetry line — DRS is really an
+   *  on/off state, not a quantity to trace, so a band reads more like
+   *  "engaged" than a thin 0/1 line does. */
+  band?: boolean
   yAxis?: ChannelYAxis
   /** Extracts the plotted series from a driver's telemetry. */
   transform: (telemetry: LapTelemetry) => number[]
@@ -74,6 +79,7 @@ export const CHANNELS: ChannelConfig[] = [
     title: 'DRS',
     yName: 'DRS',
     stepped: true,
+    band: true,
     yAxis: {
       min: 0,
       max: 1,

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -1,15 +1,19 @@
-// Channel configs for the TELEMETRY grid (issue #34, §6.1). Six of the seven
-// charts (everything but Delta) are pure "plot this array against distance"
-// jobs and share the generic `ChannelChart` component — this file is that
-// shared data. Delta is cross-driver (it diffs every loaded lap against a
-// reference lap's interpolated time, not a single telemetry array) so it
-// gets its own `DeltaChart` component in ChannelChart.tsx instead of an
-// entry here; `DELTA_TITLE` is exported so its ChartCard heading still lives
-// next to the other six.
+// Channel configs for the TELEMETRY grid (issue #34, §6.1). Seven of the
+// eight charts (everything but Delta) are pure "plot this array against
+// distance" jobs and share the generic `ChannelChart` component — this file
+// is that shared data. Delta is cross-driver (it diffs every loaded lap
+// against a reference lap's interpolated time, not a single telemetry
+// array) so it gets its own `DeltaChart` component in ChannelChart.tsx
+// instead of an entry here; `DELTA_TITLE` is exported so its ChartCard
+// heading still lives next to the other seven.
 //
 // Streamlit parity: frontend/components/telemetry/{speed,throttle,brake,rpm,
 // gear,drs}_graph.py. `transform` mirrors each module's data-prep step (only
 // DRS transforms its raw values; the rest plot the FastF1 array as-is).
+// `accel` (round 2, issue #34 follow-up) has no Streamlit precedent — it's
+// derived client-side from `speed`/`time`, added to fill the grid's lonely
+// last-row DRS slot with a real race-engineering channel instead of dead
+// space.
 
 import type { LapTelemetry } from '@/lib/api/telemetry'
 
@@ -24,7 +28,7 @@ export interface ChannelYAxis {
 }
 
 export interface ChannelConfig {
-  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'drs'
+  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'accel' | 'drs'
   /** ChartCard header + chart title. */
   title: string
   /** Y-axis name shown on the chart. */
@@ -41,6 +45,63 @@ export interface ChannelConfig {
   yAxis?: ChannelYAxis
   /** Extracts the plotted series from a driver's telemetry. */
   transform: (telemetry: LapTelemetry) => number[]
+}
+
+const GRAVITY_MS2 = 9.81
+const KMH_PER_MS = 3.6
+
+/**
+ * Longitudinal acceleration in g, derived from the `speed`/`time` arrays
+ * already present on every `lap-telemetry` response — no new backend field.
+ * Central difference over the interior samples (`a[i] = ((v[i+1]-v[i-1]) /
+ * 3.6) / (t[i+1]-t[i-1]) / 9.81`, km/h -> m/s -> g), one-sided at the two
+ * endpoints (nothing to average with past the edge), then a 3-point moving
+ * average (`movingAverage3`) to tame FastF1's ~4-5 Hz sampling noise:
+ * differentiating a sampled-and-quantized speed signal amplifies its own
+ * noise, so the raw central difference would jitter point-to-point instead
+ * of tracing the clean braking/traction zones this channel exists to show.
+ *
+ * A repeated timestamp (`dt === 0`, seen in FastF1's telemetry
+ * interpolation) would otherwise divide by zero; that sample instead
+ * carries the previous point's value forward so the trace stays finite
+ * (no NaN/Infinity) rather than poisoning the whole line.
+ */
+export function longitudinalAccelG(telemetry: LapTelemetry): number[] {
+  const { speed, time } = telemetry
+  const sampleCount = speed.length
+  if (sampleCount === 0) return []
+
+  const raw: number[] = new Array(sampleCount)
+  for (let i = 0; i < sampleCount; i++) {
+    const lo = i === 0 ? 0 : i - 1
+    const hi = i === sampleCount - 1 ? sampleCount - 1 : i + 1
+    const dt = time[hi] - time[lo]
+    if (dt === 0) {
+      raw[i] = i === 0 ? 0 : raw[i - 1]
+      continue
+    }
+    const deltaSpeedMs = (speed[hi] - speed[lo]) / KMH_PER_MS
+    raw[i] = deltaSpeedMs / dt / GRAVITY_MS2
+  }
+
+  return movingAverage3(raw)
+}
+
+/**
+ * Boundary-aware 3-point moving average: a 2-point average at the two
+ * endpoints (no data past the edge to average with), a 3-point average
+ * everywhere else. Used to smooth `longitudinalAccelG`'s central-difference
+ * noise without losing the endpoint samples.
+ */
+function movingAverage3(values: number[]): number[] {
+  const n = values.length
+  return values.map((_, i) => {
+    const lo = Math.max(0, i - 1)
+    const hi = Math.min(n - 1, i + 1)
+    let sum = 0
+    for (let j = lo; j <= hi; j++) sum += values[j]
+    return sum / (hi - lo + 1)
+  })
 }
 
 /**
@@ -73,6 +134,14 @@ export const CHANNELS: ChannelConfig[] = [
     // min 0 so neutral (nGear=0, seen at launch / in the pits) isn't clipped.
     yAxis: { min: 0, max: 8, interval: 1 },
     transform: (t) => t.gear,
+  },
+  {
+    key: 'accel',
+    title: 'Longitudinal Accel',
+    yName: 'Long. Accel (g)',
+    // No explicit yAxis: `scale: true` (baseOption's default) autoranges
+    // around the data, same as Speed/RPM/Delta.
+    transform: longitudinalAccelG,
   },
   {
     key: 'drs',

--- a/webapp/src/features/dashboard/components/channels.ts
+++ b/webapp/src/features/dashboard/components/channels.ts
@@ -1,0 +1,85 @@
+// Channel configs for the TELEMETRY grid (issue #34, §6.1). Six of the seven
+// charts (everything but Delta) are pure "plot this array against distance"
+// jobs and share the generic `ChannelChart` component — this file is that
+// shared data. Delta is cross-driver (it diffs every loaded lap against a
+// reference lap's interpolated time, not a single telemetry array) so it
+// gets its own `DeltaChart` component in ChannelChart.tsx instead of an
+// entry here; `DELTA_TITLE` is exported so its ChartCard heading still lives
+// next to the other six.
+//
+// Streamlit parity: frontend/components/telemetry/{speed,throttle,brake,rpm,
+// gear,drs}_graph.py. `transform` mirrors each module's data-prep step (only
+// DRS transforms its raw values; the rest plot the FastF1 array as-is).
+
+import type { LapTelemetry } from '@/lib/api/telemetry'
+
+export const DELTA_TITLE = 'Delta'
+
+export interface ChannelYAxis {
+  min?: number
+  max?: number
+  interval?: number
+  /** Custom tick label, e.g. DRS's 0/1 -> "Disabled"/"Enabled". */
+  formatter?: (value: number) => string
+}
+
+export interface ChannelConfig {
+  key: 'speed' | 'throttle' | 'brake' | 'rpm' | 'gear' | 'drs'
+  /** ChartCard header + chart title. */
+  title: string
+  /** Y-axis name shown on the chart. */
+  yName: string
+  /** 'end' draws a stairstep line instead of interpolating between samples —
+   *  gear and DRS are discrete states (gear_graph.py / drs_graph.py both use
+   *  a step shape for this reason), not continuous quantities. */
+  stepped?: boolean
+  yAxis?: ChannelYAxis
+  /** Extracts the plotted series from a driver's telemetry. */
+  transform: (telemetry: LapTelemetry) => number[]
+}
+
+/**
+ * DRS reads "open" only once actively deployed. FastF1 values 10/12/14 mean
+ * on; 0-1 is off and 2-8 covers intermediate/eligible-but-not-open states.
+ * Mirrors drs_graph.py's `_process_drs_data`.
+ */
+function binarizeDrs(telemetry: LapTelemetry): number[] {
+  return telemetry.drs.map((value) => (value >= 10 ? 1 : 0))
+}
+
+const DRS_TICKS: Record<number, string> = { 0: 'Disabled', 1: 'Enabled' }
+
+export const CHANNELS: ChannelConfig[] = [
+  { key: 'speed', title: 'Speed', yName: 'Speed (km/h)', transform: (t) => t.speed },
+  {
+    key: 'throttle',
+    title: 'Throttle',
+    yName: 'Throttle (%)',
+    yAxis: { min: 0, max: 100 },
+    transform: (t) => t.throttle,
+  },
+  { key: 'brake', title: 'Brake', yName: 'Brake', transform: (t) => t.brake },
+  { key: 'rpm', title: 'RPM', yName: 'RPM', transform: (t) => t.rpm },
+  {
+    key: 'gear',
+    title: 'Gear',
+    yName: 'Gear',
+    stepped: true,
+    // min 0 so neutral (nGear=0, seen at launch / in the pits) isn't clipped.
+    yAxis: { min: 0, max: 8, interval: 1 },
+    transform: (t) => t.gear,
+  },
+  {
+    key: 'drs',
+    title: 'DRS',
+    yName: 'DRS',
+    stepped: true,
+    yAxis: {
+      min: 0,
+      max: 1,
+      interval: 1,
+      formatter: (value) => DRS_TICKS[value] ?? String(value),
+    },
+    transform: binarizeDrs,
+  },
+]

--- a/webapp/src/features/dashboard/components/circuitDraw.ts
+++ b/webapp/src/features/dashboard/components/circuitDraw.ts
@@ -1,0 +1,104 @@
+// Pure geometry helpers for the Circuit Domination map. The backend already
+// did all the hard work (rotation, scaling, per-microsector dominant driver);
+// these functions only turn its raw x/y/colors arrays into something an SVG
+// can draw without distorting the track shape.
+//
+// Two things an SVG needs help with that the backend data doesn't provide:
+//  1. Aspect-ratio lock — track x/y are in real-world units (metres), and a
+//     naive "fit width x fit height" would stretch the circuit. Mirrors
+//     Plotly's `scaleanchor="y"` / matplotlib's `axis('equal')` from the
+//     original Streamlit chart (circuit_domination.py::_create_circuit_figure).
+//  2. Y-flip — track y is mathematical (up = positive), SVG y grows downward,
+//     so plotting raw y values renders the track upside down.
+
+/** Bounding box of a coordinate list, in track units. */
+export interface Bounds {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+/** One drawable segment: point[i] -> point[i+1], coloured by that
+ *  microsector's dominant driver. Coordinates are already y-flipped. */
+export interface Segment {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  color: string
+}
+
+/** Extra room around the track so segments near the edge aren't clipped by
+ *  the viewBox, as a fraction of each axis's range. */
+const VIEWBOX_PADDING_RATIO = 0.06
+
+/** Fallback stroke colour for a segment whose driver colour is missing,
+ *  matching the neutral grey used elsewhere for "no data". */
+const FALLBACK_SEGMENT_COLOR = '#94a3b8'
+
+/**
+ * Bounding box of the track's x/y coordinates.
+ * Falls back to a degenerate 0..1 box for empty input so downstream ratio
+ * math (division by range) never divides by zero.
+ */
+export function computeBounds(x: number[], y: number[]): Bounds {
+  if (x.length === 0 || y.length === 0) {
+    return { minX: 0, maxX: 1, minY: 0, maxY: 1 }
+  }
+  return {
+    minX: Math.min(...x),
+    maxX: Math.max(...x),
+    minY: Math.min(...y),
+    maxY: Math.max(...y),
+  }
+}
+
+/** Flip track y (mathematical, up = positive) to SVG-local y (down = positive). */
+export function flipY(y: number): number {
+  return -y
+}
+
+/**
+ * SVG `viewBox` string ("minX minY width height") for the given bounds, with
+ * padding. Locking the aspect ratio to the track's own width/height and
+ * relying on SVG's default `preserveAspectRatio="xMidYMid meet"` is what
+ * fits + centers the track without distortion, no manual pixel scaling
+ * needed on the component side.
+ */
+export function computeViewBox(bounds: Bounds): string {
+  const rangeX = Math.max(bounds.maxX - bounds.minX, 1e-6)
+  const rangeY = Math.max(bounds.maxY - bounds.minY, 1e-6)
+  const padX = rangeX * VIEWBOX_PADDING_RATIO
+  const padY = rangeY * VIEWBOX_PADDING_RATIO
+
+  // After the y-flip, the track's old maxY becomes the new (smaller) minY.
+  const flippedMinY = flipY(bounds.maxY)
+  const minX = bounds.minX - padX
+  const minY = flippedMinY - padY
+  const width = rangeX + 2 * padX
+  const height = rangeY + 2 * padY
+
+  return `${minX} ${minY} ${width} ${height}`
+}
+
+/**
+ * Builds one line segment per consecutive coordinate pair, each carrying the
+ * colour of the driver who dominated that microsector. `colors[i]` paints
+ * the segment from `point[i]` to `point[i+1]` (so `colors.length === x.length - 1`
+ * on well-formed data); a mismatched length is tolerated defensively.
+ */
+export function buildSegments(x: number[], y: number[], colors: string[]): Segment[] {
+  const segmentCount = Math.min(x.length, y.length) - 1
+  const segments: Segment[] = []
+  for (let i = 0; i < segmentCount; i++) {
+    segments.push({
+      x1: x[i],
+      y1: flipY(y[i]),
+      x2: x[i + 1],
+      y2: flipY(y[i + 1]),
+      color: colors[i] ?? FALLBACK_SEGMENT_COLOR,
+    })
+  }
+  return segments
+}

--- a/webapp/src/features/dashboard/components/circuitDraw.ts
+++ b/webapp/src/features/dashboard/components/circuitDraw.ts
@@ -83,6 +83,23 @@ export function computeViewBox(bounds: Bounds): string {
 }
 
 /**
+ * Builds the SVG `points` attribute for a `<polyline>` tracing every track
+ * coordinate in order (y-flipped, same convention as `buildSegments`). Drawn
+ * once as a faint continuous outline underneath the coloured microsector
+ * segments, so gaps between segments (there is no line between the last
+ * point of one microsector and the first of the next) don't read as a
+ * broken track.
+ */
+export function buildOutlinePath(x: number[], y: number[]): string {
+  const pointCount = Math.min(x.length, y.length)
+  const points: string[] = []
+  for (let i = 0; i < pointCount; i++) {
+    points.push(`${x[i]},${flipY(y[i])}`)
+  }
+  return points.join(' ')
+}
+
+/**
  * Builds one line segment per consecutive coordinate pair, each carrying the
  * colour of the driver who dominated that microsector. `colors[i]` paints
  * the segment from `point[i]` to `point[i+1]` (so `colors.length === x.length - 1`

--- a/webapp/src/features/dashboard/lib/compounds.ts
+++ b/webapp/src/features/dashboard/lib/compounds.ts
@@ -1,0 +1,57 @@
+// Tyre-compound presentation helpers, matching the Streamlit dashboard:
+// compounds are shown in the lap-chart HOVER (emoji + capitalised name) and in
+// the compound legend (per-driver lap counts). Points/lines themselves are
+// coloured by DRIVER, never by compound (see LapChart).
+//
+// FastF1 returns compound lowercase ('soft'|'medium'|'hard'|'intermediate'|
+// 'inter'|'wet'|'unknown'). `inter` is an alias of `intermediate`.
+
+/** Canonical Pill `compound` variant values (uppercase), for the legend pills. */
+export type CompoundVariant = 'SOFT' | 'MEDIUM' | 'HARD' | 'INTERMEDIATE' | 'WET'
+
+const EMOJI: Record<string, string> = {
+  soft: '🔴',
+  medium: '🟡',
+  hard: '⚪',
+  intermediate: '🟢',
+  inter: '🟢',
+  wet: '🔵',
+}
+const UNKNOWN_EMOJI = '⚫'
+
+// Display order used by the legend (Streamlit: soft→medium→hard→inter→wet).
+export const COMPOUND_ORDER = ['soft', 'medium', 'hard', 'intermediate', 'inter', 'wet']
+
+/** Emoji marker for a compound (hover text). */
+export function compoundEmoji(compound: string): string {
+  return EMOJI[compound.toLowerCase()] ?? UNKNOWN_EMOJI
+}
+
+/** Human label, capitalised (e.g. 'medium' → 'Medium'). */
+export function compoundLabel(compound: string): string {
+  if (!compound) return 'Unknown'
+  const lower = compound.toLowerCase()
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
+}
+
+/**
+ * Map a raw FastF1 compound to the Pill `compound` variant, or null when it
+ * has no branded colour (unknown). `inter` folds into INTERMEDIATE.
+ */
+export function compoundVariant(compound: string): CompoundVariant | null {
+  switch (compound.toLowerCase()) {
+    case 'soft':
+      return 'SOFT'
+    case 'medium':
+      return 'MEDIUM'
+    case 'hard':
+      return 'HARD'
+    case 'intermediate':
+    case 'inter':
+      return 'INTERMEDIATE'
+    case 'wet':
+      return 'WET'
+    default:
+      return null
+  }
+}

--- a/webapp/src/features/dashboard/lib/drivers.ts
+++ b/webapp/src/features/dashboard/lib/drivers.ts
@@ -119,6 +119,44 @@ export function getDriverColor(code: string, year?: number): string {
   return DRIVER_COLORS_FLAT[key] ?? DEFAULT_DRIVER_COLOR
 }
 
+// --- Legibility floor ---------------------------------------------------------
+// Some real team colours are near-black on the dark UI (Williams #041E42, the
+// Red Bull #2 #1B3D8E): fine as a thick chart line, invisible as text or a thin
+// swatch. `getDriverTextColor` brightens only those below a luminance threshold,
+// so driver NAMES stay team-coloured AND readable. This deviates from strict
+// Streamlit parity on purpose (a designed improvement).
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '')
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+
+/** WCAG relative luminance (0 = black, 1 = white). */
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (c: number) => {
+    const s = c / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+function mixToward([r, g, b]: [number, number, number], target: number, amount: number): string {
+  const mix = (c: number) => Math.round(c + (target - c) * amount)
+  const toHex = (c: number) => mix(c).toString(16).padStart(2, '0')
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+// Below this luminance a colour is too dark to read as text on the dark UI.
+const TEXT_LUMINANCE_FLOOR = 0.16
+
+/** Team colour for a driver, brightened toward white when too dark to read as text. */
+export function getDriverTextColor(code: string, year?: number): string {
+  const base = getDriverColor(code, year)
+  const rgb = hexToRgb(base)
+  if (relativeLuminance(rgb) >= TEXT_LUMINANCE_FLOOR) return base
+  return mixToward(rgb, 255, 0.5)
+}
+
 /** Build a `{ driver: colour }` map for the selected drivers. */
 export function driverColorMap(drivers: string[], year?: number): Record<string, string> {
   const map: Record<string, string> = {}

--- a/webapp/src/features/dashboard/lib/drivers.ts
+++ b/webapp/src/features/dashboard/lib/drivers.ts
@@ -1,0 +1,127 @@
+// Year-aware driver → team colour palette, ported 1:1 from the Streamlit
+// original (`frontend/components/common/driver_colors.py`) so the migrated
+// charts keep IDENTICAL colours. Each driver gets their team's colour for that
+// season (2023-2025 lineups). Keep in sync with the Python source if lineups
+// change.
+
+const RED_BULL = '#3671C6'
+const RED_BULL_2 = '#1B3D8E'
+const FERRARI = '#E8002D'
+const FERRARI_2 = '#A30000'
+const MERCEDES = '#27F4D2'
+const MERCEDES_2 = '#6CD3BF'
+const MCLAREN = '#FF8700'
+const MCLAREN_2 = '#FFB347'
+const ASTON = '#229971'
+const ASTON_2 = '#2BA572'
+const ALPINE_PINK = '#FF87BC'
+const ALPINE_PINK_2 = '#FFC0E3'
+const ALPINE_BLUE = '#0093CC'
+const ALPINE_BLUE_2 = '#00B0F0'
+const WILLIAMS = '#041E42'
+const WILLIAMS_2 = '#64C4FF'
+const RB = '#6692FF'
+const RB_2 = '#4682B4'
+const SAUBER = '#52E252'
+const SAUBER_2 = '#00E701'
+const HAAS = '#B6BABD'
+const HAAS_2 = '#787878'
+
+/** Fallback colour for a driver absent from the season map. */
+export const DEFAULT_DRIVER_COLOR = '#A259F7'
+
+const DRIVER_COLORS_BY_YEAR: Record<number, Record<string, string>> = {
+  2025: {
+    VER: RED_BULL,
+    LAW: RED_BULL_2,
+    LEC: FERRARI,
+    HAM: FERRARI_2,
+    RUS: MERCEDES,
+    ANT: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_BLUE,
+    DOO: ALPINE_BLUE_2,
+    ALB: WILLIAMS_2,
+    SAI: WILLIAMS,
+    TSU: RB,
+    HAD: RB_2,
+    HUL: SAUBER,
+    BOR: SAUBER_2,
+    OCO: HAAS,
+    BEA: HAAS_2,
+  },
+  2024: {
+    VER: RED_BULL,
+    PER: RED_BULL_2,
+    LEC: FERRARI,
+    SAI: FERRARI_2,
+    HAM: MERCEDES,
+    RUS: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_PINK,
+    OCO: ALPINE_PINK_2,
+    ALB: WILLIAMS_2,
+    SAR: WILLIAMS,
+    COL: WILLIAMS,
+    TSU: RB,
+    RIC: '#F5F5F5',
+    LAW: RB_2,
+    BOT: SAUBER,
+    ZHO: SAUBER_2,
+    MAG: HAAS_2,
+    HUL: HAAS,
+    BEA: HAAS,
+  },
+  2023: {
+    VER: RED_BULL,
+    PER: RED_BULL_2,
+    LEC: FERRARI,
+    SAI: FERRARI_2,
+    HAM: MERCEDES,
+    RUS: MERCEDES_2,
+    NOR: MCLAREN,
+    PIA: MCLAREN_2,
+    ALO: ASTON,
+    STR: ASTON_2,
+    GAS: ALPINE_PINK,
+    OCO: ALPINE_PINK_2,
+    ALB: WILLIAMS_2,
+    SAR: WILLIAMS,
+    TSU: RB,
+    RIC: '#F5F5F5',
+    LAW: RB_2,
+    BOT: SAUBER,
+    ZHO: SAUBER_2,
+    MAG: HAAS_2,
+    HUL: HAAS,
+  },
+}
+
+// Flat fallback = 2025 colours (mirrors the Python `DRIVER_COLORS`).
+const DRIVER_COLORS_FLAT = DRIVER_COLORS_BY_YEAR[2025]
+
+/**
+ * Team colour for a driver in a given season.
+ * @param code Three-letter driver code (case-insensitive).
+ * @param year Season year; when omitted uses the flat 2025 fallback.
+ */
+export function getDriverColor(code: string, year?: number): string {
+  const key = code.toUpperCase()
+  if (year && DRIVER_COLORS_BY_YEAR[year]) {
+    return DRIVER_COLORS_BY_YEAR[year][key] ?? DEFAULT_DRIVER_COLOR
+  }
+  return DRIVER_COLORS_FLAT[key] ?? DEFAULT_DRIVER_COLOR
+}
+
+/** Build a `{ driver: colour }` map for the selected drivers. */
+export function driverColorMap(drivers: string[], year?: number): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const code of drivers) map[code] = getDriverColor(code, year)
+  return map
+}

--- a/webapp/src/features/dashboard/lib/fastestLap.ts
+++ b/webapp/src/features/dashboard/lib/fastestLap.ts
@@ -1,0 +1,21 @@
+import type { LapTime } from '@/lib/api/telemetry'
+
+/**
+ * Each driver's fastest lap NUMBER (by `lap_time`), computed from the full
+ * (unfiltered) lap set — the outlier/invalid toggles must not hide a driver's
+ * genuine fastest lap. Drives both the SELECT FASTEST LAPS button and the
+ * auto-load-on-selection behaviour.
+ */
+export function fastestLapPerDriver(
+  lapTimes: LapTime[],
+  drivers: string[],
+): Record<string, number> {
+  const fastest: Record<string, number> = {}
+  for (const driver of drivers) {
+    const driverLaps = lapTimes.filter((lap) => lap.driver === driver)
+    if (driverLaps.length === 0) continue
+    const quickest = driverLaps.reduce((best, lap) => (lap.lap_time < best.lap_time ? lap : best))
+    fastest[driver] = quickest.lap_number
+  }
+  return fastest
+}

--- a/webapp/src/features/dashboard/lib/lapTime.ts
+++ b/webapp/src/features/dashboard/lib/lapTime.ts
@@ -1,0 +1,20 @@
+// Lap-time formatting. The Streamlit lap chart shows MM:SS ticks on the y-axis
+// (integer seconds, no milliseconds — matching `utils/time_formatters.py`),
+// while hover shows the finer M:SS.mmm value.
+
+/** Seconds → "M:SS" (integer seconds), for axis ticks. e.g. 79.4 → "1:19". */
+export function formatLapTimeAxis(seconds: number): string {
+  const total = Math.round(seconds)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+/** Seconds → "M:SS.mmm", for hover / precise readouts. e.g. 79.367 → "1:19.367". */
+export function formatLapTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const rem = seconds - mins * 60
+  const secs = Math.floor(rem)
+  const millis = Math.round((rem - secs) * 1000)
+  return `${mins}:${secs.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`
+}

--- a/webapp/src/features/dashboard/lib/outliers.test.ts
+++ b/webapp/src/features/dashboard/lib/outliers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { applyLapFilters, detectOutlierIndices } from './outliers'
+import type { LapTime } from '@/lib/api/telemetry'
+
+function lap(driver: string, lap_number: number, lap_time: number): LapTime {
+  return { driver, lap_number, lap_time, is_valid: true, compound: 'medium' }
+}
+
+describe('detectOutlierIndices', () => {
+  it('skips drivers with fewer than 4 laps', () => {
+    const laps = [lap('VER', 1, 80), lap('VER', 2, 200), lap('VER', 3, 81)]
+    expect(detectOutlierIndices(laps).size).toBe(0)
+  })
+
+  it('flags a high outlier with the 1.5×IQR index-quartile rule', () => {
+    // 8 tight laps (~79s) + one 120s lap. n=9 → q1=idx2, q3=idx6 on sorted.
+    const times = [79.0, 79.1, 79.2, 79.3, 79.4, 79.5, 79.6, 79.7, 120.0]
+    const laps = times.map((t, i) => lap('VER', i + 1, t))
+    const outliers = detectOutlierIndices(laps)
+    expect(outliers.has(8)).toBe(true) // the 120s lap
+    expect(outliers.size).toBe(1)
+  })
+
+  it('computes outliers per driver independently', () => {
+    const ver = [79.0, 79.1, 79.2, 79.3, 130.0].map((t, i) => lap('VER', i + 1, t))
+    const lec = [80.0, 80.1, 80.2, 80.3].map((t, i) => lap('LEC', i + 1, t))
+    const outliers = detectOutlierIndices([...ver, ...lec])
+    expect(outliers.has(4)).toBe(true) // VER's 130s lap (index 4 overall)
+    expect([...outliers].every((i) => i < 5)).toBe(true) // none from LEC
+  })
+})
+
+describe('applyLapFilters', () => {
+  const laps = [79.0, 79.1, 79.2, 79.3, 79.4, 79.5, 79.6, 79.7, 120.0].map((t, i) =>
+    lap('VER', i + 1, t),
+  )
+
+  it('hides outliers when showOutliers is false', () => {
+    const { visible, outlierCount } = applyLapFilters(laps, false, true)
+    expect(outlierCount).toBe(1)
+    expect(visible).toHaveLength(8)
+  })
+
+  it('keeps outliers when showOutliers is true', () => {
+    const { visible } = applyLapFilters(laps, true, true)
+    expect(visible).toHaveLength(9)
+  })
+
+  it('invalid filter is a no-op with the current backend shape', () => {
+    const { visible, invalidCount } = applyLapFilters(laps, true, false)
+    expect(invalidCount).toBe(0)
+    expect(visible).toHaveLength(9)
+  })
+})

--- a/webapp/src/features/dashboard/lib/outliers.ts
+++ b/webapp/src/features/dashboard/lib/outliers.ts
@@ -1,0 +1,95 @@
+// Client-side lap filtering, ported 1:1 from the Streamlit dashboard
+// (`components/dashboard/lap_graph.py`). Both toggles are pure transforms over
+// the already-fetched laps — no refetch (parity requirement F1-5 / P4-3).
+//
+// PARITY NOTES (faithful to the original, quirks included):
+//  - Outlier IQR uses INDEX-based quartiles (n//4, 3n//4) on the sorted times,
+//    NOT linear-interpolation quartiles; multiplier 1.5; drivers with <4 laps
+//    are skipped (never flagged).
+//  - "Invalid" = `not is_accurate or is_pit_out_lap`. The /lap-times response
+//    does not currently include these fields, so with safe defaults every lap
+//    counts as valid → the toggle is effectively a no-op today, exactly as in
+//    Streamlit. Reading the optional fields keeps it correct if the backend
+//    later starts sending them.
+
+import type { LapTime } from '@/lib/api/telemetry'
+
+/** Lap with the (currently unsent) accuracy flags the invalid filter would use. */
+type LapWithFlags = LapTime & { is_accurate?: boolean; is_pit_out_lap?: boolean }
+
+/** Integer floor division, matching Python's `//`. */
+function floorDiv(a: number, b: number): number {
+  return Math.floor(a / b)
+}
+
+/**
+ * Indices (into `laps`) flagged as lap-time outliers, computed per driver via
+ * the 1.5×IQR rule with index-based quartiles. Drivers with <4 laps are skipped.
+ */
+export function detectOutlierIndices(laps: LapTime[]): Set<number> {
+  const byDriver = new Map<string, number[]>()
+  laps.forEach((lap, idx) => {
+    const list = byDriver.get(lap.driver) ?? []
+    list.push(idx)
+    byDriver.set(lap.driver, list)
+  })
+
+  const outliers = new Set<number>()
+  for (const indices of byDriver.values()) {
+    if (indices.length < 4) continue
+    const times = indices.map((i) => laps[i].lap_time)
+    const sorted = [...times].sort((a, b) => a - b)
+    const n = sorted.length
+    const q1 = sorted[floorDiv(n, 4)]
+    const q3 = sorted[floorDiv(3 * n, 4)]
+    const iqr = q3 - q1
+    const lower = q1 - 1.5 * iqr
+    const upper = q3 + 1.5 * iqr
+    for (const i of indices) {
+      const t = laps[i].lap_time
+      if (t < lower || t > upper) outliers.add(i)
+    }
+  }
+  return outliers
+}
+
+/** Whether a lap is "invalid" per the Streamlit rule (see parity note). */
+function isInvalid(lap: LapTime): boolean {
+  const flagged = lap as LapWithFlags
+  const accurate = flagged.is_accurate ?? true
+  const pitOut = flagged.is_pit_out_lap ?? false
+  return !accurate || pitOut
+}
+
+export interface LapFilterResult {
+  visible: LapTime[]
+  outlierCount: number // total outliers detected (regardless of toggle)
+  invalidCount: number // total invalid laps detected (regardless of toggle)
+}
+
+/**
+ * Apply the outlier + invalid toggles in place (no refetch).
+ * Hides outliers when `showOutliers` is false; hides invalid when
+ * `showInvalidLaps` is false. Returns the visible laps plus the total counts so
+ * the caller can render the "Hiding/Showing N …" status line.
+ */
+export function applyLapFilters(
+  laps: LapTime[],
+  showOutliers: boolean,
+  showInvalidLaps: boolean,
+): LapFilterResult {
+  const outlierIdx = detectOutlierIndices(laps)
+  let invalidCount = 0
+  const visible: LapTime[] = []
+
+  laps.forEach((lap, idx) => {
+    const outlier = outlierIdx.has(idx)
+    const invalid = isInvalid(lap)
+    if (invalid) invalidCount += 1
+    if (!showOutliers && outlier) return
+    if (!showInvalidLaps && invalid) return
+    visible.push(lap)
+  })
+
+  return { visible, outlierCount: outlierIdx.size, invalidCount }
+}

--- a/webapp/src/features/dashboard/queries.ts
+++ b/webapp/src/features/dashboard/queries.ts
@@ -8,6 +8,7 @@
 // `{ driver: telemetry }` record, so click-to-load / fastest-laps are just
 // store writes and the charts fetch reactively.
 
+import { useMemo } from 'react'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/client'
 import { queryKeys } from '@/lib/queryKeys'
@@ -24,7 +25,10 @@ import {
 } from '@/lib/api/telemetry'
 import type { DashboardSearch } from './search'
 
-const HISTORICAL = { staleTime: Infinity, gcTime: Infinity } as const
+// Historical data never changes: cache forever, and cap retries at 1 so a
+// downed backend fails fast instead of spinning through the default 3-retry
+// exponential backoff (which, on 10s+ FastF1 calls, means minutes of spinner).
+const HISTORICAL = { staleTime: Infinity, gcTime: Infinity, retry: 1 } as const
 
 /** Available GPs for a season. */
 export function useGps(year: number | undefined) {
@@ -85,6 +89,21 @@ export function useDrivers(
 }
 
 const ready = (s: DashboardSearch) => s.year != null && !!s.gp && !!s.session
+
+/**
+ * Fire-and-forget: ask the backend to warm the FastF1 session cache for this
+ * (year, gp, session). Called when the user picks a session so the ~2-15s parse
+ * starts while they choose drivers — by the time lap-times fires, it's warm.
+ * Untyped raw fetch (same-origin via the dev proxy / nginx); errors are ignored.
+ */
+export function prewarmTelemetry(year: number, gp: string, session: string): void {
+  // Same base as the typed client (client.ts) so it works split-origin too.
+  const base = import.meta.env.VITE_API_BASE ?? ''
+  const query = new URLSearchParams({ year: String(year), gp, session })
+  void fetch(`${base}/api/v1/telemetry/prewarm?${query.toString()}`, { method: 'POST' }).catch(
+    () => {},
+  )
+}
 
 /** Lap-time series for the selected drivers (feeds the lap chart). */
 export function useLapTimes(search: DashboardSearch) {
@@ -175,30 +194,51 @@ export function useLapTelemetries(
     })),
   })
 
-  const byDriver: Record<string, LapTelemetry> = {}
-  const failedDrivers: string[] = []
-  let anyLoading = false
-  results.forEach((r, i) => {
-    if (!canFetch) return
-    const driver = entries[i][0]
-    if (r.isLoading) {
-      anyLoading = true
-      return
-    }
-    if (r.data) {
-      byDriver[driver] = r.data
-      return
-    }
-    // Settled (success with a `{}` body → null, or error after retries) but no
-    // telemetry: a pit/out/incomplete lap or a failed fetch.
-    if (r.isError || r.isSuccess) failedDrivers.push(driver)
-  })
+  // Memoize the combined result on a content signature so `byDriver` keeps a
+  // STABLE identity across unrelated re-renders (outlier/layout toggles, hovers)
+  // — without this the 7 telemetry charts' option `useMemo`s recompute thousands
+  // of points every render. The signature must capture EVERY input to `byDriver`:
+  // the session context (so navigating between sessions can't return the prior
+  // session's cached telemetry for one frame), each query's driver:lap:status,
+  // and `dataUpdatedAt` (so a refetch that keeps `status: 'success'` still busts
+  // the memo). `year`/`gp`/`session`/`canFetch` are already in scope above.
+  const signature =
+    `${canFetch}|${year ?? ''}|${gp ?? ''}|${session ?? ''}|` +
+    results
+      .map((r, i) => `${entries[i]?.[0]}:${entries[i]?.[1]}:${r.status}:${r.dataUpdatedAt}`)
+      .join('|')
 
-  return {
-    byDriver,
-    isLoading: anyLoading,
-    hasAny: Object.keys(byDriver).length > 0,
-    hasSelection: entries.length > 0,
-    failedDrivers,
-  }
+  return useMemo<LapTelemetriesResult>(
+    () => {
+      const byDriver: Record<string, LapTelemetry> = {}
+      const failedDrivers: string[] = []
+      let anyLoading = false
+      results.forEach((r, i) => {
+        if (!canFetch) return
+        const driver = entries[i][0]
+        if (r.isLoading) {
+          anyLoading = true
+          return
+        }
+        if (r.data) {
+          byDriver[driver] = r.data
+          return
+        }
+        // Settled (success with a `{}` body → null, or error after retries) but
+        // no telemetry: a pit/out/incomplete lap or a failed fetch.
+        if (r.isError || r.isSuccess) failedDrivers.push(driver)
+      })
+      return {
+        byDriver,
+        isLoading: anyLoading,
+        hasAny: Object.keys(byDriver).length > 0,
+        hasSelection: entries.length > 0,
+        failedDrivers,
+      }
+    },
+    // Keyed on the content signature above; `results`/`entries`/`canFetch` are
+    // read inside but only matter when the signature changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [signature],
+  )
 }

--- a/webapp/src/features/dashboard/queries.ts
+++ b/webapp/src/features/dashboard/queries.ts
@@ -1,0 +1,204 @@
+// TanStack Query hooks for the Dashboard data layer. All wrap the typed
+// openapi-fetch client and narrow the `unknown` telemetry bodies (see
+// lib/api/telemetry.ts). Historical data never changes, so `staleTime:
+// Infinity` — nav and UI toggles never trigger a refetch (perf target P4-3).
+//
+// Design: the store holds the SELECTED laps; `useLapTelemetries` turns that
+// selection map into N parallel queries (useQueries) and returns a
+// `{ driver: telemetry }` record, so click-to-load / fastest-laps are just
+// store writes and the charts fetch reactively.
+
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api/client'
+import { queryKeys } from '@/lib/queryKeys'
+import {
+  narrowCircuitDomination,
+  narrowDrivers,
+  narrowLapTelemetry,
+  narrowLapTimes,
+  narrowStringList,
+  type CircuitDomination,
+  type DriverOption,
+  type LapTelemetry,
+  type LapTime,
+} from '@/lib/api/telemetry'
+import type { DashboardSearch } from './search'
+
+const HISTORICAL = { staleTime: Infinity, gcTime: Infinity } as const
+
+/** Available GPs for a season. */
+export function useGps(year: number | undefined) {
+  return useQuery({
+    queryKey: year != null ? queryKeys.telemetry.gps(year) : ['telemetry', 'gps', 'idle'],
+    queryFn: async (): Promise<string[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/gps', {
+        params: { query: { year: year! } },
+      })
+      if (error) throw error
+      return narrowStringList(data, 'gps')
+    },
+    enabled: year != null,
+    ...HISTORICAL,
+  })
+}
+
+/** Available sessions for a GP. */
+export function useSessions(year: number | undefined, gp: string | undefined) {
+  return useQuery({
+    queryKey:
+      year != null && gp
+        ? queryKeys.telemetry.sessions(year, gp)
+        : ['telemetry', 'sessions', 'idle'],
+    queryFn: async (): Promise<string[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/sessions', {
+        params: { query: { year: year!, gp: gp! } },
+      })
+      if (error) throw error
+      return narrowStringList(data, 'sessions')
+    },
+    enabled: year != null && !!gp,
+    ...HISTORICAL,
+  })
+}
+
+/** Drivers who ran in a session (used to populate the driver multiselect). */
+export function useDrivers(
+  year: number | undefined,
+  gp: string | undefined,
+  session: string | undefined,
+) {
+  return useQuery({
+    queryKey:
+      year != null && gp && session
+        ? queryKeys.telemetry.drivers(year, gp, session)
+        : ['telemetry', 'drivers', 'idle'],
+    queryFn: async (): Promise<DriverOption[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/drivers', {
+        params: { query: { year: year!, gp: gp!, session: session! } },
+      })
+      if (error) throw error
+      return narrowDrivers(data)
+    },
+    enabled: year != null && !!gp && !!session,
+    ...HISTORICAL,
+  })
+}
+
+const ready = (s: DashboardSearch) => s.year != null && !!s.gp && !!s.session
+
+/** Lap-time series for the selected drivers (feeds the lap chart). */
+export function useLapTimes(search: DashboardSearch) {
+  const { year, gp, session, drivers } = search
+  // Sort the CSV (like the Streamlit original's `tuple(sorted(...))`) so
+  // VER,LEC and LEC,VER are one cache entry / one backend call, not two.
+  const driversCsv = [...drivers].sort().join(',')
+  const enabled = ready(search) && drivers.length > 0
+  return useQuery({
+    queryKey: enabled
+      ? queryKeys.telemetry.lapTimes(year!, gp!, session!, driversCsv)
+      : ['telemetry', 'lap-times', 'idle'],
+    queryFn: async (): Promise<LapTime[]> => {
+      const { data, error } = await api.GET('/api/v1/telemetry/lap-times', {
+        params: { query: { year: year!, gp: gp!, session: session!, drivers: driversCsv } },
+      })
+      if (error) throw error
+      return narrowLapTimes(data)
+    },
+    enabled,
+    ...HISTORICAL,
+  })
+}
+
+/** Microsector-dominance map (needs >=2 drivers). */
+export function useCircuitDomination(search: DashboardSearch) {
+  const { year, gp, session, drivers } = search
+  const driversCsv = [...drivers].sort().join(',')
+  const enabled = ready(search) && drivers.length >= 2
+  return useQuery({
+    queryKey: enabled
+      ? queryKeys.telemetry.circuitDomination(year!, gp!, session!, driversCsv)
+      : ['telemetry', 'circuit-domination', 'idle'],
+    queryFn: async (): Promise<CircuitDomination | null> => {
+      const { data, error } = await api.GET('/api/v1/circuit-domination', {
+        params: { query: { year: year!, gp: gp!, session: session!, drivers: driversCsv } },
+      })
+      if (error) throw error
+      return narrowCircuitDomination(data)
+    },
+    enabled,
+    ...HISTORICAL,
+  })
+}
+
+export interface LapTelemetriesResult {
+  /** driver code → that driver's loaded-lap telemetry. */
+  byDriver: Record<string, LapTelemetry>
+  /** True while at least one selected lap is still loading. */
+  isLoading: boolean
+  /** True once at least one lap's telemetry has loaded. */
+  hasAny: boolean
+  /** True when the user has selected any lap (vs. the initial idle state). */
+  hasSelection: boolean
+  /** Selected drivers whose lap settled with NO telemetry (pit / out / incomplete
+   *  lap → backend `{}`) or errored — so the UI can explain the empty state
+   *  instead of spinning the loader forever. */
+  failedDrivers: string[]
+}
+
+/**
+ * Fetch telemetry for every currently-selected (driver, lap) in parallel.
+ * Turns the store's `selectedLapsPerDriver` map into N reactive queries so
+ * click-to-load and SELECT FASTEST LAPS need no manual prefetch.
+ */
+export function useLapTelemetries(
+  search: DashboardSearch,
+  selectedLapsPerDriver: Record<string, number>,
+): LapTelemetriesResult {
+  const { year, gp, session } = search
+  const entries = Object.entries(selectedLapsPerDriver)
+  const canFetch = ready(search)
+
+  const results = useQueries({
+    queries: entries.map(([driver, lap]) => ({
+      queryKey: canFetch
+        ? queryKeys.telemetry.lapTelemetry(year!, gp!, session!, driver, lap)
+        : ['telemetry', 'lap-telemetry', 'idle', driver, lap],
+      queryFn: async (): Promise<LapTelemetry | null> => {
+        const { data, error } = await api.GET('/api/v1/telemetry/lap-telemetry', {
+          params: { query: { year: year!, gp: gp!, session: session!, driver, lap_number: lap } },
+        })
+        if (error) throw error
+        return narrowLapTelemetry(data)
+      },
+      enabled: canFetch,
+      ...HISTORICAL,
+    })),
+  })
+
+  const byDriver: Record<string, LapTelemetry> = {}
+  const failedDrivers: string[] = []
+  let anyLoading = false
+  results.forEach((r, i) => {
+    if (!canFetch) return
+    const driver = entries[i][0]
+    if (r.isLoading) {
+      anyLoading = true
+      return
+    }
+    if (r.data) {
+      byDriver[driver] = r.data
+      return
+    }
+    // Settled (success with a `{}` body → null, or error after retries) but no
+    // telemetry: a pit/out/incomplete lap or a failed fetch.
+    if (r.isError || r.isSuccess) failedDrivers.push(driver)
+  })
+
+  return {
+    byDriver,
+    isLoading: anyLoading,
+    hasAny: Object.keys(byDriver).length > 0,
+    hasSelection: entries.length > 0,
+    failedDrivers,
+  }
+}

--- a/webapp/src/features/dashboard/search.ts
+++ b/webapp/src/features/dashboard/search.ts
@@ -1,0 +1,92 @@
+// URL search-param contract for the Dashboard. Selector state (year / GP /
+// session / drivers) lives in the URL so a link like
+// `?year=2023&gp=Monaco Grand Prix&session=R&drivers=VER,LEC` reproduces the
+// screen (the big UX unlock, U2-1). This is the single source of truth read by
+// the selectors toolbar AND every data query on the page.
+//
+// Two shapes, one boundary:
+//  - RawDashboardSearch — what lives in the URL / what `validateSearch` returns.
+//    `drivers` is a comma-joined string so the URL stays `?drivers=VER,LEC`.
+//  - DashboardSearch — the component-facing shape (`drivers` as an array).
+// The page converts raw↔component; every component only ever sees the array
+// shape. The 3-driver cap is enforced at this boundary, so a hand-edited URL
+// cannot exceed it.
+
+export const MAX_DRIVERS = 3
+
+/** Component-facing selection (drivers as an array). */
+export interface DashboardSearch {
+  year?: number
+  gp?: string
+  session?: string
+  drivers: string[]
+}
+
+/** URL / validated selection (drivers comma-joined). */
+export interface RawDashboardSearch {
+  year?: number
+  gp?: string
+  session?: string
+  drivers?: string
+}
+
+function coerceYear(raw: unknown): number | undefined {
+  if (raw == null || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isNaN(n) ? undefined : n
+}
+
+function coerceStr(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined
+}
+
+/**
+ * Normalise a raw drivers param (array or comma string) to a capped comma
+ * string. Driver codes are upper-cased and de-duplicated so a hand-edited URL
+ * like `?drivers=ver,VER,lec` can't produce duplicate chart series or a
+ * case-mismatch against the backend's upper-case driver rows.
+ */
+function capDriversCsv(raw: unknown): string | undefined {
+  let list: string[] = []
+  if (Array.isArray(raw)) list = raw.map(String).filter(Boolean)
+  else if (typeof raw === 'string' && raw !== '') list = raw.split(',').filter(Boolean)
+  const normalized = [...new Set(list.map((code) => code.trim().toUpperCase()).filter(Boolean))]
+  const capped = normalized.slice(0, MAX_DRIVERS)
+  return capped.length > 0 ? capped.join(',') : undefined
+}
+
+/** `validateSearch` for the /dashboard route: coerce raw router search. */
+export function validateDashboardSearch(raw: Record<string, unknown>): RawDashboardSearch {
+  const year = coerceYear(raw.year)
+  const gp = coerceStr(raw.gp)
+  const session = coerceStr(raw.session)
+  const drivers = capDriversCsv(raw.drivers)
+  return {
+    ...(year != null ? { year } : {}),
+    ...(gp ? { gp } : {}),
+    ...(session ? { session } : {}),
+    ...(drivers ? { drivers } : {}),
+  }
+}
+
+/** URL shape → component shape. */
+export function fromRaw(raw: RawDashboardSearch): DashboardSearch {
+  return {
+    year: raw.year,
+    gp: raw.gp,
+    session: raw.session,
+    drivers: raw.drivers ? raw.drivers.split(',').filter(Boolean).slice(0, MAX_DRIVERS) : [],
+  }
+}
+
+/** Component shape → URL shape (empty fields dropped so the URL stays clean). */
+export function toRaw(search: DashboardSearch): RawDashboardSearch {
+  const drivers =
+    search.drivers.length > 0 ? search.drivers.slice(0, MAX_DRIVERS).join(',') : undefined
+  return {
+    ...(search.year != null ? { year: search.year } : {}),
+    ...(search.gp ? { gp: search.gp } : {}),
+    ...(search.session ? { session: search.session } : {}),
+    ...(drivers ? { drivers } : {}),
+  }
+}

--- a/webapp/src/features/dashboard/search.ts
+++ b/webapp/src/features/dashboard/search.ts
@@ -55,12 +55,15 @@ function capDriversCsv(raw: unknown): string | undefined {
   return capped.length > 0 ? capped.join(',') : undefined
 }
 
-/** `validateSearch` for the /dashboard route: coerce raw router search. */
+/** `validateSearch` for the /dashboard route: coerce raw router search AND
+ *  enforce the cascade (drivers need a session, session needs a GP, GP needs a
+ *  year). A hand-truncated link like `?drivers=VER,LEC` therefore drops the
+ *  orphan drivers instead of rendering the page in a broken half-selected state. */
 export function validateDashboardSearch(raw: Record<string, unknown>): RawDashboardSearch {
   const year = coerceYear(raw.year)
-  const gp = coerceStr(raw.gp)
-  const session = coerceStr(raw.session)
-  const drivers = capDriversCsv(raw.drivers)
+  const gp = year != null ? coerceStr(raw.gp) : undefined
+  const session = gp ? coerceStr(raw.session) : undefined
+  const drivers = session ? capDriversCsv(raw.drivers) : undefined
   return {
     ...(year != null ? { year } : {}),
     ...(gp ? { gp } : {}),

--- a/webapp/src/features/dashboard/store.ts
+++ b/webapp/src/features/dashboard/store.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+// Dashboard UI state (Zustand). This holds the user's SELECTIONS and view
+// toggles only — the telemetry DATA for each selected lap lives in TanStack
+// Query (keyed by driver+lap), so click-to-load is just `setLap()` and the
+// charts read the query cache. Mirrors the Streamlit session-state keys
+// `selected_laps_per_driver`, `show_outliers`, `show_invalid_laps`.
+//
+// Only `chartLayout` persists (a view preference); lap selections + filter
+// toggles reset per load, matching the Streamlit defaults.
+
+export type ChartLayout = 'grid' | 'stack'
+
+interface DashboardState {
+  /** driver code → the lap number whose telemetry is loaded. */
+  selectedLapsPerDriver: Record<string, number>
+  /** Merge one driver's loaded lap (click-to-load). */
+  setLap: (driver: string, lap: number) => void
+  /** Replace the whole map (SELECT FASTEST LAPS batch load). */
+  setFastestLaps: (laps: Record<string, number>) => void
+  /** Drop selections for drivers no longer chosen (call on selection change). */
+  pruneLaps: (drivers: string[]) => void
+  clearLaps: () => void
+
+  showOutliers: boolean
+  showInvalidLaps: boolean
+  toggleOutliers: () => void
+  toggleInvalidLaps: () => void
+
+  chartLayout: ChartLayout
+  toggleChartLayout: () => void
+}
+
+export const useDashboardStore = create<DashboardState>()(
+  persist(
+    (set) => ({
+      selectedLapsPerDriver: {},
+      setLap: (driver, lap) =>
+        set((s) => ({ selectedLapsPerDriver: { ...s.selectedLapsPerDriver, [driver]: lap } })),
+      setFastestLaps: (laps) => set({ selectedLapsPerDriver: laps }),
+      pruneLaps: (drivers) =>
+        set((s) => {
+          const allowed = new Set(drivers)
+          const next: Record<string, number> = {}
+          for (const [driver, lap] of Object.entries(s.selectedLapsPerDriver)) {
+            if (allowed.has(driver)) next[driver] = lap
+          }
+          return { selectedLapsPerDriver: next }
+        }),
+      clearLaps: () => set({ selectedLapsPerDriver: {} }),
+
+      showOutliers: false,
+      showInvalidLaps: true,
+      toggleOutliers: () => set((s) => ({ showOutliers: !s.showOutliers })),
+      toggleInvalidLaps: () => set((s) => ({ showInvalidLaps: !s.showInvalidLaps })),
+
+      chartLayout: 'grid',
+      toggleChartLayout: () =>
+        set((s) => ({ chartLayout: s.chartLayout === 'grid' ? 'stack' : 'grid' })),
+    }),
+    { name: 'f1sl.dashboard', partialize: (s) => ({ chartLayout: s.chartLayout }) },
+  ),
+)

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -69,6 +69,46 @@
   --tracking-widest: var(--tracking-widest);
 }
 
+/* View Transition circular theme reveal (ThemeToggle.tsx). Kill the browser's
+   default cross-fade so only the JS-driven clip-path circle animates — the
+   old frame sits still underneath while the new one wipes over it from the
+   toggle button's position (`--theme-x`/`--theme-y`, set by ThemeToggle). */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+  z-index: 1;
+}
+::view-transition-new(root) {
+  z-index: 2;
+}
+
+/* Subtle premium touch: the incoming frame starts a hair out of focus and
+   sharpens as the circle reveal completes, instead of snapping in crisp.
+   Duration is hardcoded to match ThemeToggle's `VIEW_TRANSITION_DURATION_MS`
+   (480ms) — keep the two in sync if either changes. Placed BEFORE the
+   reduced-motion override below so that override still wins when it applies. */
+@keyframes theme-reveal-focus {
+  from {
+    filter: blur(2px);
+  }
+  to {
+    filter: blur(0);
+  }
+}
+::view-transition-new(root) {
+  animation: theme-reveal-focus 480ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 @layer base {
   html {
     color-scheme: dark;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,6 +57,16 @@
   --font-display: var(--font-display);
   --font-body: var(--font-body);
   --font-mono: var(--font-mono);
+
+  /* Brand letter-spacing (tokens.css). Without this map, every `tracking-*`
+     utility silently falls back to Tailwind's defaults (widest 0.1em, wide
+     0.025em) instead of the brand scale — the eyebrow tracking (0.18em) is the
+     one that reads wrong. Keeps `tracking-*` theme-swappable like the colors. */
+  --tracking-tightest: var(--tracking-tightest);
+  --tracking-tighter: var(--tracking-tighter);
+  --tracking-tight: var(--tracking-tight);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-widest: var(--tracking-widest);
 }
 
 @layer base {

--- a/webapp/src/lib/api/telemetry.ts
+++ b/webapp/src/lib/api/telemetry.ts
@@ -1,0 +1,93 @@
+// Telemetry response types + light runtime narrowing.
+//
+// The generated OpenAPI schema types every telemetry 200 body as `unknown`
+// (the backend ships no response models), so the typed client returns `unknown`
+// and we narrow here — one place, so callers get real types. The backend is the
+// same app (trusted), so these are light casts with safe fallbacks, not full
+// schema validation (that would be over-engineering for an in-house contract).
+//
+// --- WHERE TO CHANGE IF THE BACKEND CONTRACT CHANGES ---
+// backend/services/telemetry/telemetry_service.py (lap-times/lap-telemetry shapes)
+// backend/services/telemetry_service.py::get_circuit_domination_data (domination shape)
+
+/** One lap on the lap-time chart. `compound` is lowercase from FastF1. */
+export interface LapTime {
+  driver: string
+  lap_number: number
+  lap_time: number // seconds
+  is_valid: boolean // IsPersonalBest (see parity note in dashboard queries)
+  compound: string // 'soft' | 'medium' | 'hard' | 'intermediate' | 'inter' | 'wet' | 'unknown'
+}
+
+/** Full channel telemetry for a single (driver, lap). One call = all 7 channels. */
+export interface LapTelemetry {
+  driver: string
+  lap_number: number
+  distance: number[]
+  time: number[]
+  speed: number[]
+  throttle: number[]
+  brake: number[]
+  rpm: number[]
+  gear: number[]
+  drs: number[]
+}
+
+/** Microsector dominance map: colors[i] paints the segment point[i]→point[i+1]. */
+export interface CircuitDomination {
+  x: number[]
+  y: number[]
+  colors: string[]
+  drivers: { driver: string; color: string }[]
+}
+
+export interface DriverOption {
+  code: string
+  name: string
+}
+
+/** Pull a string[] out of a `{ [key]: string[] }` wrapper, tolerating a bad shape. */
+export function narrowStringList(data: unknown, key: string): string[] {
+  const record = data as Record<string, unknown> | null
+  const list = record?.[key]
+  return Array.isArray(list) ? (list as string[]) : []
+}
+
+export function narrowDrivers(data: unknown): DriverOption[] {
+  const record = data as { drivers?: unknown } | null
+  const list = record?.drivers
+  return Array.isArray(list) ? (list as DriverOption[]) : []
+}
+
+export function narrowLapTimes(data: unknown): LapTime[] {
+  const record = data as { lap_times?: unknown } | null
+  const list = record?.lap_times
+  return Array.isArray(list) ? (list as LapTime[]) : []
+}
+
+export function narrowLapTelemetry(data: unknown): LapTelemetry | null {
+  const record = data as LapTelemetry | null
+  // Every channel must be an array: the backend returns `{}` (→ null here) for
+  // laps without telemetry (pit / out / incomplete laps), and a partial body
+  // would crash the channel `.map(...)` downstream. All-or-nothing is safest.
+  if (
+    !record ||
+    !Array.isArray(record.distance) ||
+    !Array.isArray(record.time) ||
+    !Array.isArray(record.speed) ||
+    !Array.isArray(record.throttle) ||
+    !Array.isArray(record.brake) ||
+    !Array.isArray(record.rpm) ||
+    !Array.isArray(record.gear) ||
+    !Array.isArray(record.drs)
+  ) {
+    return null
+  }
+  return record
+}
+
+export function narrowCircuitDomination(data: unknown): CircuitDomination | null {
+  const record = data as CircuitDomination | null
+  if (!record || !Array.isArray(record.x) || !Array.isArray(record.colors)) return null
+  return record
+}

--- a/webapp/src/lib/queryKeys.ts
+++ b/webapp/src/lib/queryKeys.ts
@@ -7,6 +7,12 @@ export const queryKeys = {
     sessions: (year: number, gp: string) => ['telemetry', 'sessions', year, gp] as const,
     drivers: (year: number, gp: string, session: string) =>
       ['telemetry', 'drivers', year, gp, session] as const,
+    lapTimes: (year: number, gp: string, session: string, drivers: string) =>
+      ['telemetry', 'lap-times', year, gp, session, drivers] as const,
+    lapTelemetry: (year: number, gp: string, session: string, driver: string, lap: number) =>
+      ['telemetry', 'lap-telemetry', year, gp, session, driver, lap] as const,
+    circuitDomination: (year: number, gp: string, session: string, drivers: string) =>
+      ['telemetry', 'circuit-domination', year, gp, session, drivers] as const,
   },
   chat: {
     health: () => ['chat', 'health'] as const,

--- a/webapp/src/stores/ui.ts
+++ b/webapp/src/stores/ui.ts
@@ -11,10 +11,25 @@ import { persist } from 'zustand/middleware'
 // resolves here, not in the CSS.
 export type Theme = 'dark' | 'light'
 
+// Drag-to-resize bounds for the expanded rail (Rail.tsx owns the collapsed
+// width, which is fixed and never resizable). Exported so Rail.tsx can reuse
+// the exact same numbers for its `aria-valuemin`/`aria-valuemax` instead of
+// duplicating the bounds and risking drift between the clamp and the a11y
+// attributes that describe it.
+export const RAIL_WIDTH_MIN = 200
+export const RAIL_WIDTH_MAX = 360
+const RAIL_WIDTH_DEFAULT = 232
+
+function clampRailWidth(width: number): number {
+  return Math.min(RAIL_WIDTH_MAX, Math.max(RAIL_WIDTH_MIN, width))
+}
+
 interface UiState {
   railCollapsed: boolean
   toggleRail: () => void
   setRailCollapsed: (collapsed: boolean) => void
+  railWidth: number
+  setRailWidth: (width: number) => void
   theme: Theme
   toggleTheme: () => void
 }
@@ -25,6 +40,8 @@ export const useUiStore = create<UiState>()(
       railCollapsed: false,
       toggleRail: () => set((state) => ({ railCollapsed: !state.railCollapsed })),
       setRailCollapsed: (collapsed) => set({ railCollapsed: collapsed }),
+      railWidth: RAIL_WIDTH_DEFAULT,
+      setRailWidth: (width) => set({ railWidth: clampRailWidth(width) }),
       theme: 'dark',
       toggleTheme: () => set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
     }),

--- a/webapp/src/stores/ui.ts
+++ b/webapp/src/stores/ui.ts
@@ -5,10 +5,18 @@ import { persist } from 'zustand/middleware'
 // namespace per the state-model plan (A5-1). Server data lives in TanStack Query
 // and selector state in the URL; this store is only for what the user *did* to
 // the UI. Feature slices (chat, voice, replay) arrive with their features.
+// Two-state theme (no 'system'): both sibling brand surfaces (landing, docs) are
+// dark-only, so dark is the identity default and a binary toggle keeps the CSS
+// single-sourced on the `data-theme` attribute. If 'system' is ever wanted it
+// resolves here, not in the CSS.
+export type Theme = 'dark' | 'light'
+
 interface UiState {
   railCollapsed: boolean
   toggleRail: () => void
   setRailCollapsed: (collapsed: boolean) => void
+  theme: Theme
+  toggleTheme: () => void
 }
 
 export const useUiStore = create<UiState>()(
@@ -17,6 +25,8 @@ export const useUiStore = create<UiState>()(
       railCollapsed: false,
       toggleRail: () => set((state) => ({ railCollapsed: !state.railCollapsed })),
       setRailCollapsed: (collapsed) => set({ railCollapsed: collapsed }),
+      theme: 'dark',
+      toggleTheme: () => set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
     }),
     { name: 'f1sl.ui' },
   ),

--- a/webapp/src/styles/tokens.css
+++ b/webapp/src/styles/tokens.css
@@ -107,3 +107,56 @@
   --tracking-wide: 0.04em;
   --tracking-widest: 0.18em;
 }
+
+/* =========================================================
+   LIGHT THEME (E1) — a token swap, stamped via data-theme='light' on
+   <html> (see app/providers.tsx + the FOUC guard in index.html). Only the
+   *semantic* ramp flips: the background/foreground ladders, dividers, shadows
+   and the hero gradient. Identity colours (purple, blue, tyre compounds) and
+   chrome gradients stay put — they read on both themes. This block is more
+   specific than `html { color-scheme: dark }`, so `color-scheme: light` wins
+   here declaratively (no @media, single source of truth = the attribute).
+
+   Not solved by a var swap: HARD's white chip (--tire-hard) would vanish on a
+   light card — instead every compound pill carries a permanent border-hairline
+   (invisible-ish in dark, load-bearing in light). Status colours are darkened
+   to pass contrast on white. */
+:root[data-theme='light'] {
+  color-scheme: light;
+
+  --bg-0: #f5f5fa; /* page */
+  --bg-1: #eef0f7; /* deep surface (hero) */
+  --bg-2: #e9eaf4; /* sidebar / chrome */
+  --bg-3: #ffffff; /* card resting */
+  --bg-4: #f7f7fc; /* card hovered / elevated */
+  --bg-5: #eceaf9; /* input bg */
+
+  --fg-1: #14121f; /* near-black, purple tint (mirror of dark --bg-1) */
+  --fg-2: rgba(20, 18, 31, 0.75);
+  --fg-3: rgba(20, 18, 31, 0.58);
+  --fg-4: rgba(20, 18, 31, 0.42);
+  --fg-inv: #ffffff;
+
+  --accent-hover: var(--purple-700); /* purple-300 fails as text on white */
+
+  --success: #15803d;
+  --warning: #b45309;
+  --danger: #dc2626;
+  --info: #1d4ed8;
+
+  --divider: rgba(20, 18, 31, 0.1);
+  --divider-strong: rgba(20, 18, 31, 0.18);
+  --hairline: rgba(20, 18, 31, 0.06);
+
+  --grad-hero: radial-gradient(
+    ellipse 120% 80% at 50% 0%,
+    rgba(108, 92, 231, 0.14) 0%,
+    rgba(108, 92, 231, 0.05) 35%,
+    transparent 70%
+  );
+
+  --shadow-card: 0 2px 10px rgba(20, 18, 31, 0.08);
+  --shadow-elev: 0 12px 40px rgba(20, 18, 31, 0.14);
+  --shadow-glow: 0 0 0 1px rgba(108, 92, 231, 0.3), 0 12px 40px rgba(108, 92, 231, 0.15);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}


### PR DESCRIPTION
Promote the migrated Dashboard from dev to main: round-2 content (#95), app rail + typography (#97), light theme (#98), and the two polish rounds (#100, #101). All landed and verified on dev; main is strictly behind dev (23 commits, 0 divergent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive telemetry dashboard with lap charts, driver comparisons, circuit domination, telemetry channels, filtering, and fastest-lap selection.
  * Added light/dark theme switching with themed charts and reduced-motion support.
  * Added collapsible, resizable, grouped navigation.
  * Added background telemetry prewarming for faster session access.
* **Bug Fixes**
  * Improved handling of missing or incomplete telemetry and non-ASCII output.
  * Added clearer loading, empty, and partial-data states.
* **Documentation**
  * Added design specifications for upcoming dashboard, chat, comparison, strategy, and analysis experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->