### PR TITLE
fix(webapp): chart entrance animation + fast driver-selection race

### DIFF
--- a/webapp/src/charts/useFirstPaintAnimation.test.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.test.ts
@@ -4,7 +4,6 @@ import type { EChartsOption } from 'echarts'
 import { useFirstPaintAnimation } from './useFirstPaintAnimation'
 
 const noSeries: EChartsOption = { series: [] }
-const oneSeries: EChartsOption = { series: [{ type: 'line', data: [] }] }
 const twoSeries: EChartsOption = {
   series: [
     { type: 'line', data: [] },
@@ -12,40 +11,31 @@ const twoSeries: EChartsOption = {
   ],
 }
 
-// A bit longer than the hook's internal SETTLE_MS debounce window.
-const PAST_SETTLE = 160
+const PAST_SETTLE = 160 // > the hook's internal debounce window
 
 describe('useFirstPaintAnimation', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('coalesces the settling churn and animates the paint exactly once', () => {
+  it('leaves the entrance animation on and makes every update instant', () => {
     const { result, rerender } = renderHook((o: EChartsOption) => useFirstPaintAnimation(o), {
       initialProps: noSeries,
     })
-    // nothing to paint yet
-    expect(result.current.animation).toBe(false)
+    // The entrance is NEVER disabled (no `animation:false` — that was the bug);
+    // updates are instant so a follow-up setOption can't re-sweep or snap.
+    expect(result.current.animation).toBeUndefined()
+    expect(result.current.animationDurationUpdate).toBe(0)
 
-    // data lands in a burst (VER, then LEC) inside the settle window — the
-    // applied option must NOT change per arrival (that's what would cancel the
-    // animation); it stays the initial empty option until the burst settles.
-    rerender(oneSeries)
+    // A burst of option changes is coalesced: not applied until it settles.
+    rerender({ series: [{ type: 'line', data: [] }] })
     rerender(twoSeries)
     expect(result.current.series).toHaveLength(0)
 
     act(() => {
       vi.advanceTimersByTime(PAST_SETTLE)
     })
-    // one settled apply, with both series and the entrance animation left on
-    // (undefined → ECharts default true).
     expect(result.current.series).toHaveLength(2)
-    expect(result.current.animation).toBeUndefined()
-
-    // a later interaction settles without replaying the sweep.
-    rerender(oneSeries)
-    act(() => {
-      vi.advanceTimersByTime(PAST_SETTLE)
-    })
-    expect(result.current.animation).toBe(false)
+    expect(result.current.animation).toBeUndefined() // entrance still enabled
+    expect(result.current.animationDurationUpdate).toBe(0)
   })
 })

--- a/webapp/src/charts/useFirstPaintAnimation.ts
+++ b/webapp/src/charts/useFirstPaintAnimation.ts
@@ -1,30 +1,34 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { EChartsOption } from 'echarts'
 
 // A multi-driver session's telemetry resolves as separate `useQueries` (VER
 // lands, then LEC), and the lap chart's selected-lap rings land a tick after
 // its lines — so a chart's option changes several times in quick succession as
-// the data settles. With `notMerge` each `setOption` cancels and restarts the
-// entrance animation, so the paint either flickers twice or (when the last
-// update lands mid-sweep) snaps to the end without ever visibly playing.
-//
-// The debounce window: long enough to swallow the gap between two telemetry
-// queries resolving off one warm session, short enough to be imperceptible.
+// the data settles. The debounce coalesces that burst into ONE applied option,
+// so the entrance sweep isn't restarted per arrival. The window is long enough
+// to swallow the gap between two queries resolving off one warm session, short
+// enough to be imperceptible.
 const SETTLE_MS = 120
 
 /**
- * Make an ECharts chart paint its entrance animation exactly once. It coalesces
- * the settling burst of option changes into a SINGLE applied option (so there's
- * only one `setOption`, which can't be cancelled by a follow-up), then locks
- * animation off so later interactions — driver toggles, lap clicks — update
- * instantly without replaying the sweep.
+ * Gate an ECharts option so the chart paints its entrance animation once, and
+ * every later update applies instantly.
  *
- * A `key`-driven remount (theme / maximize change) creates a fresh instance, so
- * the ref resets and those transitions re-animate on purpose.
+ * ECharts plays the left-to-right entrance sweep only for a NEW series view
+ * (first mount, or a newly added driver); a `notMerge` `setOption` on an
+ * EXISTING same-name series is an update, governed by `animationDurationUpdate`.
+ * So instead of a "have I painted yet" flag (which — because echarts-for-react
+ * inits asynchronously — flipped before the real chart existed and then forced
+ * `animation:false`, snapping the in-flight sweep, see
+ * design-specs/chart-animation-selection-bugs.md), we set `animationDurationUpdate:
+ * 0`: entrances animate, updates are instant, and there is no animate→frozen
+ * render transition left to cancel a running sweep.
+ *
+ * Requires the caller-side churn fixes (a stable option identity) so no spurious
+ * `setOption` fires mid-sweep — see the same spec.
  */
 export function useFirstPaintAnimation(option: EChartsOption): EChartsOption {
   const [settledOption, setSettledOption] = useState(option)
-  const hasPaintedRef = useRef(false)
 
   // Apply the option only once it has stopped changing for SETTLE_MS.
   useEffect(() => {
@@ -32,13 +36,7 @@ export function useFirstPaintAnimation(option: EChartsOption): EChartsOption {
     return () => clearTimeout(timer)
   }, [option])
 
-  const hasSeries = Array.isArray(settledOption.series) && settledOption.series.length > 0
-  const animate = hasSeries && !hasPaintedRef.current
-  useEffect(() => {
-    if (animate) hasPaintedRef.current = true
-  }, [animate])
-
-  // When animating, pass the option through so ECharts' default entrance
-  // animation runs; afterwards, force it off so updates apply instantly.
-  return animate ? settledOption : { ...settledOption, animation: false }
+  // Keep referential stability while `settledOption` is unchanged so the deep-
+  // equal prop check in echarts-for-react doesn't fire a redundant `setOption`.
+  return useMemo(() => ({ ...settledOption, animationDurationUpdate: 0 }), [settledOption])
 }

--- a/webapp/src/features/dashboard/DashboardPage.tsx
+++ b/webapp/src/features/dashboard/DashboardPage.tsx
@@ -8,7 +8,7 @@
 // `search`; the lap chart writes loaded laps to the store, the telemetry grid
 // and circuit map read them.
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Link, getRouteApi } from '@tanstack/react-router'
 import { ArrowRightLeft, Gauge, TriangleAlert } from 'lucide-react'
 import { Header } from '@/app/Header'
@@ -22,14 +22,31 @@ import { TelemetryGrid } from './components/TelemetryGrid'
 import { useDashboardStore } from './store'
 import { useLapTimes, prewarmTelemetry } from './queries'
 import { fastestLapPerDriver } from './lib/fastestLap'
-import { applySelectionPatch, fromRaw, toRaw, type DashboardSearch } from './search'
+import { applySelectionPatch, fromRaw, toRaw, MAX_DRIVERS, type DashboardSearch } from './search'
 
 const routeApi = getRouteApi('/dashboard')
 
 export function DashboardPage() {
   const raw = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
-  const search = fromRaw(raw)
+  // Memoize: `fromRaw` builds a fresh `drivers` array each call, and an unstable
+  // `search`/`drivers` reference defeats the telemetry charts' `memo`, rebuilds
+  // their option every render and resets the paint debounce mid-sweep. `raw` is
+  // referentially stable from TanStack Router across unrelated renders, so this
+  // only recomputes when the URL actually changes.
+  const search = useMemo(() => fromRaw(raw), [raw])
+
+  // Synchronous accumulator for the driver selection. URL navigations are async
+  // and do NOT compose across a rapid burst of picks (each sees the same
+  // pre-burst `prev`), so a fast multi-select would drop drivers. We track the
+  // intended selection in a ref that toggles synchronously per click and always
+  // navigate with the FULL accumulated set — the last navigate wins with the
+  // complete list. The effect re-seeds it whenever the URL settles (external
+  // nav, cascade reset). (design-specs/chart-animation-selection-bugs.md B-1.)
+  const driversRef = useRef(search.drivers)
+  useEffect(() => {
+    driversRef.current = search.drivers
+  }, [search.drivers])
 
   const pruneLaps = useDashboardStore((s) => s.pruneLaps)
   const clearLaps = useDashboardStore((s) => s.clearLaps)
@@ -75,10 +92,9 @@ export function DashboardPage() {
 
   /** Patch the URL selection, applying the cascading reset of dependent levels. */
   const handleChange = (patch: Partial<DashboardSearch>) => {
-    const next = applySelectionPatch(search, patch)
-    // Re-picking the SAME upstream value returns the original object — nothing
-    // to navigate or warm.
-    if (next === search) return
+    // Re-picking the SAME upstream value is a no-op (applySelectionPatch returns
+    // its input) — skip the prewarm; the navigate below still no-ops structurally.
+    if (applySelectionPatch(search, patch) === search) return
 
     // Warm the session cache the moment a session is chosen — the parse runs
     // while the user picks drivers, so the charts don't hang afterwards.
@@ -86,7 +102,36 @@ export function DashboardPage() {
       prewarmTelemetry(search.year, search.gp, patch.session)
     }
 
-    void navigate({ search: toRaw(next) })
+    // Drivers change via the multiselect (which stays open for rapid picks):
+    // its `onChange` ships a WHOLE array computed from the render-captured
+    // selection, so composing that array over the committed URL would still
+    // overwrite a just-added driver. Instead derive the single TOGGLED driver
+    // from the same-render selection→patch delta, then apply that toggle over
+    // the COMMITTED URL — so a burst accumulates instead of overwriting.
+    // (design-specs/chart-animation-selection-bugs.md B-1.)
+    if ('drivers' in patch && patch.drivers) {
+      // The single toggled driver = the same-render delta between the current
+      // selection and the array the multiselect shipped (both use the same,
+      // possibly-stale, value — so the delta is correct regardless of staleness).
+      const before = new Set(search.drivers)
+      const after = new Set(patch.drivers)
+      const toggled =
+        [...after].find((d) => !before.has(d)) ?? [...before].find((d) => !after.has(d))
+      if (!toggled) return
+      // Toggle it into the SYNCHRONOUS accumulator and navigate with the full
+      // set, so a rapid burst can't overwrite an earlier pick from a stale base.
+      const current = driversRef.current
+      const nextDrivers = current.includes(toggled)
+        ? current.filter((d) => d !== toggled)
+        : [...current, toggled].slice(0, MAX_DRIVERS)
+      driversRef.current = nextDrivers
+      void navigate({ search: (prevRaw) => toRaw({ ...fromRaw(prevRaw), drivers: nextDrivers }) })
+      return
+    }
+
+    // Cascading selectors (year / GP / session): compose the patch over the
+    // COMMITTED-latest URL, not the render-captured `search`.
+    void navigate({ search: (prevRaw) => toRaw(applySelectionPatch(fromRaw(prevRaw), patch)) })
   }
 
   const hasDrivers = search.drivers.length > 0

--- a/webapp/src/features/dashboard/store.ts
+++ b/webapp/src/features/dashboard/store.ts
@@ -34,20 +34,26 @@ interface DashboardState {
 
 export const useDashboardStore = create<DashboardState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       selectedLapsPerDriver: {},
       setLap: (driver, lap) =>
         set((s) => ({ selectedLapsPerDriver: { ...s.selectedLapsPerDriver, [driver]: lap } })),
       setFastestLaps: (laps) => set({ selectedLapsPerDriver: laps }),
-      pruneLaps: (drivers) =>
-        set((s) => {
-          const allowed = new Set(drivers)
-          const next: Record<string, number> = {}
-          for (const [driver, lap] of Object.entries(s.selectedLapsPerDriver)) {
-            if (allowed.has(driver)) next[driver] = lap
-          }
-          return { selectedLapsPerDriver: next }
-        }),
+      pruneLaps: (drivers) => {
+        // No-op guard: this fires on every selection change (a DashboardPage
+        // effect), but usually nothing needs pruning. Bail BEFORE `set` when
+        // every loaded driver is still allowed — a fresh map identity here
+        // notifies all subscribers, re-rendering every chart and resetting the
+        // paint debounce mid-sweep (see design-specs/chart-animation-selection-bugs.md).
+        const current = get().selectedLapsPerDriver
+        const allowed = new Set(drivers)
+        if (Object.keys(current).every((driver) => allowed.has(driver))) return
+        const next: Record<string, number> = {}
+        for (const [driver, lap] of Object.entries(current)) {
+          if (allowed.has(driver)) next[driver] = lap
+        }
+        set({ selectedLapsPerDriver: next })
+      },
       clearLaps: () => set({ selectedLapsPerDriver: {} }),
 
       showOutliers: false,


### PR DESCRIPTION
The real fix for both bugs (audit: `docs/migration/design-specs/chart-animation-selection-bugs.md`), **both verified in-browser** (frame-diff detector + fast-select stress).

## BUG A — the entrance sweep plays once
- **Drop the paint-once ref.** It flipped in the mount effect — before echarts-for-react's async double-init had created the real instance — then forced `animation:false`, and because `notMerge` reuses same-name series views, the in-flight sweep snapped to instant. The hook now returns `animationDurationUpdate:0`: entrances (new series views — first paint AND newly added drivers) sweep; every update is instant; there's no animate→frozen render transition left to cancel a running sweep.
- **Kill the option-identity churn** that fired spurious mid-sweep `setOption`s: `useMemo` the search (stable `raw` from TanStack Router) so the charts' `memo` holds, and give `pruneLaps` a no-op guard so it stops notifying all subscribers when nothing is pruned.

## BUG B — fast selection keeps every driver
- URL navigations are async and don't compose across a rapid burst (each sees the same pre-burst `prev`), so a fast multi-select overwrote earlier picks. Track the intended selection in a **synchronous ref**, toggle per click (delta derived from the same-render selection→patch), and always navigate with the full accumulated set. Cascading selectors use a functional navigate updater.

## Verification
- **A:** frame-diff detector on 2023 Monaco R (VER, LEC) — a visible multi-frame paint sweep (vs the instant spawn before).
- **B:** 3-driver rapid pick (45/20ms gaps) — URL ends `VER,LEC,PER`, none dropped.
- tsc -b, oxlint, vitest (44/44), vite build — all green.