### PR TITLE
fix(webapp): paint chart animation once, not per-driver data arrival

### DIFF
--- a/webapp/src/charts/useFirstPaintAnimation.test.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { EChartsOption } from 'echarts'
+import { useFirstPaintAnimation } from './useFirstPaintAnimation'
+
+const noSeries: EChartsOption = { series: [] }
+const oneSeries: EChartsOption = { series: [{ type: 'line', data: [] }] }
+const twoSeries: EChartsOption = {
+  series: [
+    { type: 'line', data: [] },
+    { type: 'line', data: [] },
+  ],
+}
+
+describe('useFirstPaintAnimation', () => {
+  it('keeps animation off until the first render that has series', () => {
+    const { result } = renderHook((o: EChartsOption) => useFirstPaintAnimation(o), {
+      initialProps: noSeries,
+    })
+    expect(result.current.animation).toBe(false)
+  })
+
+  it('animates only the first data paint, not later data updates', () => {
+    const { result, rerender } = renderHook((o: EChartsOption) => useFirstPaintAnimation(o), {
+      initialProps: noSeries,
+    })
+    expect(result.current.animation).toBe(false) // no data yet
+
+    rerender(oneSeries)
+    // first data paint: option passed through untouched, ECharts' default
+    // animation (undefined → true) draws the entrance sweep.
+    expect(result.current.animation).toBeUndefined()
+
+    rerender(twoSeries)
+    // a second driver's telemetry landing must NOT replay the sweep.
+    expect(result.current.animation).toBe(false)
+  })
+})

--- a/webapp/src/charts/useFirstPaintAnimation.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react'
+import type { EChartsOption } from 'echarts'
+
+/**
+ * Gate an ECharts option so its entrance paint animation plays only on the
+ * FIRST render that actually has series, and never again for that mount.
+ *
+ * Why: the dashboard charts render with `notMerge`, which re-runs the full
+ * entrance sweep on EVERY `setOption`. A multi-driver session's telemetry
+ * arrives as separate `useQueries` resolutions (VER lands, then LEC), so
+ * `byDriver` updates once per driver — without this the chart would replay its
+ * paint animation two or three times as each driver's data lands. This animates
+ * the first data paint, then returns the same option with `animation: false` on
+ * every later update.
+ *
+ * Remounts (a `key` change on theme / maximize) create a fresh instance, so the
+ * ref resets and those transitions re-animate on purpose.
+ */
+export function useFirstPaintAnimation(option: EChartsOption): EChartsOption {
+  const hasSeries = Array.isArray(option.series) && option.series.length > 0
+  const paintedRef = useRef(false)
+  const animate = hasSeries && !paintedRef.current
+
+  useEffect(() => {
+    if (animate) paintedRef.current = true
+  }, [animate])
+
+  return animate ? option : { ...option, animation: false }
+}

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -20,6 +20,7 @@ import type {
 } from 'echarts'
 import * as echarts from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
 import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTelemetry } from '@/lib/api/telemetry'
@@ -266,12 +267,16 @@ function SyncedLineChart({
   // on window resize, not on this container change, so a stale canvas would
   // mis-place the hover crosshair otherwise.
   const maximized = useContext(ChartMaximizedContext)
+  // Animate the paint once, on the first render with data — a 2-3 driver
+  // session's telemetry lands per driver, and `notMerge` would otherwise replay
+  // the sweep on each arrival.
+  const paintedOption = useFirstPaintAnimation(option)
   return (
     <div role="img" aria-label={ariaLabel} className={maximized ? 'h-full' : undefined}>
       <ReactECharts
         theme={chartTheme}
         key={`${chartTheme}-${maximized}`}
-        option={option}
+        option={paintedOption}
         style={{ height: maximized ? '100%' : height }}
         notMerge
         onChartReady={(instance) => {

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -17,6 +17,7 @@ import { useCallback, useContext, useMemo, useRef } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type { ECharts, EChartsOption } from 'echarts'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
 import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTime } from '@/lib/api/telemetry'
@@ -399,6 +400,11 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
     }
   }, [laps, drivers, year, selectedLaps, chartTheme])
 
+  // Animate the paint once, on the first render with data — the lap chart also
+  // rebuilds when the auto-loaded fastest laps land (a second render right
+  // after the lap times), so `notMerge` would otherwise redraw the lines twice.
+  const paintedOption = useFirstPaintAnimation(option)
+
   // Latest-ref mirror: the zrender click handler is registered once (see
   // `handleChartReady` below) and reads through this ref on every click, so
   // it always sees the current laps/onLapClick without re-binding.
@@ -418,7 +424,7 @@ export function LapChart({ laps, drivers, year, onLapClick, selectedLaps }: LapC
       <ReactECharts
         theme={chartTheme}
         key={`${chartTheme}-${maximized}`}
-        option={option}
+        option={paintedOption}
         style={{ height: maximized ? '100%' : 400 }}
         notMerge
         onChartReady={handleChartReady}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -5,9 +5,10 @@ import '@fontsource-variable/jetbrains-mono'
 import './index.css'
 import { Providers } from './app/providers'
 
-// No <StrictMode>: its intentional dev-only double-invoke of effects double-
-// MOUNTS every component, which makes echarts-for-react init + play its
-// entrance animation twice on first paint (prod, with a single mount, is fine).
-// Dropping it lets the chart paint animation run exactly once in dev too —
-// matching production behaviour.
+// No <StrictMode>. The chart double-paint is actually fixed by
+// `charts/useFirstPaintAnimation` (a multi-driver session's telemetry lands per
+// driver, and `notMerge` replayed the sweep on each arrival — the hook animates
+// only the first data paint). StrictMode's dev-only double-mount was a red
+// herring, but it's left off as belt-and-suspenders so no dev remount can
+// re-trigger the entrance animation on top of the hook.
 createRoot(document.getElementById('root')!).render(<Providers />)


### PR DESCRIPTION
Correct fix for the chart double-paint (the StrictMode change in #105 was a mis-diagnosis — it wasn't the cause).

## Root cause (confirmed)
A multi-driver session's telemetry is fetched with `useQueries` — one query per driver (`useLapTelemetries`, queries.ts). VER's data lands, then LEC's, so `byDriver` updates **once per driver**. The charts render with `notMerge`, which replays the full entrance sweep on every `setOption` — so a 2-driver load animated **twice** (three drivers, three times). StrictMode's dev double-mount happens before any data, so it never actually doubled the animation.

## Fix
- `charts/useFirstPaintAnimation`: gates the ECharts option so the paint animates only on the **first render that has series**, then returns `{ …option, animation: false }` on every later data update. A `key`-driven remount (theme / maximize) resets it, so those transitions re-animate on purpose.
- Wired into `ChannelChart` (telemetry) and `LapChart`.
- Unit-tested (`useFirstPaintAnimation.test.ts`): no animation before series exist → animates the first data paint → suppressed on the next update.

## Checks
- tsc -b, oxlint, vitest (45/45, incl. the new hook test), vite build — all green.

Builds on #105 (which restored the animation + added the favicon); this makes it play exactly once regardless of driver count.