### PR TITLE
fix(webapp): coalesce chart option churn so the paint animates once

### DIFF
--- a/webapp/src/charts/useFirstPaintAnimation.test.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import type { EChartsOption } from 'echarts'
 import { useFirstPaintAnimation } from './useFirstPaintAnimation'
 
@@ -12,27 +12,40 @@ const twoSeries: EChartsOption = {
   ],
 }
 
-describe('useFirstPaintAnimation', () => {
-  it('keeps animation off until the first render that has series', () => {
-    const { result } = renderHook((o: EChartsOption) => useFirstPaintAnimation(o), {
-      initialProps: noSeries,
-    })
-    expect(result.current.animation).toBe(false)
-  })
+// A bit longer than the hook's internal SETTLE_MS debounce window.
+const PAST_SETTLE = 160
 
-  it('animates only the first data paint, not later data updates', () => {
+describe('useFirstPaintAnimation', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('coalesces the settling churn and animates the paint exactly once', () => {
     const { result, rerender } = renderHook((o: EChartsOption) => useFirstPaintAnimation(o), {
       initialProps: noSeries,
     })
-    expect(result.current.animation).toBe(false) // no data yet
+    // nothing to paint yet
+    expect(result.current.animation).toBe(false)
 
+    // data lands in a burst (VER, then LEC) inside the settle window — the
+    // applied option must NOT change per arrival (that's what would cancel the
+    // animation); it stays the initial empty option until the burst settles.
     rerender(oneSeries)
-    // first data paint: option passed through untouched, ECharts' default
-    // animation (undefined → true) draws the entrance sweep.
+    rerender(twoSeries)
+    expect(result.current.series).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(PAST_SETTLE)
+    })
+    // one settled apply, with both series and the entrance animation left on
+    // (undefined → ECharts default true).
+    expect(result.current.series).toHaveLength(2)
     expect(result.current.animation).toBeUndefined()
 
-    rerender(twoSeries)
-    // a second driver's telemetry landing must NOT replay the sweep.
+    // a later interaction settles without replaying the sweep.
+    rerender(oneSeries)
+    act(() => {
+      vi.advanceTimersByTime(PAST_SETTLE)
+    })
     expect(result.current.animation).toBe(false)
   })
 })

--- a/webapp/src/charts/useFirstPaintAnimation.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.ts
@@ -1,29 +1,44 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { EChartsOption } from 'echarts'
 
+// A multi-driver session's telemetry resolves as separate `useQueries` (VER
+// lands, then LEC), and the lap chart's selected-lap rings land a tick after
+// its lines — so a chart's option changes several times in quick succession as
+// the data settles. With `notMerge` each `setOption` cancels and restarts the
+// entrance animation, so the paint either flickers twice or (when the last
+// update lands mid-sweep) snaps to the end without ever visibly playing.
+//
+// The debounce window: long enough to swallow the gap between two telemetry
+// queries resolving off one warm session, short enough to be imperceptible.
+const SETTLE_MS = 120
+
 /**
- * Gate an ECharts option so its entrance paint animation plays only on the
- * FIRST render that actually has series, and never again for that mount.
+ * Make an ECharts chart paint its entrance animation exactly once. It coalesces
+ * the settling burst of option changes into a SINGLE applied option (so there's
+ * only one `setOption`, which can't be cancelled by a follow-up), then locks
+ * animation off so later interactions — driver toggles, lap clicks — update
+ * instantly without replaying the sweep.
  *
- * Why: the dashboard charts render with `notMerge`, which re-runs the full
- * entrance sweep on EVERY `setOption`. A multi-driver session's telemetry
- * arrives as separate `useQueries` resolutions (VER lands, then LEC), so
- * `byDriver` updates once per driver — without this the chart would replay its
- * paint animation two or three times as each driver's data lands. This animates
- * the first data paint, then returns the same option with `animation: false` on
- * every later update.
- *
- * Remounts (a `key` change on theme / maximize) create a fresh instance, so the
- * ref resets and those transitions re-animate on purpose.
+ * A `key`-driven remount (theme / maximize change) creates a fresh instance, so
+ * the ref resets and those transitions re-animate on purpose.
  */
 export function useFirstPaintAnimation(option: EChartsOption): EChartsOption {
-  const hasSeries = Array.isArray(option.series) && option.series.length > 0
-  const paintedRef = useRef(false)
-  const animate = hasSeries && !paintedRef.current
+  const [settledOption, setSettledOption] = useState(option)
+  const hasPaintedRef = useRef(false)
 
+  // Apply the option only once it has stopped changing for SETTLE_MS.
   useEffect(() => {
-    if (animate) paintedRef.current = true
+    const timer = setTimeout(() => setSettledOption(option), SETTLE_MS)
+    return () => clearTimeout(timer)
+  }, [option])
+
+  const hasSeries = Array.isArray(settledOption.series) && settledOption.series.length > 0
+  const animate = hasSeries && !hasPaintedRef.current
+  useEffect(() => {
+    if (animate) hasPaintedRef.current = true
   }, [animate])
 
-  return animate ? option : { ...option, animation: false }
+  // When animating, pass the option through so ECharts' default entrance
+  // animation runs; afterwards, force it off so updates apply instantly.
+  return animate ? settledOption : { ...settledOption, animation: false }
 }


### PR DESCRIPTION
Third and correct take on the chart paint animation (the #106 hook over-suppressed it).

## What went wrong in #106
The hook animated the **first render with series** (VER's telemetry), but a multi-driver session's data lands per driver — LEC's telemetry a beat later re-set the option with `animation: false`, which (with `notMerge`) **cancelled VER's sweep mid-flight**. Net: no visible paint.

## The fix
Coalesce the settling burst of option changes — VER then LEC for the telemetry charts, lines then selected-lap rings for the lap chart — into a **single applied option** via a short (120ms) debounce. That means exactly **one** `notMerge` `setOption` with the complete data → one entrance animation, with no follow-up to cancel it. Then lock animation off so later interactions (driver toggles, lap clicks) update instantly without replaying the sweep. A `key`-driven remount (theme / maximize) resets it, so those re-animate on purpose.

## Verification (this time, empirically)
- Unit test (fake timers): the applied option does NOT change per data arrival during the burst, applies once with animation on after it settles, then locks off on the next update.
- Browser frame-diff detector on 2023 Monaco R (VER, LEC): a single paint burst.
- tsc -b, oxlint, vitest (44/44), vite build — all green.