### PR TITLE
feat(webapp): add the Strategy pit-wall tab (#35)

### DIFF
--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -5,6 +5,8 @@ import { HomePage } from '@/features/home/HomePage'
 import { ThemePreview } from '@/features/dev/ThemePreview'
 import { DashboardPage } from '@/features/dashboard/DashboardPage'
 import { validateDashboardSearch } from '@/features/dashboard/search'
+import { StrategyPage } from '@/features/strategy/StrategyPage'
+import { validateStrategySearch } from '@/features/strategy/search'
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
 // content plane, see Shell.tsx); the shell's <Outlet/> renders whichever leaf
@@ -42,14 +44,14 @@ const dashboardRoute = createRoute({
   component: DashboardPage,
 })
 
-// Strategy shares the Dashboard's selection shape so the Home launcher's
-// "Open in Strategy" can carry year/gp/session/drivers forward (wired up in
-// #35), exactly like /comparison below.
+// Strategy (#35) — the multi-agent pit wall. Its own scenario search shape
+// (gp/driver/rival/laps/risk); the Home launcher maps its Year>GP>Session>Drivers
+// selection onto it (GP + first two drivers → driver/rival).
 const strategyRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/strategy',
-  validateSearch: validateDashboardSearch,
-  component: () => <ComingSoon title="Strategy" />,
+  validateSearch: validateStrategySearch,
+  component: StrategyPage,
 })
 
 // Dev-only theme QA surface (not in the rail); the palette the migration used

--- a/webapp/src/components/ActionBadge.tsx
+++ b/webapp/src/components/ActionBadge.tsx
@@ -1,0 +1,73 @@
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  CircleCheck,
+  CircleHelp,
+  TriangleAlert,
+  Wrench,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/cn'
+import type { StrategyAction } from '@/lib/api/strategy'
+
+// The strategy action vocabulary as a badge, at two sizes: `hero` for the
+// Decision Card headline, `sm` for inline use (contingency playbook rows). Each
+// v2 action gets an icon + tone; ALERT pulses (motion-safe) to read as urgent.
+// An unknown action string falls back to a neutral badge, so a schema drift or
+// a sparse response never renders a blank or crashes.
+
+type Tone = 'success' | 'danger' | 'warning' | 'info' | 'neutral'
+
+interface ActionConfig {
+  label: string
+  icon: LucideIcon
+  tone: Tone
+  pulse?: boolean
+}
+
+const ACTIONS: Record<StrategyAction, ActionConfig> = {
+  STAY_OUT: { label: 'STAY OUT', icon: CircleCheck, tone: 'success' },
+  PIT_NOW: { label: 'PIT NOW', icon: Wrench, tone: 'danger' },
+  UNDERCUT: { label: 'UNDERCUT', icon: ArrowDownRight, tone: 'warning' },
+  OVERCUT: { label: 'OVERCUT', icon: ArrowUpRight, tone: 'info' },
+  ALERT: { label: 'ALERT', icon: TriangleAlert, tone: 'danger', pulse: true },
+}
+
+const UNKNOWN: ActionConfig = { label: 'UNKNOWN', icon: CircleHelp, tone: 'neutral' }
+
+const TONE_STYLES: Record<Tone, string> = {
+  success: 'bg-success/15 text-success border-success/30',
+  danger: 'bg-danger/15 text-danger border-danger/30',
+  warning: 'bg-warning/15 text-warning border-warning/30',
+  info: 'bg-info/15 text-info border-info/30',
+  neutral: 'bg-bg-4 text-fg-2 border-hairline',
+}
+
+export interface ActionBadgeProps {
+  action: string
+  size?: 'hero' | 'sm'
+  className?: string
+}
+
+/** Render a strategy action as an icon + label badge, tone-coded by action. */
+export function ActionBadge({ action, size = 'sm', className }: ActionBadgeProps) {
+  const config = (ACTIONS as Record<string, ActionConfig>)[action] ?? UNKNOWN
+  const Icon = config.icon
+  const isHero = size === 'hero'
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border font-semibold uppercase tracking-wide',
+        isHero ? 'gap-2.5 px-5 py-2 text-2xl' : 'gap-1.5 px-2.5 py-0.5 text-xs',
+        TONE_STYLES[config.tone],
+        className,
+      )}
+    >
+      <Icon
+        className={cn(isHero ? 'size-6' : 'size-3.5', config.pulse && 'motion-safe:animate-pulse')}
+        aria-hidden="true"
+      />
+      {config.label}
+    </span>
+  )
+}

--- a/webapp/src/components/CompoundPill.tsx
+++ b/webapp/src/components/CompoundPill.tsx
@@ -1,0 +1,56 @@
+import { Pill } from '@/components/Pill'
+
+// A tyre-compound chip in its branded colour. Wraps Pill's `compound` variant
+// but accepts a raw compound string in ANY case — the orchestrator returns
+// uppercase ('SOFT'|'MEDIUM'|'HARD'), while lap_state / FastF1 returns lowercase
+// ('soft'|'intermediate'|'inter'|'wet'). Normalises both so call sites (decision
+// pit plan, situation strip, agent tabs) don't each re-derive the variant.
+// Unknown compounds fall back to a neutral pill with the raw text.
+
+type CompoundVariant = 'SOFT' | 'MEDIUM' | 'HARD' | 'INTERMEDIATE' | 'WET'
+
+function toVariant(compound: string): CompoundVariant | null {
+  switch (compound.toLowerCase()) {
+    case 'soft':
+      return 'SOFT'
+    case 'medium':
+      return 'MEDIUM'
+    case 'hard':
+      return 'HARD'
+    case 'intermediate':
+    case 'inter':
+      return 'INTERMEDIATE'
+    case 'wet':
+      return 'WET'
+    default:
+      return null
+  }
+}
+
+function label(compound: string): string {
+  const lower = compound.toLowerCase()
+  if (!lower) return 'Unknown'
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
+}
+
+export interface CompoundPillProps {
+  compound: string
+  className?: string
+}
+
+/** Branded tyre-compound chip; neutral fallback for an unknown compound. */
+export function CompoundPill({ compound, className }: CompoundPillProps) {
+  const variant = toVariant(compound)
+  if (!variant) {
+    return (
+      <Pill tone="neutral" className={className}>
+        {label(compound)}
+      </Pill>
+    )
+  }
+  return (
+    <Pill compound={variant} className={className}>
+      {label(compound)}
+    </Pill>
+  )
+}

--- a/webapp/src/components/ConfidenceDial.tsx
+++ b/webapp/src/components/ConfidenceDial.tsx
@@ -1,0 +1,72 @@
+import { cn } from '@/lib/cn'
+
+// Radial SVG dial for the orchestrator's self-assessed confidence (0-1). The
+// value is the LLM's own certainty — qualitative, NOT a calibrated probability
+// — so the dial carries a `title` note saying exactly that, to stop a reader
+// mistaking 82% for a validated 82% chance. Pure SVG (no chart lib) since it's
+// one static arc.
+
+const QUALITATIVE_NOTE = 'LLM self-assessed confidence — qualitative, not a calibrated probability'
+
+export interface ConfidenceDialProps {
+  /** Confidence in [0, 1]. */
+  value: number
+  size?: number
+  className?: string
+  /** Footnote explaining what the value means — defaults to the LLM
+   *  self-assessment caveat. Callers wrapping a calibrated model probability
+   *  (overtake / safety-car / undercut) should override this, since the
+   *  default note is factually wrong for those cases. */
+  note?: string
+}
+
+/** Circular confidence gauge: an accent arc sweeping `value` of a full turn. */
+export function ConfidenceDial({
+  value,
+  size = 64,
+  className,
+  note = QUALITATIVE_NOTE,
+}: ConfidenceDialProps) {
+  const pct = Math.min(1, Math.max(0, value))
+  const stroke = size >= 56 ? 6 : 4
+  const radius = (size - stroke) / 2
+  const circumference = 2 * Math.PI * radius
+  const dash = circumference * pct
+
+  return (
+    <div
+      className={cn('relative inline-flex items-center justify-center', className)}
+      style={{ width: size, height: size }}
+      title={note}
+      role="img"
+      aria-label={`Confidence ${Math.round(pct * 100)} percent. ${note}.`}
+    >
+      <svg width={size} height={size} className="-rotate-90" aria-hidden="true">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={stroke}
+          className="stroke-bg-5"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${dash} ${circumference}`}
+          className="stroke-purple-500 transition-[stroke-dasharray] duration-500"
+        />
+      </svg>
+      <span
+        className="absolute font-mono font-semibold tabular-nums text-fg-1"
+        style={{ fontSize: size * 0.28 }}
+      >
+        {Math.round(pct * 100)}%
+      </span>
+    </div>
+  )
+}

--- a/webapp/src/components/Pill.test.tsx
+++ b/webapp/src/components/Pill.test.tsx
@@ -5,7 +5,14 @@ import { Pill } from './Pill'
 describe('Pill', () => {
   it('applies the matching tire color for each compound', () => {
     render(<Pill compound="SOFT">S</Pill>)
-    expect(screen.getByText('S')).toHaveClass('bg-tire-soft', 'text-fg-inv')
+    // Compound pills use fixed dark ink (--tire-ink) + a hairline border so the
+    // light tyre colours stay WCAG-legible in BOTH themes (not theme-flipping
+    // text-fg-inv, which went white-on-light in the light theme).
+    expect(screen.getByText('S')).toHaveClass(
+      'bg-tire-soft',
+      'text-[color:var(--tire-ink)]',
+      'border',
+    )
   })
 
   it('falls back to tone styling when no compound is set', () => {

--- a/webapp/src/components/Pill.tsx
+++ b/webapp/src/components/Pill.tsx
@@ -2,10 +2,11 @@ import { forwardRef, type HTMLAttributes } from 'react'
 import { cn } from '@/lib/cn'
 
 // Small rounded label for statuses, sentiment, intent flags and entity chips
-// (`tone`), or an F1 tire compound (`compound`). Tire hues are light/saturated
-// (see tokens.css), so compound chips always use dark (`fg-inv`) text for
-// contrast instead of the tinted-text treatment tone pills use. When both are
-// passed, `compound` wins — it is the more specific signal.
+// (`tone`), or an F1 tire compound (`compound`). Tire hues are a fixed brand
+// identity (not themeable, see tokens.css), so compound chips always use the
+// non-themeable `--tire-ink` dark text for contrast instead of the tinted-text
+// treatment tone pills use. When both are passed, `compound` wins — it is the
+// more specific signal.
 
 type Tone = 'neutral' | 'purple' | 'success' | 'warning' | 'danger' | 'info'
 type Compound = 'SOFT' | 'MEDIUM' | 'HARD' | 'INTERMEDIATE' | 'WET'
@@ -20,11 +21,11 @@ const TONE_STYLES: Record<Tone, string> = {
 }
 
 const COMPOUND_STYLES: Record<Compound, string> = {
-  SOFT: 'bg-tire-soft text-fg-inv',
-  MEDIUM: 'bg-tire-medium text-fg-inv',
-  HARD: 'bg-tire-hard text-fg-inv',
-  INTERMEDIATE: 'bg-tire-inter text-fg-inv',
-  WET: 'bg-tire-wet text-fg-inv',
+  SOFT: 'bg-tire-soft text-[color:var(--tire-ink)] border border-hairline',
+  MEDIUM: 'bg-tire-medium text-[color:var(--tire-ink)] border border-hairline',
+  HARD: 'bg-tire-hard text-[color:var(--tire-ink)] border border-hairline',
+  INTERMEDIATE: 'bg-tire-inter text-[color:var(--tire-ink)] border border-hairline',
+  WET: 'bg-tire-wet text-[color:var(--tire-ink)] border border-hairline',
 }
 
 export interface PillProps extends HTMLAttributes<HTMLSpanElement> {

--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -24,7 +24,7 @@ import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
 import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTelemetry } from '@/lib/api/telemetry'
-import { getDriverColor, getDriverTextColor } from '../lib/drivers'
+import { getDriverColor, getDriverTextColor } from '@/lib/drivers'
 import type { ChannelConfig } from './channels'
 import { TelemetryLoader } from './TelemetryLoader'
 

--- a/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
+++ b/webapp/src/features/dashboard/components/CircuitDominationSection.tsx
@@ -13,7 +13,7 @@ import { TelemetryLoader } from './TelemetryLoader'
 import { SectionHeader } from './SectionHeader'
 import { Card } from '@/components/Card'
 import { cn } from '@/lib/cn'
-import { getDriverTextColor } from '../lib/drivers'
+import { getDriverTextColor } from '@/lib/drivers'
 import { computeBounds, computeViewBox, buildSegments, buildOutlinePath } from './circuitDraw'
 
 export interface CircuitDominationSectionProps {

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -21,7 +21,7 @@ import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { buildEchartsTheme, F1_LIGHT_THEME, tireColors } from '@/charts/echartsTheme'
 import { ChartMaximizedContext } from '@/components/ChartCard'
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverColor, getDriverTextColor } from '../lib/drivers'
+import { getDriverColor, getDriverTextColor } from '@/lib/drivers'
 import { compoundLabel, compoundVariant } from '../lib/compounds'
 import { formatLapTime, formatLapTimeAxis } from '../lib/lapTime'
 

--- a/webapp/src/features/dashboard/components/LapChartFooter.tsx
+++ b/webapp/src/features/dashboard/components/LapChartFooter.tsx
@@ -10,7 +10,7 @@
 // is non-empty.
 
 import type { LapTime } from '@/lib/api/telemetry'
-import { getDriverColor } from '../lib/drivers'
+import { getDriverColor } from '@/lib/drivers'
 import { CompoundLegend } from './CompoundLegend'
 
 const EYEBROW_CLASSNAME = 'font-medium uppercase tracking-widest text-fg-3'

--- a/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
+++ b/webapp/src/features/dashboard/components/SelectorsToolbar.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react'
 import type { DashboardSearch } from '../search'
 import { MAX_DRIVERS } from '../search'
 import { useGps, useSessions, useDrivers } from '../queries'
-import { getDriverColor } from '../lib/drivers'
+import { getDriverColor } from '@/lib/drivers'
 import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
 import { cn } from '@/lib/cn'
 

--- a/webapp/src/features/home/components/SessionLauncher.tsx
+++ b/webapp/src/features/home/components/SessionLauncher.tsx
@@ -91,14 +91,24 @@ export function SessionLauncher({ value, onChange }: SessionLauncherProps) {
         )}
 
         {ready ? (
-          <Link to="/strategy" search={toRaw(value)}>
+          // Strategy is live (#35). Map the launcher selection onto the Strategy
+          // scenario shape: GP carries over, the first two picked drivers become
+          // the driver + optional rival for the pit-wall duel.
+          <Link
+            to="/strategy"
+            search={{
+              ...(value.gp ? { gp: value.gp } : {}),
+              ...(value.drivers[0] ? { driver: value.drivers[0] } : {}),
+              ...(value.drivers[1] ? { rival: value.drivers[1] } : {}),
+            }}
+          >
             <Button variant="ghost">
-              <ActionContent icon={Crosshair} label="Strategy" soon />
+              <ActionContent icon={Crosshair} label="Strategy" />
             </Button>
           </Link>
         ) : (
           <Button variant="ghost" disabled>
-            <ActionContent icon={Crosshair} label="Strategy" soon />
+            <ActionContent icon={Crosshair} label="Strategy" />
           </Button>
         )}
 

--- a/webapp/src/features/strategy/StrategyPage.tsx
+++ b/webapp/src/features/strategy/StrategyPage.tsx
@@ -1,0 +1,325 @@
+// Strategy page (#35) — the multi-agent pit wall, the crown jewel of the TFG.
+//
+// A three-act experience over the N31 orchestrator: CONFIGURE a scenario
+// (scenario bar, URL-bound so it's shareable) → watch the agent council
+// DELIBERATE (the run IS the loading state, no fake skeletons) → read a
+// DECISION brief with its evidence trail (per-agent analysis, Monte-Carlo
+// scores, stint timeline). Decision first, evidence below.
+//
+// This component owns the URL (scenario config) and the run lifecycle (the
+// /recommend mutation, its abortable timer, and the five view states:
+// idle / running / complete / error / stale). Every child is a dumb consumer of
+// `search` or of the active RunRecord; results persist in the Zustand store so
+// navigating away and back keeps the brief.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import { Check, Crosshair, Link2, RotateCcw, TriangleAlert } from 'lucide-react'
+import { Header } from '@/app/Header'
+import { Button } from '@/components/Button'
+import { EmptyState } from '@/components/EmptyState'
+import { StrategyApiError } from '@/lib/api/strategy'
+import { cn } from '@/lib/cn'
+import { ScenarioBar } from './components/ScenarioBar'
+import { AgentDeliberation } from './components/AgentDeliberation'
+import { SituationStrip } from './components/SituationStrip'
+import { DecisionCard } from './components/DecisionCard'
+import { ScenarioScoresChart } from './components/ScenarioScoresChart'
+import { StintTimeline } from './components/StintTimeline'
+import { AgentTabs } from './components/AgentTabs'
+import { useStrategyStore, selectActiveRun, type RunRecord } from './store'
+import { useStrategyGps, useStrategyDrivers, useLapRange, useRecommend } from './queries'
+import { applyStrategyPatch, fromRaw, toRaw, type StrategySearch } from './search'
+
+const routeApi = getRouteApi('/strategy')
+
+/** Two scenarios are the same run when every config field matches. */
+function sameScenario(a: StrategySearch, b: StrategySearch): boolean {
+  return (
+    a.gp === b.gp &&
+    a.driver === b.driver &&
+    a.rival === b.rival &&
+    a.risk === b.risk &&
+    a.laps?.[0] === b.laps?.[0] &&
+    a.laps?.[1] === b.laps?.[1]
+  )
+}
+
+/** Serialise the full recommendation verbatim and trigger a file download. */
+function downloadRunJson(run: RunRecord): void {
+  const { gp, driver } = run.config
+  const lap = run.lapState.lap_number
+  const filename = `strategy_${gp ?? 'gp'}_${driver ?? 'drv'}_lap${lap}.json`.replace(/\s+/g, '_')
+  const blob = new Blob([JSON.stringify(run.result, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+export function StrategyPage() {
+  const raw = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  // Memoize: fromRaw builds fresh arrays each call; a stable identity keeps the
+  // child charts' memo intact across unrelated renders (same fix as Dashboard).
+  const search = useMemo(() => fromRaw(raw), [raw])
+
+  const gpsQuery = useStrategyGps()
+  const driversQuery = useStrategyDrivers(search.gp)
+  const lapRangeQuery = useLapRange(search.gp, search.driver)
+  const recommend = useRecommend()
+
+  const runs = useStrategyStore((s) => s.runs)
+  const addRun = useStrategyStore((s) => s.addRun)
+  const activeRun = useStrategyStore(selectActiveRun)
+
+  // The scenario bar collapses to a chip row once a run exists; "Edit scenario"
+  // re-expands it. A fresh run collapses it again.
+  const [editing, setEditing] = useState(false)
+
+  // Elapsed timer for the deliberation panel — ticks only while a run is
+  // in-flight, reset on each new run.
+  const [elapsedMs, setElapsedMs] = useState(0)
+  useEffect(() => {
+    if (!recommend.isPending) return
+    const start = Date.now()
+    setElapsedMs(0)
+    const id = setInterval(() => setElapsedMs(Date.now() - start), 100)
+    return () => clearInterval(id)
+  }, [recommend.isPending])
+
+  // AbortController for the Cancel button — aborting rejects the in-flight fetch.
+  const abortRef = useRef<AbortController | null>(null)
+
+  /** Apply a single-key scenario patch (cascade + navigate), like Dashboard. */
+  const handleChange = (patch: Partial<StrategySearch>) => {
+    if (applyStrategyPatch(search, patch) === search) return
+    void navigate({ search: (prevRaw) => toRaw(applyStrategyPatch(fromRaw(prevRaw), patch)) })
+  }
+
+  // The lap window defaults to the driver's full range until the slider is
+  // touched, so a run is possible the moment gp+driver+range are ready.
+  const lapRange = lapRangeQuery.data
+  const effectiveLaps: [number, number] | undefined =
+    search.laps ?? (lapRange ? [lapRange.min_lap, lapRange.max_lap] : undefined)
+  const canRun = !!search.gp && !!search.driver && !!effectiveLaps
+
+  const handleRun = () => {
+    if (!canRun || !effectiveLaps) return
+    const controller = new AbortController()
+    abortRef.current = controller
+    const runSearch: StrategySearch = { ...search, laps: effectiveLaps }
+    recommend.mutate(
+      { search: runSearch, signal: controller.signal },
+      {
+        onSuccess: ({ lapState, result }) => {
+          addRun({
+            id: crypto.randomUUID(),
+            config: runSearch,
+            lapState,
+            result,
+            ranAt: Date.now(),
+          })
+          setEditing(false)
+        },
+      },
+    )
+  }
+
+  /** Abort the run and drop the (abort) error so we fall back to the prior view. */
+  const handleCancel = () => {
+    abortRef.current?.abort()
+    recommend.reset()
+  }
+
+  const [copied, setCopied] = useState(false)
+  const handleCopyLink = () => {
+    void navigator.clipboard?.writeText(window.location.href)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  // ── Derived view state ────────────────────────────────────────────────────
+  const running = recommend.isPending
+  const hasRun = !!activeRun
+  const collapsed = hasRun && !editing && !running
+  const isStale = hasRun && !running && !sameScenario(activeRun.config, search)
+  const apiError = recommend.error instanceof StrategyApiError ? recommend.error : null
+  const showError = recommend.isError
+
+  return (
+    <>
+      <Header title="Strategy">
+        {hasRun ? (
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="sm" onClick={handleCopyLink}>
+              {copied ? (
+                <Check className="size-4 text-success" aria-hidden="true" />
+              ) : (
+                <Link2 className="size-4" aria-hidden="true" />
+              )}
+              {copied ? 'Copied' : 'Copy scenario link'}
+            </Button>
+          </div>
+        ) : null}
+      </Header>
+
+      <div className="flex flex-col gap-6">
+        {/* Scenario bar — sticky under the header, the persistent config surface. */}
+        <div className="sticky top-14 z-20 -mx-6 border-b border-hairline bg-bg-1/85 px-6 py-3 backdrop-blur">
+          <ScenarioBar
+            search={search}
+            gps={gpsQuery.data ?? []}
+            gpsLoading={gpsQuery.isLoading}
+            drivers={driversQuery.data ?? []}
+            driversLoading={driversQuery.isLoading}
+            lapRange={lapRange}
+            onChange={(patch) => {
+              setEditing(true)
+              handleChange(patch)
+            }}
+            onRun={handleRun}
+            running={running}
+            collapsed={collapsed}
+            onEdit={() => setEditing(true)}
+          />
+        </div>
+
+        {running ? (
+          <AgentDeliberation elapsedMs={elapsedMs} onCancel={handleCancel} />
+        ) : showError ? (
+          <StrategyErrorBanner error={apiError} onRetry={handleRun} />
+        ) : hasRun ? (
+          <CompleteView
+            run={activeRun}
+            isStale={isStale}
+            onRerun={handleRun}
+            onDownloadJson={() => downloadRunJson(activeRun)}
+          />
+        ) : (
+          <IdleView
+            search={search}
+            hasGps={(gpsQuery.data?.length ?? 0) > 0}
+            runCount={runs.length}
+          />
+        )}
+      </div>
+    </>
+  )
+}
+
+/** The completed decision brief + its evidence trail. */
+function CompleteView({
+  run,
+  isStale,
+  onRerun,
+  onDownloadJson,
+}: {
+  run: RunRecord
+  isStale: boolean
+  onRerun: () => void
+  onDownloadJson: () => void
+}) {
+  const { result, lapState, config } = run
+  return (
+    <div className="flex flex-col gap-6">
+      {isStale ? (
+        <div
+          role="status"
+          className="flex flex-wrap items-center gap-3 rounded-2xl border border-hairline border-l-4 border-l-warning bg-bg-3 px-4 py-3 text-sm text-fg-2"
+        >
+          <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
+          <span>
+            The scenario has changed since this run — the brief below is from the previous one.
+          </span>
+          <Button size="sm" variant="ghost" className="ml-auto" onClick={onRerun}>
+            <RotateCcw className="size-4" aria-hidden="true" />
+            Re-run
+          </Button>
+        </div>
+      ) : null}
+
+      <SituationStrip lapState={lapState} rival={config.rival} />
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <div className="min-w-0 xl:col-span-2">
+          <DecisionCard
+            result={result}
+            lapState={lapState}
+            rival={config.rival}
+            onDownloadJson={onDownloadJson}
+          />
+        </div>
+        <div className="min-w-0 xl:col-span-1">
+          <ScenarioScoresChart scores={result.scenario_scores} chosenAction={result.action} />
+        </div>
+      </div>
+
+      {/* Stint timeline full-width — a lap-axis ruler reads far better wide than
+          crammed into the 1/3 rail (audit P1). */}
+      <StintTimeline lapState={lapState} result={result} />
+
+      <AgentTabs lapState={lapState} enabled />
+    </div>
+  )
+}
+
+/** The pre-run empty state — progressive prompt of what to configure. */
+function IdleView({
+  search,
+  hasGps,
+  runCount,
+}: {
+  search: StrategySearch
+  hasGps: boolean
+  runCount: number
+}) {
+  const description = !hasGps
+    ? 'Loading available Grands Prix…'
+    : !search.gp
+      ? 'Pick a Grand Prix above to begin.'
+      : !search.driver
+        ? 'Pick a driver, then a lap window and risk appetite.'
+        : 'Set the lap window and risk, then run the pit wall to get a defensible strategy call.'
+  return (
+    <EmptyState
+      icon={<Crosshair className="size-8 text-fg-3" aria-hidden="true" />}
+      title="Configure a strategy scenario"
+      description={description}
+      className={cn(runCount > 0 && 'opacity-90')}
+    />
+  )
+}
+
+/** Orchestrator failure — tailored copy by status; config is preserved so Retry
+ *  just re-fires the same scenario. */
+function StrategyErrorBanner({
+  error,
+  onRetry,
+}: {
+  error: StrategyApiError | null
+  onRetry: () => void
+}) {
+  const isRateLimited = error?.isRateLimited ?? false
+  const message = isRateLimited
+    ? 'Rate limit reached (5 runs per minute). Wait a moment, then retry.'
+    : (error?.message ?? 'The orchestrator could not complete this run.')
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-3 rounded-2xl border border-hairline border-l-4 border-l-danger bg-bg-3 px-5 py-4"
+    >
+      <div className="flex items-center gap-3 text-sm text-fg-1">
+        <TriangleAlert className="size-5 shrink-0 text-danger" aria-hidden="true" />
+        <span className="font-medium">Run failed</span>
+      </div>
+      <p className="text-sm text-fg-2">{message}</p>
+      <Button size="sm" variant="primary" className="self-start" onClick={onRetry}>
+        <RotateCcw className="size-4" aria-hidden="true" />
+        Retry
+      </Button>
+    </div>
+  )
+}

--- a/webapp/src/features/strategy/components/AgentDeliberation.tsx
+++ b/webapp/src/features/strategy/components/AgentDeliberation.tsx
@@ -1,0 +1,120 @@
+import { X } from 'lucide-react'
+import { Card } from '@/components/Card'
+import { Button } from '@/components/Button'
+import { StatusStepper, type StatusStep } from '@/components/StatusStepper'
+import { Pill } from '@/components/Pill'
+import { cn } from '@/lib/cn'
+
+// The loading/running experience while POST /recommend is in flight. The
+// endpoint has no progress channel of its own — it returns exactly once, at
+// the very end — so this narrates a SCRIPTED four-stage pipeline derived from
+// `elapsedMs` (ticked by the page) rather than any real signal from the
+// backend. The stages mirror N31's actual phases (lap-state fetch -> 4 ML
+// sub-agents -> 500-sample Monte-Carlo scoring -> LLM synthesis), so the
+// narration stays truthful even though its timing is only approximate. The
+// synthesis stage has no upper threshold: it is the long, variable tail (a
+// few seconds to ~30s), and the page unmounts this component the moment the
+// real result lands — there is deliberately no "done" state to render here.
+
+const DELIBERATION_STEPS: StatusStep[] = [
+  { id: 'lap-state', label: 'Building lap state…' },
+  { id: 'sub-agents', label: 'Running agents (Pace · Tire · Pit · SC · Radio)…' },
+  { id: 'monte-carlo', label: 'Scoring 500 Monte-Carlo × 4 scenarios…' },
+  { id: 'synthesis', label: 'Synthesizing recommendation…' },
+]
+
+const AGENT_CHIP_LABELS = ['Pace', 'Tire', 'Pit', 'SC', 'Radio'] as const
+
+// Millisecond thresholds between the scripted stages above, chosen from the
+// pipeline's known relative costs (a parquet lookup is near-instant, the 4
+// sub-agents are cheap ML calls, Monte-Carlo scoring is in-memory, LLM
+// synthesis is the slow part) rather than any measured distribution — good
+// enough to feel alive without pretending to know the true progress.
+const STAGE_1_START_MS = 700
+const STAGE_2_START_MS = 6_500
+const STAGE_3_START_MS = 9_000
+
+/** Resolve which of the 4 scripted stages is active for a given elapsed time.
+ *  Pure and file-local so the thresholds above stay easy to eyeball and tune. */
+function deliberationStage(elapsedMs: number): number {
+  if (elapsedMs < STAGE_1_START_MS) return 0
+  if (elapsedMs < STAGE_2_START_MS) return 1
+  if (elapsedMs < STAGE_3_START_MS) return 2
+  return 3
+}
+
+/** "12.3s" — the elapsed run timer. */
+function formatElapsed(elapsedMs: number): string {
+  return `${(elapsedMs / 1000).toFixed(1)}s`
+}
+
+interface AgentChipsProps {
+  stage: number
+}
+
+/** Five pulsing pills standing in for the sub-agent council. Purely
+ *  decorative — the StatusStepper above already carries the accessible
+ *  narration — so these are `aria-hidden`. They stay dim and still during the
+ *  lap-state stage, then pulse with a small stagger from stage 1 onward so
+ *  the row reads as several agents working concurrently rather than one
+ *  blinking light. */
+function AgentChips({ stage }: AgentChipsProps) {
+  const isDeliberating = stage >= 1
+  return (
+    <div className="flex flex-wrap gap-2" aria-hidden="true">
+      {AGENT_CHIP_LABELS.map((label, index) => (
+        <Pill
+          key={label}
+          tone={isDeliberating ? 'purple' : 'neutral'}
+          className={cn(isDeliberating && 'motion-safe:animate-pulse')}
+          style={isDeliberating ? { animationDelay: `${index * 150}ms` } : undefined}
+        >
+          {label}
+        </Pill>
+      ))}
+    </div>
+  )
+}
+
+export interface AgentDeliberationProps {
+  /** Milliseconds since the run started; the page ticks this while the
+   *  mutation is in flight. */
+  elapsedMs: number
+  /** Cancel the in-flight run (aborts the underlying request). */
+  onCancel: () => void
+}
+
+/**
+ * The N31 orchestrator run's loading state — deliberately not a generic
+ * skeleton. Shows a scripted stage narration, a pulsing agent council, and an
+ * elapsed timer so a 5-30s LLM-backed wait reads as visible progress instead
+ * of a stalled spinner.
+ */
+export function AgentDeliberation({ elapsedMs, onCancel }: AgentDeliberationProps) {
+  const stage = deliberationStage(elapsedMs)
+
+  return (
+    <Card className="flex flex-col gap-5 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-display text-lg text-fg-1">Deliberating…</p>
+          <p className="text-sm text-fg-3">The pit wall council is scoring your strategy.</p>
+        </div>
+        <span className="font-mono text-sm tabular-nums text-fg-3">{formatElapsed(elapsedMs)}</span>
+      </div>
+
+      <div aria-live="polite">
+        <StatusStepper steps={DELIBERATION_STEPS} activeIndex={stage} />
+      </div>
+
+      <AgentChips stage={stage} />
+
+      <div className="flex justify-end">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          <X className="size-4" aria-hidden="true" />
+          Cancel
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/webapp/src/features/strategy/components/AgentTabs.tsx
+++ b/webapp/src/features/strategy/components/AgentTabs.tsx
@@ -1,0 +1,512 @@
+// The Strategy tab's per-agent evidence pane (#35's "pit wall"). Segmented
+// tabs — Pace / Tyres / Situation / Pit — each surface that sub-agent's raw ML
+// output underneath the LLM-synthesised recommendation, so a strategist can
+// audit *why* the orchestrator decided what it decided, not just *what* it
+// decided. Sibling to `ScenarioBar` in this same directory: same "pure
+// presentational, page owns the data" idiom.
+//
+// Lazy-fetch contract: a tab's `useAgent` call only becomes `enabled` once
+// BOTH the master gate (`enabled` — a run has completed) AND that specific
+// tab has been opened at least once are true. TanStack Query then caches the
+// result keyed on (gp, driver, lap) — see `useAgent` in `../queries` — so
+// flipping back and forth between tabs never re-fetches. The default 'pace'
+// tab counts as opened the instant this component mounts, matching what the
+// user actually sees on screen.
+//
+// Null tolerance: the 4 result shapes in `lib/api/strategy.ts` are hand-typed
+// over a backend that returns `Dict[str, Any]` with no response-model
+// validation, so a field being `null`/missing at runtime despite its TS type
+// claiming `number`/`string` is a real case, not just type-checker paranoia.
+// Every numeric read goes through `fmt`/`fmtSigned`; every categorical field
+// goes through `levelConfig`; both degrade to a placeholder instead of
+// crashing.
+
+import { useState, type ReactNode } from 'react'
+import type { LapState } from '@/lib/api/strategy'
+import { useAgent } from '../queries'
+import { Card } from '@/components/Card'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/Tabs'
+import { StatCard, MetricRow } from '@/components/StatCard'
+import { ConfidenceDial } from '@/components/ConfidenceDial'
+import { CompoundPill } from '@/components/CompoundPill'
+import { Pill } from '@/components/Pill'
+import { Skeleton } from '@/components/Skeleton'
+
+// ── Formatting helpers ───────────────────────────────────────────────────
+
+/**
+ * Fixed-point formatter tolerant of null/undefined/NaN. Renders an em dash
+ * instead of crashing `.toFixed()` — see the module docstring for why a
+ * "number" field can still be missing at runtime.
+ */
+function fmt(value: number | null | undefined, digits: number, unit = ''): string {
+  if (value == null || Number.isNaN(value)) return '—'
+  return `${value.toFixed(digits)}${unit}`
+}
+
+/** Same as `fmt`, but always shows a leading sign so direction reads at a
+ *  glance (e.g. "+0.12s" vs "-0.08s"). */
+function fmtSigned(value: number | null | undefined, digits: number, unit = ''): string {
+  if (value == null || Number.isNaN(value)) return '—'
+  const prefix = value > 0 ? '+' : ''
+  return `${prefix}${value.toFixed(digits)}${unit}`
+}
+
+type DeltaTone = 'success' | 'danger' | 'neutral'
+
+const DELTA_COLOR: Record<DeltaTone, string> = {
+  success: 'text-success',
+  danger: 'text-danger',
+  neutral: 'text-fg-1',
+}
+
+/** Tone for a signed delta: negative = faster/better (green), positive =
+ *  slower/worse (red), zero or missing = neutral. */
+function deltaTone(value: number | null | undefined): DeltaTone {
+  if (value == null || Number.isNaN(value) || value === 0) return 'neutral'
+  return value < 0 ? 'success' : 'danger'
+}
+
+// ── Categorical level → Pill label + tone ───────────────────────────────
+//
+// The 3 categorical fields (tyre warning_level, situation threat_level, pit
+// action) are plain strings over an untyped backend dict — the exact literal
+// sets come straight from the Python agents (tire_agent.py, race_situation_
+// agent.py, pit_strategy_agent.py) rather than a shared TS enum, so each gets
+// its own small config map here, mirroring `ActionBadge.tsx`'s ActionConfig
+// pattern for the same reason: a value outside the known set must degrade
+// gracefully, never crash.
+
+type PillTone = 'neutral' | 'purple' | 'success' | 'warning' | 'danger' | 'info'
+
+interface LevelConfig {
+  label: string
+  tone: PillTone
+}
+
+const TIRE_WARNING_CONFIG: Record<string, LevelConfig> = {
+  OK: { label: 'OK', tone: 'success' },
+  MONITOR: { label: 'Monitor', tone: 'warning' },
+  PIT_SOON: { label: 'Pit soon', tone: 'danger' },
+}
+
+const THREAT_CONFIG: Record<string, LevelConfig> = {
+  LOW: { label: 'Low', tone: 'success' },
+  MEDIUM: { label: 'Medium', tone: 'warning' },
+  HIGH: { label: 'High', tone: 'danger' },
+}
+
+const PIT_ACTION_CONFIG: Record<string, LevelConfig> = {
+  STAY_OUT: { label: 'Stay out', tone: 'success' },
+  PIT_NOW: { label: 'Pit now', tone: 'danger' },
+  UNDERCUT: { label: 'Undercut', tone: 'warning' },
+  OVERCUT: { label: 'Overcut', tone: 'warning' },
+  REACTIVE_SC: { label: 'Reactive SC', tone: 'danger' },
+}
+
+const UNKNOWN_LEVEL: LevelConfig = { label: 'Unknown', tone: 'neutral' }
+
+/** Look up a categorical level's Pill label + tone. Case-tolerant; a value
+ *  outside the known set still renders (its raw text, neutral tone) instead
+ *  of disappearing or throwing. */
+function levelConfig(
+  map: Record<string, LevelConfig>,
+  level: string | null | undefined,
+): LevelConfig {
+  if (!level) return UNKNOWN_LEVEL
+  return map[level.toUpperCase()] ?? { label: level, tone: 'neutral' }
+}
+
+// ── Micro-charts (plain HTML/CSS — no chart lib for a handful of static shapes) ──
+
+interface RangeBarProps {
+  low: number | null | undefined
+  mid: number | null | undefined
+  high: number | null | undefined
+  format: (value: number) => string
+}
+
+/** Horizontal range indicator: a track from `low` to `high` with a marker dot
+ *  at `mid` (a confidence interval, or a P05-P95 spread). Null-tolerant: any
+ *  missing bound falls back to a short text note instead of a broken shape. */
+function RangeBar({ low, mid, high, format }: RangeBarProps) {
+  const isValid =
+    low != null &&
+    mid != null &&
+    high != null &&
+    !Number.isNaN(low) &&
+    !Number.isNaN(mid) &&
+    !Number.isNaN(high)
+  if (!isValid) return <p className="text-xs text-fg-4">Range unavailable</p>
+
+  const span = high - low
+  const rawPct = span > 0 ? ((mid - low) / span) * 100 : 50
+  const markerPct = Math.min(100, Math.max(0, rawPct))
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="relative h-1.5 rounded-full bg-bg-5" aria-hidden="true">
+        <div className="absolute left-0 top-1/2 h-2 w-px -translate-y-1/2 bg-fg-4" />
+        <div className="absolute right-0 top-1/2 h-2 w-px -translate-y-1/2 bg-fg-4" />
+        <div
+          className="absolute size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-purple-500"
+          style={{ left: `${markerPct}%`, top: '50%' }}
+        />
+      </div>
+      <div className="flex justify-between font-mono text-xs tabular-nums text-fg-4">
+        <span>{format(low)}</span>
+        <span className="text-fg-1">{format(mid)}</span>
+        <span>{format(high)}</span>
+      </div>
+    </div>
+  )
+}
+
+interface MiniBarItem {
+  label: string
+  value: number | null | undefined
+}
+
+interface MiniBarsProps {
+  items: MiniBarItem[]
+  format: (value: number) => string
+}
+
+/** A handful of small vertical bars scaled to their shared max, for a quick
+ *  visual compare (e.g. laps-to-cliff P10/P50/P90). Drops any item whose
+ *  value is missing rather than rendering a broken bar. */
+function MiniBars({ items, format }: MiniBarsProps) {
+  const valid = items.filter(
+    (item): item is { label: string; value: number } =>
+      item.value != null && !Number.isNaN(item.value),
+  )
+  if (valid.length === 0) return <p className="text-xs text-fg-4">No data</p>
+
+  const max = Math.max(1, ...valid.map((item) => item.value))
+
+  return (
+    <div className="flex items-end gap-4">
+      {valid.map((item) => (
+        <div key={item.label} className="flex flex-col items-center gap-1.5">
+          <div className="flex h-16 w-6 items-end rounded bg-bg-5">
+            <div
+              className="w-full rounded bg-purple-500"
+              style={{ height: `${Math.max(6, (item.value / max) * 100)}%` }}
+            />
+          </div>
+          <span className="font-mono text-xs tabular-nums text-fg-2">{format(item.value)}</span>
+          <span className="text-[10px] uppercase tracking-wide text-fg-4">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Small uppercase caption above a micro-chart, matching `StatCard`'s eyebrow
+ *  styling so a tab's charts read as part of the same visual system. */
+function ChartLabel({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium uppercase tracking-widest text-fg-3">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+// ── Shared per-tab states (loading / error / idle / reasoning) ──────────
+
+/** Structural loading placeholder — `cards` approximates the number of
+ *  StatCard-sized blocks the real content will show once it arrives. */
+function AgentTabSkeleton({ cards }: { cards: number }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {Array.from({ length: cards }, (_, index) => (
+          <Skeleton key={index} className="h-20 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-16 w-full" />
+    </div>
+  )
+}
+
+function AgentUnavailable() {
+  return <p className="text-sm text-fg-4">Agent unavailable.</p>
+}
+
+function AgentIdle() {
+  return <p className="text-sm text-fg-4">Run a scenario to see this agent&rsquo;s evidence.</p>
+}
+
+/** The agent's free-text reasoning, tucked behind a `<details>` disclosure so
+ *  the tab's headline numbers stay the focus. Renders nothing for an empty
+ *  reasoning string rather than an empty disclosure. */
+function ReasoningDisclosure({ reasoning }: { reasoning: string | null | undefined }) {
+  if (!reasoning) return null
+  return (
+    <details className="group rounded-lg border border-hairline bg-bg-4 p-3">
+      <summary className="cursor-pointer select-none text-xs font-medium uppercase tracking-widest text-fg-3 group-open:text-fg-1">
+        Reasoning
+      </summary>
+      <p className="mt-2 whitespace-pre-wrap text-sm text-fg-2">{reasoning}</p>
+    </details>
+  )
+}
+
+// ── Per-agent tabs ───────────────────────────────────────────────────────
+//
+// Each tab calls its own `useAgent` unconditionally (rules of hooks) and
+// gates only the *fetch* via the `enabled` argument — never the hook call
+// itself. State order is always: error → data → (enabled ? skeleton : idle).
+
+interface AgentTabPanelProps {
+  lapState: LapState
+  enabled: boolean
+}
+
+/** Pace evidence: predicted lap time plus both deltas as StatCards, a
+ *  confidence-interval range bar around the point prediction, and the
+ *  agent's reasoning. */
+function PaceTab({ lapState, enabled }: AgentTabPanelProps) {
+  const query = useAgent('pace', lapState, enabled)
+
+  if (query.isError) return <AgentUnavailable />
+  if (!query.data) return enabled ? <AgentTabSkeleton cards={3} /> : <AgentIdle />
+
+  const pace = query.data
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <StatCard eyebrow="Lap time" value={fmt(pace.lap_time_pred, 3, 's')} />
+        <StatCard
+          eyebrow="Δ vs median"
+          value={
+            <span className={DELTA_COLOR[deltaTone(pace.delta_vs_median)]}>
+              {fmtSigned(pace.delta_vs_median, 2, 's')}
+            </span>
+          }
+          hint="Negative = faster than the field median"
+        />
+        <StatCard
+          eyebrow="Δ vs previous"
+          value={
+            <span className={DELTA_COLOR[deltaTone(pace.delta_vs_prev)]}>
+              {fmtSigned(pace.delta_vs_prev, 2, 's')}
+            </span>
+          }
+          hint="Negative = faster than the last lap"
+        />
+      </div>
+      <ChartLabel label="Confidence interval">
+        <RangeBar
+          low={pace.ci_p10}
+          mid={pace.lap_time_pred}
+          high={pace.ci_p90}
+          format={(value) => `${value.toFixed(2)}s`}
+        />
+      </ChartLabel>
+      <ReasoningDisclosure reasoning={pace.reasoning} />
+    </div>
+  )
+}
+
+/** Tyre evidence: compound + warning-level pills, tyre-life/degradation
+ *  StatCards, and a laps-to-cliff P10/P50/P90 mini bar chart. */
+function TyresTab({ lapState, enabled }: AgentTabPanelProps) {
+  const query = useAgent('tire', lapState, enabled)
+
+  if (query.isError) return <AgentUnavailable />
+  if (!query.data) return enabled ? <AgentTabSkeleton cards={2} /> : <AgentIdle />
+
+  const tire = query.data
+  const warning = levelConfig(TIRE_WARNING_CONFIG, tire.warning_level)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {tire.compound ? <CompoundPill compound={tire.compound} /> : null}
+        <Pill tone={warning.tone}>{warning.label}</Pill>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <StatCard eyebrow="Tyre life" value={fmt(tire.current_tyre_life, 0, ' laps')} />
+        <StatCard eyebrow="Degradation rate" value={fmt(tire.deg_rate, 3, 's/lap')} />
+      </div>
+      <ChartLabel label="Laps to cliff (P10 / P50 / P90)">
+        <MiniBars
+          items={[
+            { label: 'P10', value: tire.laps_to_cliff_p10 },
+            { label: 'P50', value: tire.laps_to_cliff_p50 },
+            { label: 'P90', value: tire.laps_to_cliff_p90 },
+          ]}
+          format={(value) => value.toFixed(0)}
+        />
+      </ChartLabel>
+      <ReasoningDisclosure reasoning={tire.reasoning} />
+    </div>
+  )
+}
+
+/** Situation evidence: a threat-level pill, side-by-side confidence dials for
+ *  overtake probability and 3-lap safety-car probability, and the
+ *  surrounding gap/pace-delta context. */
+function SituationTab({ lapState, enabled }: AgentTabPanelProps) {
+  const query = useAgent('situation', lapState, enabled)
+
+  if (query.isError) return <AgentUnavailable />
+  if (!query.data) return enabled ? <AgentTabSkeleton cards={2} /> : <AgentIdle />
+
+  const situation = query.data
+  const threat = levelConfig(THREAT_CONFIG, situation.threat_level)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Pill tone={threat.tone} className="w-fit">
+        {threat.label} threat
+      </Pill>
+      <div className="flex flex-wrap gap-6">
+        <div className="flex flex-col items-center gap-2">
+          <ConfidenceDial
+            value={situation.overtake_prob ?? 0}
+            note="Calibrated model probability"
+          />
+          <span className="text-xs uppercase tracking-wide text-fg-4">Overtake</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <ConfidenceDial value={situation.sc_prob_3lap ?? 0} note="Calibrated model probability" />
+          <span className="text-xs uppercase tracking-wide text-fg-4">Safety car (3 laps)</span>
+        </div>
+      </div>
+      <MetricRow
+        items={[
+          { label: 'Gap ahead', value: fmt(situation.gap_ahead_s, 1, 's') },
+          { label: 'Pace Δ', value: fmtSigned(situation.pace_delta_s, 2, 's') },
+        ]}
+      />
+      <ReasoningDisclosure reasoning={situation.reasoning} />
+    </div>
+  )
+}
+
+/** Pit evidence: recommended action + compound pills, recommended-lap/stop-
+ *  duration StatCards, a P05-P95 stop-duration range bar, and — only when the
+ *  agent actually returned one — an undercut-probability dial against its
+ *  target rival. */
+function PitTab({ lapState, enabled }: AgentTabPanelProps) {
+  const query = useAgent('pit', lapState, enabled)
+
+  if (query.isError) return <AgentUnavailable />
+  if (!query.data) return enabled ? <AgentTabSkeleton cards={2} /> : <AgentIdle />
+
+  const pit = query.data
+  const action = levelConfig(PIT_ACTION_CONFIG, pit.action)
+  const hasUndercut = pit.undercut_prob != null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Pill tone={action.tone}>{action.label}</Pill>
+        {pit.compound_recommendation ? (
+          <CompoundPill compound={pit.compound_recommendation} />
+        ) : null}
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <StatCard
+          eyebrow="Recommended lap"
+          value={pit.recommended_lap != null ? `Lap ${pit.recommended_lap}` : '—'}
+        />
+        <StatCard eyebrow="Stop duration (P50)" value={fmt(pit.stop_duration_p50, 1, 's')} />
+      </div>
+      <ChartLabel label="Stop duration range (P05 / P95)">
+        <RangeBar
+          low={pit.stop_duration_p05}
+          mid={pit.stop_duration_p50}
+          high={pit.stop_duration_p95}
+          format={(value) => `${value.toFixed(1)}s`}
+        />
+      </ChartLabel>
+      {hasUndercut ? (
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-col items-center gap-2">
+            <ConfidenceDial value={pit.undercut_prob ?? 0} note="Calibrated model probability" />
+            <span className="text-xs uppercase tracking-wide text-fg-4">Undercut</span>
+          </div>
+          {pit.undercut_target ? (
+            <span className="text-sm text-fg-3">
+              vs <span className="font-mono text-fg-1">{pit.undercut_target}</span>
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      <ReasoningDisclosure reasoning={pit.reasoning} />
+    </div>
+  )
+}
+
+// ── The tab set ──────────────────────────────────────────────────────────
+
+type AgentTabKey = 'pace' | 'tire' | 'situation' | 'pit'
+
+const TAB_LABELS: Record<AgentTabKey, string> = {
+  pace: 'Pace',
+  tire: 'Tyres',
+  situation: 'Situation',
+  pit: 'Pit',
+}
+
+/** 'pace' is the default active tab, so it counts as opened the moment this
+ *  component mounts — no click needed to fire its first fetch. */
+const INITIAL_OPENED: Record<AgentTabKey, boolean> = {
+  pace: true,
+  tire: false,
+  situation: false,
+  pit: false,
+}
+
+export interface AgentTabsProps {
+  lapState: LapState
+  /** Master gate: only fetch once a run has completed (the page passes
+   *  `true` when complete). */
+  enabled: boolean
+}
+
+/**
+ * Segmented tab set exposing each sub-agent's raw ML evidence behind the
+ * synthesised recommendation. See the module docstring for the lazy-fetch
+ * and null-tolerance contracts.
+ */
+export function AgentTabs({ lapState, enabled }: AgentTabsProps) {
+  const [opened, setOpened] = useState<Record<AgentTabKey, boolean>>(INITIAL_OPENED)
+
+  function markOpened(value: string) {
+    const key = value as AgentTabKey
+    setOpened((prev) => (prev[key] ? prev : { ...prev, [key]: true }))
+  }
+
+  return (
+    <Card className="flex flex-col gap-4 p-4">
+      <h3 className="text-sm font-semibold text-fg-1">Agent breakdown</h3>
+      <Tabs defaultValue="pace" onValueChange={markOpened}>
+        <TabsList variant="segmented">
+          <TabsTrigger value="pace">{TAB_LABELS.pace}</TabsTrigger>
+          <TabsTrigger value="tire">{TAB_LABELS.tire}</TabsTrigger>
+          <TabsTrigger value="situation">{TAB_LABELS.situation}</TabsTrigger>
+          <TabsTrigger value="pit">{TAB_LABELS.pit}</TabsTrigger>
+        </TabsList>
+        <TabsContent value="pace" className="pt-4">
+          <PaceTab lapState={lapState} enabled={enabled && opened.pace} />
+        </TabsContent>
+        <TabsContent value="tire" className="pt-4">
+          <TyresTab lapState={lapState} enabled={enabled && opened.tire} />
+        </TabsContent>
+        <TabsContent value="situation" className="pt-4">
+          <SituationTab lapState={lapState} enabled={enabled && opened.situation} />
+        </TabsContent>
+        <TabsContent value="pit" className="pt-4">
+          <PitTab lapState={lapState} enabled={enabled && opened.pit} />
+        </TabsContent>
+      </Tabs>
+    </Card>
+  )
+}

--- a/webapp/src/features/strategy/components/ContingencyList.tsx
+++ b/webapp/src/features/strategy/components/ContingencyList.tsx
@@ -1,0 +1,69 @@
+import { ActionBadge } from '@/components/ActionBadge'
+import type { Contingency, ContingencyPriority } from '@/lib/api/strategy'
+
+// The IF-THEN playbook: conditional branches the orchestrator's LLM synthesis
+// step planned for laps ahead of the current one (e.g. "IF the gap drops
+// under 1s -> UNDERCUT"). A no-LLM / degraded `/recommend` run returns an
+// empty array, so this list renders nothing rather than an empty "Playbook"
+// panel — the caller (DecisionCard) decides whether its own section heading
+// is worth showing at all when there's nothing to plan for.
+
+/** Cap rows so a verbose LLM run can't push the Decision Card off-screen. */
+const MAX_ROWS = 4
+
+const PRIORITY_DOT_TONE: Record<ContingencyPriority, string> = {
+  HIGH: 'bg-danger',
+  MEDIUM: 'bg-warning',
+  LOW: 'bg-fg-4',
+}
+
+/** Map a contingency's priority to its status-dot colour. Filled tonal
+ *  `Pill`s are reserved for the action badge — priority renders as a neutral
+ *  outline chip with a coloured dot instead, so the two don't visually
+ *  compete for the same "important" signal. */
+function priorityDotTone(priority: ContingencyPriority): string {
+  return PRIORITY_DOT_TONE[priority] ?? 'bg-fg-4'
+}
+
+export interface ContingencyListProps {
+  contingencies: Contingency[]
+}
+
+/**
+ * Render up to 4 "IF trigger -> switch_to" playbook rows, each tagged with its
+ * priority and rationale. Returns `null` when there are no contingencies, so
+ * a sparse/no-LLM run never shows an empty list.
+ */
+export function ContingencyList({ contingencies }: ContingencyListProps) {
+  if (contingencies.length === 0) return null
+
+  const rows = contingencies.slice(0, MAX_ROWS)
+
+  return (
+    <ul className="flex flex-col divide-y divide-hairline">
+      {rows.map((contingency, index) => (
+        <li
+          key={`${contingency.trigger}-${index}`}
+          className="flex flex-col gap-1.5 py-2.5 first:pt-0 last:pb-0"
+        >
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="font-mono text-xs uppercase tracking-wide text-fg-4">IF</span>
+            <span className="text-fg-2">{contingency.trigger}</span>
+            <span aria-hidden="true" className="text-fg-4">
+              →
+            </span>
+            <ActionBadge action={contingency.switch_to} size="sm" />
+            <span className="ml-auto inline-flex items-center gap-1.5 rounded-full border border-hairline px-2 py-0.5 font-mono text-xs text-fg-3">
+              <span
+                aria-hidden="true"
+                className={`size-1.5 rounded-full ${priorityDotTone(contingency.priority)}`}
+              />
+              {contingency.priority}
+            </span>
+          </div>
+          <p className="text-xs text-fg-3">{contingency.rationale}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/webapp/src/features/strategy/components/DecisionCard.test.tsx
+++ b/webapp/src/features/strategy/components/DecisionCard.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DecisionCard } from './DecisionCard'
+import type { LapState, StrategyRecommendation } from '@/lib/api/strategy'
+
+// The Decision Card's whole job is to surface the full v2 schema WHILE staying
+// null-tolerant: a no-LLM / degraded run returns only action + reasoning +
+// confidence with every other field null/empty, and that must read as a shorter
+// brief, never a broken one. These two renders (rich + sparse) pin that contract.
+
+const lapState: LapState = {
+  lap_number: 30,
+  driver: {
+    driver: 'VER',
+    team: 'Red Bull',
+    lap_number: 30,
+    lap_time_s: 78.912,
+    position: 1,
+    compound: 'MEDIUM',
+    compound_id: 2,
+    tyre_life: 14,
+    stint: 2,
+    fresh_tyre: false,
+    speed_i1: 300,
+    speed_i2: 280,
+    speed_fl: 320,
+    speed_st: 330,
+    fuel_load: 40,
+    driver_number: 1,
+    sector1_s: 25,
+    sector2_s: 28,
+    sector3_s: 25.9,
+    gap_ahead_s: 2.4,
+  },
+  rivals: [],
+  weather: { air_temp: 25, track_temp: 40, humidity: 50, rainfall: 0 },
+  session_meta: { gp_name: 'Austin', year: 2025, driver: 'VER', team: 'Red Bull', total_laps: 56 },
+}
+
+const richResult: StrategyRecommendation = {
+  action: 'PIT_NOW',
+  reasoning: 'Tyres are past the cliff; boxing now protects track position.',
+  confidence: 0.82,
+  pit_lap_target: 31,
+  compound_next: 'HARD',
+  undercut_target: 'LEC',
+  pace_mode: 'PUSH',
+  target_lap_time_s: 78.45,
+  risk_posture: 'AGGRESSIVE',
+  contingencies: [
+    {
+      trigger: 'Safety car within 3 laps',
+      switch_to: 'STAY_OUT',
+      priority: 'HIGH',
+      rationale: 'Free stop.',
+    },
+  ],
+  key_risks: ['Cliff risk rising in the last three laps'],
+  expected_stint_end: 52,
+  scenario_scores: {
+    PIT_NOW: { E: 0.61, P10: 0.4, P90: 0.8, score: 0.61 },
+    STAY_OUT: { E: 0.44, P10: 0.2, P90: 0.6, score: 0.44 },
+  },
+  regulation_context: 'Article 30.5 governs the mandatory tyre-compound rule.',
+}
+
+/** The minimum a degraded / no-LLM run returns: 3 required fields, rest empty. */
+const sparseResult: StrategyRecommendation = {
+  action: 'STAY_OUT',
+  reasoning: 'Hold position; no undercut threat.',
+  confidence: 0.5,
+  pace_mode: 'NEUTRAL',
+  risk_posture: 'BALANCED',
+  contingencies: [],
+  key_risks: [],
+  scenario_scores: {},
+  regulation_context: '',
+}
+
+describe('DecisionCard', () => {
+  it('surfaces the full v2 brief when every field is present', () => {
+    render(
+      <DecisionCard result={richResult} lapState={lapState} rival="LEC" onDownloadJson={vi.fn()} />,
+    )
+    expect(screen.getByText('PIT NOW')).toBeInTheDocument()
+    expect(screen.getByText('82%')).toBeInTheDocument()
+    expect(screen.getByText('PUSH')).toBeInTheDocument()
+    expect(screen.getByText(/TARGET 78\.450/)).toBeInTheDocument()
+    expect(screen.getByText('AGGRESSIVE')).toBeInTheDocument()
+    expect(screen.getByText(/Box lap/)).toBeInTheDocument()
+    expect(screen.getByText(/Cliff risk rising/)).toBeInTheDocument()
+    expect(screen.getByText("Engineer's note")).toBeInTheDocument()
+    expect(screen.getByText('Regulation context')).toBeInTheDocument()
+    expect(screen.getByText(/stint ends ~lap 52/)).toBeInTheDocument()
+  })
+
+  it('degrades to a shorter brief when optional fields are absent — no broken sections', () => {
+    render(<DecisionCard result={sparseResult} lapState={lapState} onDownloadJson={vi.fn()} />)
+    expect(screen.getByText('STAY OUT')).toBeInTheDocument()
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    // None of the optional sections should render for a sparse result.
+    expect(screen.queryByText(/Box lap/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Key risks')).not.toBeInTheDocument()
+    expect(screen.queryByText('Playbook')).not.toBeInTheDocument()
+    expect(screen.queryByText('Regulation context')).not.toBeInTheDocument()
+    // Never leak literal null/undefined/NaN into the DOM.
+    expect(screen.queryByText(/undefined|NaN|null/)).not.toBeInTheDocument()
+  })
+})

--- a/webapp/src/features/strategy/components/DecisionCard.tsx
+++ b/webapp/src/features/strategy/components/DecisionCard.tsx
@@ -1,0 +1,231 @@
+import { ChevronRight, Download, Scale, TriangleAlert } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { ActionBadge } from '@/components/ActionBadge'
+import { Button } from '@/components/Button'
+import { Card } from '@/components/Card'
+import { CompoundPill } from '@/components/CompoundPill'
+import { ConfidenceDial } from '@/components/ConfidenceDial'
+import { Markdown } from '@/components/Markdown'
+import { Pill } from '@/components/Pill'
+import { cn } from '@/lib/cn'
+import { getDriverTextColor } from '@/lib/drivers'
+import type { LapState, RiskPosture, StrategyRecommendation } from '@/lib/api/strategy'
+import { ContingencyList } from './ContingencyList'
+
+// The Decision Card is the Strategy tab's HERO surface: the full 14-field v2
+// orchestrator recommendation as one scannable "pit wall" brief. The
+// Streamlit predecessor rendered action + reasoning + a raw JSON dump — about
+// 40% of the schema; every section below recreates a field that UI threw
+// away. A no-LLM / degraded `/recommend` run still returns only the 3
+// required fields (action, reasoning, confidence) with everything else
+// null/empty, so EVERY section past the header is gated on its own data
+// being present rather than assumed — a sparse run reads as a shorter brief,
+// never as a broken one.
+
+/** Season used to tint driver codes (rival, undercut target) — matches the
+ *  `/recommend` endpoint's own default year (see lib/api/strategy.ts `YEAR`). */
+const DRIVER_COLOR_YEAR = 2025
+
+const RISK_POSTURE_TONE: Record<RiskPosture, 'danger' | 'neutral' | 'info'> = {
+  AGGRESSIVE: 'danger',
+  BALANCED: 'neutral',
+  DEFENSIVE: 'info',
+}
+
+/** Map a risk posture to the Pill tone that best conveys its aggressiveness. */
+function riskPostureTone(posture: RiskPosture): 'danger' | 'neutral' | 'info' {
+  return RISK_POSTURE_TONE[posture] ?? 'neutral'
+}
+
+/**
+ * Small uppercase eyebrow + purple tick, mirroring the Dashboard's
+ * `SectionHeader` idiom but sized for a card interior rather than a page
+ * section. Kept as a local copy of the pattern (not a cross-feature import)
+ * because features stay decoupled siblings in this codebase — see the
+ * comment atop `lib/drivers.ts`.
+ */
+function SubHeading({ label }: { label: string }) {
+  return (
+    <h3 className="flex items-center gap-2 font-display text-xs font-medium uppercase tracking-widest text-fg-3">
+      <span aria-hidden="true" className="inline-block h-3 w-0.5 rounded-full bg-purple-600" />
+      {label}
+    </h3>
+  )
+}
+
+interface DisclosureProps {
+  icon: LucideIcon
+  label: string
+  /** Whether the icon rotates 90deg on open. True for the chevron on the
+   *  engineer's note (it doubles as the expand/collapse cue); false for the
+   *  static Scale icon on regulation context, which is a content marker, not
+   *  an affordance. */
+  rotateIcon?: boolean
+  children: ReactNode
+}
+
+/**
+ * Native `<details>` disclosure styled to the design tokens — used for the
+ * engineer's note and regulation context panels. Native disclosure is
+ * accessible and keyboard-operable for free; no accordion dependency is
+ * worth pulling in for two static panels.
+ */
+function Disclosure({ icon: Icon, label, rotateIcon = false, children }: DisclosureProps) {
+  return (
+    <details className="group rounded-lg border border-hairline open:bg-bg-4/60">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium text-fg-2 [&::-webkit-details-marker]:hidden">
+        <Icon
+          aria-hidden="true"
+          className={cn(
+            'size-4 shrink-0 text-fg-3',
+            rotateIcon && 'transition-transform duration-200 group-open:rotate-90',
+          )}
+        />
+        {label}
+      </summary>
+      <div className="border-t border-hairline px-3 py-3">{children}</div>
+    </details>
+  )
+}
+
+export interface DecisionCardProps {
+  result: StrategyRecommendation
+  lapState: LapState
+  rival?: string
+  onDownloadJson: () => void
+}
+
+/**
+ * The strategy brief: headline action + confidence, the pace/risk
+ * instruction, the pit plan, key risks, the IF-THEN playbook, and two
+ * collapsible panels (engineer's reasoning, regulation context). See the
+ * module docstring above for why every section past the header is
+ * conditional.
+ */
+export function DecisionCard({ result, lapState, rival, onDownloadJson }: DecisionCardProps) {
+  const hasPitPlan =
+    result.pit_lap_target != null || result.compound_next != null || result.undercut_target != null
+
+  return (
+    <Card elevation="glow" className="flex flex-col gap-5 p-6">
+      <div className="flex flex-col gap-1">
+        <p className="font-mono text-xs uppercase tracking-widest text-fg-4">
+          Lap {lapState.lap_number} / {lapState.session_meta.total_laps} ·{' '}
+          {lapState.session_meta.gp_name} {lapState.session_meta.year}
+        </p>
+        {rival ? (
+          <p className="text-xs uppercase tracking-widest text-fg-3">
+            Battling{' '}
+            <span
+              className="font-mono font-semibold"
+              style={{ color: getDriverTextColor(rival, DRIVER_COLOR_YEAR) }}
+            >
+              {rival}
+            </span>
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <ActionBadge action={result.action} size="hero" />
+        <div className="flex items-center gap-3">
+          <div className="flex flex-col items-center gap-1">
+            <ConfidenceDial value={result.confidence} />
+            <span className="text-[10px] uppercase tracking-widest text-fg-4">self-assessed</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Download strategy JSON"
+            onClick={onDownloadJson}
+          >
+            <Download className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 font-mono text-sm">
+        <span className="font-semibold tracking-wide text-fg-1">{result.pace_mode}</span>
+        {result.target_lap_time_s != null ? (
+          <span className="tabular-nums text-fg-3">
+            · TARGET {result.target_lap_time_s.toFixed(3)}s
+          </span>
+        ) : null}
+        <Pill tone={riskPostureTone(result.risk_posture)} className="ml-auto">
+          {result.risk_posture}
+        </Pill>
+      </div>
+
+      {hasPitPlan ? (
+        <div className="flex flex-col gap-1 rounded-lg bg-bg-4/60 px-3 py-2.5">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-fg-2">
+            {result.pit_lap_target != null ? (
+              <span>
+                Box lap{' '}
+                <span className="font-mono font-semibold text-fg-1">{result.pit_lap_target}</span>
+              </span>
+            ) : null}
+            {result.compound_next ? (
+              <>
+                <span aria-hidden="true">→</span>
+                <CompoundPill compound={result.compound_next} />
+              </>
+            ) : null}
+            {result.undercut_target ? (
+              <span>
+                undercut{' '}
+                <span
+                  className="font-mono font-semibold"
+                  style={{ color: getDriverTextColor(result.undercut_target, DRIVER_COLOR_YEAR) }}
+                >
+                  {result.undercut_target}
+                </span>
+              </span>
+            ) : null}
+          </div>
+          {result.expected_stint_end != null ? (
+            <p className="text-xs text-fg-3">stint ends ~lap {result.expected_stint_end}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {result.key_risks.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <SubHeading label="Key risks" />
+          <ul className="flex flex-col gap-1.5">
+            {result.key_risks.map((risk, index) => (
+              <li key={`${risk}-${index}`} className="flex items-start gap-2 text-sm text-fg-2">
+                <TriangleAlert
+                  className="mt-0.5 size-3.5 shrink-0 text-warning"
+                  aria-hidden="true"
+                />
+                <span>{risk}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {result.contingencies.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <SubHeading label="Playbook" />
+          <ContingencyList contingencies={result.contingencies} />
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        {result.reasoning ? (
+          <Disclosure icon={ChevronRight} label="Engineer's note" rotateIcon>
+            <Markdown>{result.reasoning}</Markdown>
+          </Disclosure>
+        ) : null}
+        {result.regulation_context ? (
+          <Disclosure icon={Scale} label="Regulation context">
+            <Markdown>{result.regulation_context}</Markdown>
+          </Disclosure>
+        ) : null}
+      </div>
+    </Card>
+  )
+}

--- a/webapp/src/features/strategy/components/ScenarioBar.tsx
+++ b/webapp/src/features/strategy/components/ScenarioBar.tsx
@@ -1,0 +1,320 @@
+// The Strategy tab's scenario-configuration bar (#35's "pit wall" entry
+// point). Pure presentational, same idiom as the Dashboard's
+// `SelectorsToolbar`: it only reads `search`/`lapRange` and fires single-key
+// patches via `onChange` — the page owns the URL, applies the gp→driver→
+// rival→laps cascade (`applyStrategyPatch`) and re-fetches `lapRange` /
+// `drivers` when an upstream selector changes.
+//
+// Two render modes, chosen by `collapsed`:
+//  - expanded (default) — the full form: GP → driver → rival cascade, the
+//    lap window, risk tolerance, and the Run button. Shown before the first
+//    run, or while editing an existing scenario.
+//  - collapsed (after a completed run) — a one-line pill summary of the
+//    scenario plus Edit/Re-run actions, so the deliberation/decision surfaces
+//    below get the vertical space instead of the full form staying open.
+
+import type { ReactNode } from 'react'
+import { Pencil, Play, RotateCcw } from 'lucide-react'
+import type { StrategySearch } from '../search'
+import { STRATEGY_YEAR, analysedLap } from '../search'
+import type { LapRange } from '@/lib/api/strategy'
+import { Combobox, type ComboboxOption } from '@/components/Combobox'
+import { Slider, DualRangeSlider } from '@/components/Slider'
+import { Button } from '@/components/Button'
+import { Pill } from '@/components/Pill'
+import { getDriverTextColor } from '@/lib/drivers'
+import { cn } from '@/lib/cn'
+
+const RISK_STEP = 0.05
+// An explicit, selectable "no rival" choice — value `''` so it round-trips
+// through `Combobox`'s string-only `value`/`onChange` and can clear a
+// previously-picked rival back out (a plain `undefined` can't be an option).
+const NONE_RIVAL_OPTION: ComboboxOption = { value: '', label: '— None —' }
+
+/**
+ * Coarse risk-tolerance label shown next to the numeric value. Mirrors the
+ * three-band posture the orchestrator itself reasons in (aggressive/balanced/
+ * defensive — see `RiskPosture` in `lib/api/strategy.ts`), so the slider the
+ * user drags speaks the same language as the recommendation it produces.
+ */
+function riskZone(risk: number): string {
+  if (risk < 0.33) return 'Conservative'
+  if (risk < 0.66) return 'Balanced'
+  return 'Aggressive'
+}
+
+function formatRisk(risk: number): string {
+  return `${risk.toFixed(2)} · ${riskZone(risk)}`
+}
+
+function toOptions(codes: string[]): ComboboxOption[] {
+  return codes.map((code) => ({ value: code, label: code }))
+}
+
+/** Rival choices exclude the chosen driver (can't duel yourself) and lead
+ *  with the "— None —" escape hatch so a rival, once picked, can be cleared. */
+function rivalOptions(drivers: string[], driver: string | undefined): ComboboxOption[] {
+  return [NONE_RIVAL_OPTION, ...toOptions(drivers.filter((code) => code !== driver))]
+}
+
+/**
+ * Why the Run button can't fire yet, or `undefined` once the scenario is
+ * complete. Lap readiness tolerates EITHER an explicit `search.laps` or a
+ * loaded `lapRange` with none picked yet, since the lap slider itself
+ * defaults to the full range the moment `lapRange` arrives — the scenario is
+ * already runnable at that point, the user just hasn't touched the slider.
+ */
+function scenarioIssue(search: StrategySearch, lapRange: LapRange | undefined): string | undefined {
+  if (!search.gp) return 'Pick a Grand Prix'
+  if (!search.driver) return 'Pick a driver'
+  if (!search.laps && !lapRange) return 'Pick a lap window'
+  return undefined
+}
+
+const EYEBROW_CLASSNAME = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+
+/** A labelled field cell: the small uppercase eyebrow above its control,
+ *  matching `SelectorsToolbar`'s eyebrow styling so both cascades read as one
+ *  system. */
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className={EYEBROW_CLASSNAME}>{label}</span>
+      {children}
+    </div>
+  )
+}
+
+/** A driver/rival code, tinted with its team colour (brightened if the raw
+ *  team hue is too dark to read as text — see `getDriverTextColor`). */
+function DriverLabel({ code }: { code: string }) {
+  return <span style={{ color: getDriverTextColor(code, STRATEGY_YEAR) }}>{code}</span>
+}
+
+interface ExpandedFormProps {
+  search: StrategySearch
+  gps: string[]
+  gpsLoading: boolean
+  drivers: string[]
+  driversLoading: boolean
+  lapRange: LapRange | undefined
+  onChange: (patch: Partial<StrategySearch>) => void
+  onRun: () => void
+  running: boolean
+}
+
+/** The full scenario form: GP → driver → rival cascade, lap window, risk
+ *  tolerance, and the Run button. */
+function ExpandedForm({
+  search,
+  gps,
+  gpsLoading,
+  drivers,
+  driversLoading,
+  lapRange,
+  onChange,
+  onRun,
+  running,
+}: ExpandedFormProps) {
+  const gpOptions = toOptions(gps)
+  const driverOptions = toOptions(drivers)
+  const rivalChoices = rivalOptions(drivers, search.driver)
+
+  const lapsReady = lapRange != null
+  const lapValue: [number, number] =
+    search.laps ?? (lapRange ? [lapRange.min_lap, lapRange.max_lap] : [0, 0])
+  const analysedLapNumber = analysedLap(search) ?? lapRange?.max_lap
+
+  const issue = scenarioIssue(search, lapRange)
+  const canRun = issue === undefined
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-hairline bg-bg-3 p-4">
+      <Pill tone="neutral" className="w-fit">
+        {STRATEGY_YEAR} season
+      </Pill>
+
+      <div className={cn('grid grid-cols-1 gap-4', 'sm:grid-cols-2', 'lg:grid-cols-3')}>
+        <Field label="Grand Prix">
+          <Combobox
+            ariaLabel="Grand Prix"
+            options={gpOptions}
+            value={search.gp}
+            onChange={(gp) => onChange({ gp })}
+            placeholder="Select GP"
+            loading={gpsLoading}
+            disabled={running}
+          />
+        </Field>
+
+        <Field label="Driver">
+          <Combobox
+            ariaLabel="Driver"
+            options={driverOptions}
+            value={search.driver}
+            onChange={(driver) => onChange({ driver })}
+            placeholder="Select driver"
+            loading={driversLoading}
+            disabled={running || !search.gp}
+          />
+        </Field>
+
+        <Field label="Rival (optional)">
+          <Combobox
+            ariaLabel="Rival"
+            options={rivalChoices}
+            value={search.rival ?? ''}
+            onChange={(rival) => onChange({ rival: rival === '' ? undefined : rival })}
+            placeholder="No rival"
+            disabled={running || !search.driver}
+          />
+        </Field>
+      </div>
+
+      <div className={cn('grid grid-cols-1 gap-4', 'sm:grid-cols-2')}>
+        <Field label="Lap window">
+          <div className="flex flex-col gap-2">
+            {lapsReady ? (
+              <DualRangeSlider
+                min={lapRange?.min_lap ?? 0}
+                max={lapRange?.max_lap ?? 0}
+                value={lapValue}
+                onValueChange={(laps) => onChange({ laps })}
+                disabled={running}
+              />
+            ) : (
+              <p className="text-xs text-fg-4">Pick a GP and driver to unlock the lap window</p>
+            )}
+            {analysedLapNumber != null && (
+              <Pill tone="purple" className="w-fit">
+                Analysing lap {analysedLapNumber}
+              </Pill>
+            )}
+          </div>
+        </Field>
+
+        <Field label="Risk tolerance">
+          <Slider
+            min={0}
+            max={1}
+            step={RISK_STEP}
+            value={search.risk}
+            onValueChange={(risk) => onChange({ risk })}
+            formatValue={formatRisk}
+            disabled={running}
+          />
+        </Field>
+      </div>
+
+      <div className="flex items-center justify-end gap-3">
+        {issue ? (
+          <span aria-live="polite" className="text-xs text-fg-4">
+            {issue}
+          </span>
+        ) : null}
+        <Button onClick={onRun} disabled={running || !canRun} title={running ? undefined : issue}>
+          <Play className="size-4" aria-hidden="true" />
+          {running ? 'Running…' : 'Run strategy'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface CollapsedSummaryProps {
+  search: StrategySearch
+  onRun: () => void
+  running: boolean
+  onEdit: () => void
+}
+
+/** Compact post-run summary: the scenario as a pill row, plus Edit/Re-run. */
+function CollapsedSummary({ search, onRun, running, onEdit }: CollapsedSummaryProps) {
+  const lap = analysedLap(search)
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-xl border border-hairline bg-bg-3 p-3">
+      {search.gp && <Pill tone="neutral">{search.gp}</Pill>}
+      {search.driver && (
+        <Pill tone="neutral">
+          <DriverLabel code={search.driver} />
+        </Pill>
+      )}
+      {search.rival && (
+        <Pill tone="neutral">
+          vs <DriverLabel code={search.rival} />
+        </Pill>
+      )}
+      {lap != null && <Pill tone="purple">Lap {lap}</Pill>}
+      <Pill tone="neutral">{formatRisk(search.risk)}</Pill>
+
+      <div className="ml-auto flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onEdit}>
+          <Pencil className="size-4" aria-hidden="true" />
+          Edit scenario
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onRun} disabled={running}>
+          <RotateCcw className="size-4" aria-hidden="true" />
+          Re-run
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export interface ScenarioBarProps {
+  search: StrategySearch
+  gps: string[]
+  gpsLoading: boolean
+  /** Driver codes for the chosen GP. */
+  drivers: string[]
+  driversLoading: boolean
+  /** `{min_lap, max_lap}` for (gp, driver); undefined until loaded. */
+  lapRange?: LapRange
+  /** Page applies the cascade + navigates; this component only emits patches. */
+  onChange: (patch: Partial<StrategySearch>) => void
+  onRun: () => void
+  /** A run is in-flight — locks every control. */
+  running: boolean
+  /** True after a completed run — render the compact chip row instead of the form. */
+  collapsed: boolean
+  /** Expand from collapsed back to the full form. */
+  onEdit: () => void
+}
+
+/**
+ * The sticky scenario bar at the top of the Strategy tab. Renders either the
+ * full configuration form or, once a run has completed, a compact chip
+ * summary — see the module docstring for the two-mode rationale.
+ */
+export function ScenarioBar({
+  search,
+  gps,
+  gpsLoading,
+  drivers,
+  driversLoading,
+  lapRange,
+  onChange,
+  onRun,
+  running,
+  collapsed,
+  onEdit,
+}: ScenarioBarProps) {
+  if (collapsed) {
+    return <CollapsedSummary search={search} onRun={onRun} running={running} onEdit={onEdit} />
+  }
+
+  return (
+    <ExpandedForm
+      search={search}
+      gps={gps}
+      gpsLoading={gpsLoading}
+      drivers={drivers}
+      driversLoading={driversLoading}
+      lapRange={lapRange}
+      onChange={onChange}
+      onRun={onRun}
+      running={running}
+    />
+  )
+}

--- a/webapp/src/features/strategy/components/ScenarioScoresChart.tsx
+++ b/webapp/src/features/strategy/components/ScenarioScoresChart.tsx
@@ -1,0 +1,368 @@
+// ScenarioScoresChart (#35) — the Monte-Carlo evidence bar for the Strategy
+// tab. The Streamlit page plotted only `score` per candidate action; the
+// orchestrator's 500-sample MC step (`strategy_orchestrator.py:319`) already
+// computes a P10-P90 band around each candidate's expected value `E`, so this
+// chart surfaces that band too — a "winner" whose whisker spans wide is a much
+// weaker pick than one with a tight band at the same E, and the old bar chart
+// couldn't show that difference at all.
+//
+// ECharts has no built-in horizontal error-bar mark, so the whisker is drawn
+// with a `custom` series — the documented ECharts recipe for error bars:
+// `renderItem` reads `[categoryIndex, P10, P90, E]` per row and projects it
+// through `api.coord()` into pixel space, then draws a line + two end caps +
+// a dot at E. That series shares the bar series' category axis, so the two
+// stay pixel-aligned without any extra bookkeeping.
+
+import { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type {
+  BarSeriesOption,
+  CustomSeriesOption,
+  CustomSeriesRenderItem,
+  EChartsOption,
+  TooltipComponentFormatterCallbackParams,
+} from 'echarts'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
+import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
+import { ChartCard } from '@/components/ChartCard'
+import type { ScenarioScore, StrategyAction } from '@/lib/api/strategy'
+
+registerF1Theme()
+
+const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
+
+// Identity colors — the accent reads the same purple in both themes (mirrors
+// echartsTheme.ts's SERIES_COLORS[1] / tokens.css --purple-600/300).
+const ACCENT = '#6c5ce7'
+const ACCENT_WHISKER = '#a29bfe'
+
+// The muted tones DO need a per-theme swap (an ECharts per-series/per-item
+// color bypasses the registered theme entirely) — same reasoning as
+// Gauge.tsx's GaugePalette and ChannelChart's DeltaChart markLineColor.
+interface ScorePalette {
+  mutedBar: string
+  mutedWhisker: string
+  label: string
+}
+
+const DARK_SCORE_PALETTE: ScorePalette = {
+  mutedBar: 'rgba(255,255,255,0.16)',
+  mutedWhisker: 'rgba(255,255,255,0.45)',
+  label: 'rgba(255,255,255,0.72)',
+}
+
+const LIGHT_SCORE_PALETTE: ScorePalette = {
+  mutedBar: 'rgba(20,18,31,0.14)',
+  mutedWhisker: 'rgba(20,18,31,0.45)',
+  label: 'rgba(20,18,31,0.75)',
+}
+
+const MIN_HEIGHT_PX = 220
+const MAX_HEIGHT_PX = 280
+const ROW_HEIGHT_PX = 42
+// Fixed vertical allowance (axis + card padding) on top of the per-row height.
+const CHROME_PX = 60
+
+const CAP_HALF_HEIGHT_PX = 6
+const WHISKER_LINE_WIDTH = 1.5
+const WHISKER_DOT_RADIUS = 3.5
+// Gap between the P90 cap and the E/delta label drawn past it (fix for the
+// label being struck through by the whisker line when it sat on the bar).
+const WHISKER_LABEL_GAP_PX = 8
+
+interface ScenarioRow {
+  action: string
+  score: ScenarioScore
+}
+
+/** Rows sorted best-first (E descending). Combined with `yAxis.inverse` in
+ *  `buildScoresOption`, the winner renders at the TOP of the chart. */
+function sortedRows(scores: Record<string, ScenarioScore>): ScenarioRow[] {
+  return Object.entries(scores)
+    .map(([action, score]) => ({ action, score }))
+    .sort((a, b) => b.score.E - a.score.E)
+}
+
+/** Clamp the chart's pixel height to the row count so a 2-candidate run
+ *  doesn't stretch as tall as a 4-candidate one. */
+function chartHeight(rowCount: number): number {
+  return Math.min(MAX_HEIGHT_PX, Math.max(MIN_HEIGHT_PX, rowCount * ROW_HEIGHT_PX + CHROME_PX))
+}
+
+/** "0.842  (0.00)" for the winner, "0.671  (-0.17)" for the rest — the
+ *  delta-to-winner Streamlit's plain score bar never showed. Rounds -0 to
+ *  "0.00" so a near-zero delta never prints a confusing "-0.00". */
+function formatDelta(delta: number): string {
+  const rounded = Math.round(delta * 100) / 100
+  return rounded === 0 ? '0.00' : rounded.toFixed(2)
+}
+
+function formatScoreLabel(row: ScenarioRow, bestE: number): string {
+  const delta = row.score.E - bestE
+  return `${row.score.E.toFixed(3)}  (${formatDelta(delta)})`
+}
+
+/** One tooltip per row: the action name plus its full E / P10-P90 spread —
+ *  the label on the bar only has room for E and the delta, this fills in the
+ *  rest on hover. Defensive `Array.isArray` check mirrors ChannelChart's
+ *  `buildTooltipFormatter` since the callback's param type covers both the
+ *  axis-trigger (array) and item-trigger (single object) shapes. */
+function buildScoreTooltipFormatter(rows: ScenarioRow[]) {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items = Array.isArray(params) ? params : [params]
+    const first = items[0]
+    const row = first ? rows[first.dataIndex] : undefined
+    if (!row) return ''
+    return `<div style="font-family:${MONO}">
+  <div style="font-weight:600;margin-bottom:4px">${row.action}</div>
+  <div>E &nbsp;${row.score.E.toFixed(3)}</div>
+  <div style="opacity:0.7">P10-P90 &nbsp;${row.score.P10.toFixed(3)} to ${row.score.P90.toFixed(3)}</div>
+</div>`
+  }
+}
+
+/** The x-axis window: `min` is pinned to 0 rather than the widest P10 lower
+ *  bound — scores are bounded [0,1], and a truncated baseline made bar
+ *  LENGTH encode `E - baseline` instead of `E` itself, visually exaggerating
+ *  how much better the winner looked. `max` is still padded a little past
+ *  the widest P10-P90 spread (capped at 1) so no whisker cap ever touches
+ *  the plot edge. */
+function axisRange(rows: ScenarioRow[]): { min: number; max: number } {
+  const bounds = rows.flatMap((row) => [row.score.P10, row.score.P90])
+  const low = Math.min(...bounds)
+  const high = Math.max(...bounds)
+  const pad = (high - low) * 0.15 || 0.1
+  return { min: 0, max: Math.min(1, high + pad) }
+}
+
+/**
+ * Draws one row's P10-P90 whisker: a horizontal line between the two bounds,
+ * a short vertical cap at each end, a dot at E, and — past the P90 cap — the
+ * E/delta label itself. That label used to be the bar series' own
+ * `label: { position: 'right' }`, which sits at x = E: exactly where this
+ * whisker's line crosses, so it got struck through. Drawing it here instead,
+ * clear of the P90 cap, is the fix. Row data is `[categoryIndex, P10, P90, E]`;
+ * `api.coord()` projects an `[x, categoryIndex]` pair through the shared
+ * value/category axes, so the whisker (and its label) lands exactly where
+ * the paired bar series' row sits — no separate layout math needed.
+ */
+function buildWhiskerRenderItem(
+  chosenIndex: number,
+  palette: ScorePalette,
+  rows: ScenarioRow[],
+  bestE: number,
+): CustomSeriesRenderItem {
+  return (params, api) => {
+    const categoryIndex = api.value(0) as number
+    const p10 = api.value(1) as number
+    const p90 = api.value(2) as number
+    const e = api.value(3) as number
+    const isChosen = params.dataIndex === chosenIndex
+    const color = isChosen ? ACCENT_WHISKER : palette.mutedWhisker
+
+    const lowPoint = api.coord([p10, categoryIndex])
+    const highPoint = api.coord([p90, categoryIndex])
+    const meanPoint = api.coord([e, categoryIndex])
+
+    const row = rows[params.dataIndex]
+    const labelText = row ? formatScoreLabel(row, bestE) : ''
+    const labelColor = isChosen ? ACCENT : palette.label
+
+    return {
+      type: 'group',
+      children: [
+        {
+          type: 'line',
+          shape: { x1: lowPoint[0], y1: lowPoint[1], x2: highPoint[0], y2: highPoint[1] },
+          style: { stroke: color, lineWidth: WHISKER_LINE_WIDTH },
+        },
+        {
+          type: 'line',
+          shape: {
+            x1: lowPoint[0],
+            y1: lowPoint[1] - CAP_HALF_HEIGHT_PX,
+            x2: lowPoint[0],
+            y2: lowPoint[1] + CAP_HALF_HEIGHT_PX,
+          },
+          style: { stroke: color, lineWidth: WHISKER_LINE_WIDTH },
+        },
+        {
+          type: 'line',
+          shape: {
+            x1: highPoint[0],
+            y1: highPoint[1] - CAP_HALF_HEIGHT_PX,
+            x2: highPoint[0],
+            y2: highPoint[1] + CAP_HALF_HEIGHT_PX,
+          },
+          style: { stroke: color, lineWidth: WHISKER_LINE_WIDTH },
+        },
+        {
+          type: 'circle',
+          shape: { cx: meanPoint[0], cy: meanPoint[1], r: WHISKER_DOT_RADIUS },
+          style: { fill: color },
+        },
+        {
+          type: 'text',
+          style: {
+            text: labelText,
+            x: highPoint[0] + WHISKER_LABEL_GAP_PX,
+            y: highPoint[1],
+            textVerticalAlign: 'middle',
+            fontFamily: MONO,
+            fontSize: 11,
+            fill: labelColor,
+          },
+        },
+      ],
+    }
+  }
+}
+
+/** The bar series: length = E, colored purple for the chosen action and a
+ *  muted neutral for the rest, so the recommendation reads as the obvious
+ *  pick even before a viewer reads any label. Its own label stays off — a
+ *  `position: 'right'` label sits at x = E, exactly where the paired
+ *  whisker's line crosses it, so the label now renders inside
+ *  `buildWhiskerRenderItem` instead, past the P90 cap where nothing
+ *  overlaps it. */
+function buildBarSeries(
+  rows: ScenarioRow[],
+  chosenAction: StrategyAction,
+  palette: ScorePalette,
+): BarSeriesOption {
+  return {
+    type: 'bar',
+    barWidth: '46%',
+    z: 5,
+    data: rows.map((row) => ({
+      value: row.score.E,
+      itemStyle: {
+        color: row.action === chosenAction ? ACCENT : palette.mutedBar,
+        borderRadius: 4,
+      },
+    })),
+    label: { show: false },
+  }
+}
+
+/** The whisker overlay — a `silent` custom series (see module docstring)
+ *  sharing the bar series' category axis so both stay pixel-aligned. Also
+ *  draws the E/delta label past its P90 cap (see `buildWhiskerRenderItem`),
+ *  hence the extra `bestE` argument. */
+function buildWhiskerSeries(
+  rows: ScenarioRow[],
+  chosenAction: StrategyAction,
+  palette: ScorePalette,
+  bestE: number,
+): CustomSeriesOption {
+  const chosenIndex = rows.findIndex((row) => row.action === chosenAction)
+  return {
+    type: 'custom',
+    silent: true,
+    z: 10,
+    renderItem: buildWhiskerRenderItem(chosenIndex, palette, rows, bestE),
+    data: rows.map((row, index) => [index, row.score.P10, row.score.P90, row.score.E]),
+  }
+}
+
+/** Composes the full option: a category axis of scenario names (best row on
+ *  top, via `inverse`), a padded value axis wide enough for every whisker,
+ *  and the two series above. Returns an empty series list for zero rows —
+ *  the component itself renders a text empty-state instead of this option. */
+function buildScoresOption(
+  rows: ScenarioRow[],
+  chosenAction: StrategyAction,
+  palette: ScorePalette,
+): EChartsOption {
+  if (rows.length === 0) return { series: [] }
+
+  const bestE = rows[0].score.E
+  const { min, max } = axisRange(rows)
+
+  return {
+    tooltip: {
+      trigger: 'item',
+      extraCssText: 'border-radius:12px;padding:10px 12px',
+      formatter: buildScoreTooltipFormatter(rows),
+    },
+    // `right` reserves room for the E/delta label now drawn past each
+    // whisker's P90 cap (see buildWhiskerRenderItem) instead of on the bar.
+    grid: { top: 8, left: 8, right: 140, bottom: 8, containLabel: true },
+    xAxis: {
+      type: 'value',
+      min,
+      max,
+      // Fewer, non-overlapping ticks — the default split count crammed
+      // 8 labels ("0.2", "0.3", ...) into digit soup at this chart's width.
+      splitNumber: 3,
+      splitLine: { show: false },
+      axisLabel: {
+        fontSize: 10,
+        hideOverlap: true,
+        margin: 10,
+        formatter: (value: number) => value.toFixed(2),
+      },
+    },
+    yAxis: {
+      type: 'category',
+      inverse: true,
+      // Humanized for display only — the tooltip (buildScoreTooltipFormatter)
+      // still reads the raw `row.action` enum key.
+      data: rows.map((row) => row.action.replace(/_/g, ' ')),
+    },
+    series: [
+      buildBarSeries(rows, chosenAction, palette),
+      buildWhiskerSeries(rows, chosenAction, palette, bestE),
+    ],
+  }
+}
+
+export interface ScenarioScoresChartProps {
+  /** e.g. `{"STAY_OUT": {E,P10,P90,score}, "PIT_NOW": {...}}` — one entry per
+   *  Monte-Carlo-scored strategy candidate. Always present on a completed run,
+   *  possibly empty (see `StrategyRecommendation`'s docstring). */
+  scores: Record<string, ScenarioScore>
+  /** The orchestrator's recommended action — its row is highlighted. */
+  chosenAction: StrategyAction
+}
+
+/** Horizontal Monte-Carlo evidence bar: one row per candidate action, sorted
+ *  best-first by expected value, with a P10-P90 uncertainty whisker per row.
+ *  The chosen action's bar and whisker render in the purple accent; the rest
+ *  in a muted neutral. */
+export function ScenarioScoresChart({ scores, chosenAction }: ScenarioScoresChartProps) {
+  const chartTheme = useChartTheme()
+  const palette = chartTheme === F1_LIGHT_THEME ? LIGHT_SCORE_PALETTE : DARK_SCORE_PALETTE
+  const rows = useMemo(() => sortedRows(scores), [scores])
+  const option = useMemo(
+    () => buildScoresOption(rows, chosenAction, palette),
+    [rows, chosenAction, palette],
+  )
+  const paintedOption = useFirstPaintAnimation(option)
+
+  if (rows.length === 0) {
+    return (
+      <ChartCard title="Scenario scores">
+        <p className="px-2 py-12 text-center text-sm text-fg-3">No scenario scores for this run</p>
+      </ChartCard>
+    )
+  }
+
+  return (
+    <ChartCard title="Scenario scores">
+      <div
+        role="img"
+        aria-label="Monte-Carlo scenario scores: expected value with P10 to P90 range, one row per candidate action"
+      >
+        <ReactECharts
+          theme={chartTheme}
+          key={chartTheme}
+          option={paintedOption}
+          style={{ height: chartHeight(rows.length) }}
+          notMerge
+        />
+      </div>
+    </ChartCard>
+  )
+}

--- a/webapp/src/features/strategy/components/SituationStrip.tsx
+++ b/webapp/src/features/strategy/components/SituationStrip.tsx
@@ -1,0 +1,131 @@
+import type { LapState, LapStateDriver, LapStateRival, SituationResult } from '@/lib/api/strategy'
+import { StatCard, MetricRow } from '@/components/StatCard'
+import { CompoundPill } from '@/components/CompoundPill'
+import { Card } from '@/components/Card'
+import { getDriverTextColor } from '@/lib/drivers'
+import { useAgent } from '../queries'
+import { STRATEGY_YEAR } from '../search'
+
+// The lap snapshot strip — our driver's live telemetry as a row of StatCards,
+// plus an optional rival duel comparison. It reads directly off `lapState`
+// (no derived store), so it always mirrors the exact lap the orchestrator is
+// about to analyse. The SC-probability card fires its own `situation` agent
+// query rather than waiting on the full orchestrator run, since that
+// sub-agent is pure ML (no LLM, no rate limit) and cheap to prefetch the
+// moment a lap state exists.
+
+/** "+X.Xs" — a gap is always framed as a positive interval to the car ahead,
+ *  so the sign is decorative, not a direction indicator (unlike `formatSigned`).
+ *  A zero gap means there's no car ahead at all, so it reads as "Leader"
+ *  rather than the meaningless "+0.0s". */
+function formatGap(seconds: number): string {
+  if (seconds === 0) return 'Leader'
+  return `+${seconds.toFixed(1)}s`
+}
+
+/** Lap time to 3 decimals with a trailing unit, e.g. "92.345s". */
+function formatLapTime(seconds: number): string {
+  return `${seconds.toFixed(3)}s`
+}
+
+/** Sign-prefixed number for a duel delta (e.g. "+2" or "-1"). A bare negative
+ *  already reads as negative, so only the `+` case needs adding explicitly. */
+function formatSigned(value: number, decimals = 0): string {
+  const sign = value >= 0 ? '+' : ''
+  return `${sign}${value.toFixed(decimals)}`
+}
+
+/** Δgap for the duel row: a zero delta means both cars have identical
+ *  breathing room, so it reads as "Level" rather than the meaningless
+ *  "+0.0s". */
+function formatGapDelta(value: number): string {
+  if (value === 0) return 'Level'
+  return `${formatSigned(value, 1)}s`
+}
+
+/** SC probability as a percentage, or an em dash while the `situation` agent
+ *  query is loading OR has errored — the caller never needs to branch on
+ *  query status itself, just render this string. */
+function scProbabilityLabel(result: SituationResult | undefined): string {
+  if (result == null) return '—'
+  return `${(result.sc_prob_3lap * 100).toFixed(1)}%`
+}
+
+/** Find the rival by driver code among the timing-screen-only rivals array.
+ *  Returns undefined for an unknown code — the caller renders the strip
+ *  without a duel row rather than crashing. */
+function findRival(lapState: LapState, code: string): LapStateRival | undefined {
+  return lapState.rivals.find((candidate) => candidate.driver === code)
+}
+
+interface DuelRowProps {
+  driver: LapStateDriver
+  rival: LapStateRival
+}
+
+/**
+ * Head-to-head comparison card for the optional rival duel. Δtyre and Δgap
+ * are framed from our driver's perspective (positive = fresher tyres / more
+ * gap in hand) so the sign alone tells the story without a legend.
+ *
+ * Δgap compares each car's own "gap to the car ahead of them" — the contract
+ * has no literal driver-to-rival interval (rivals are timing-screen data
+ * only), so this is the best available proxy: it reads as "who has more
+ * breathing room right now", not a precise on-track distance between the two.
+ */
+function DuelRow({ driver, rival }: DuelRowProps) {
+  const tyreDelta = driver.tyre_life - rival.tyre_life
+  const gapDelta = driver.gap_ahead_s - rival.gap_ahead_s
+  const driverColor = getDriverTextColor(driver.driver, STRATEGY_YEAR)
+  const rivalColor = getDriverTextColor(rival.driver, STRATEGY_YEAR)
+
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      <div className="flex items-center gap-1.5 font-body text-sm">
+        <span className="font-semibold" style={{ color: driverColor }}>
+          {driver.driver}
+        </span>
+        <span className="text-fg-4">vs</span>
+        <span className="font-semibold" style={{ color: rivalColor }}>
+          {rival.driver}
+        </span>
+      </div>
+      <MetricRow
+        items={[
+          { label: 'Δtyre', value: `${formatSigned(tyreDelta)} laps` },
+          { label: 'Δgap', value: formatGapDelta(gapDelta) },
+          { label: `${rival.driver} tyre`, value: <CompoundPill compound={rival.compound} /> },
+          { label: `${rival.driver} lap`, value: formatLapTime(rival.lap_time_s) },
+        ]}
+      />
+    </Card>
+  )
+}
+
+export interface SituationStripProps {
+  lapState: LapState
+  /** Optional rival driver code for the duel row below the strip. */
+  rival?: string
+}
+
+/** The lap snapshot header: our driver's compound/tyre age/gap/lap time/SC
+ *  risk as a row of StatCards, plus an optional rival duel comparison. */
+export function SituationStrip({ lapState, rival }: SituationStripProps) {
+  const driver = lapState.driver
+  const situationQuery = useAgent('situation', lapState, true)
+  const scLabel = scProbabilityLabel(situationQuery.data)
+  const rivalMatch = rival ? findRival(lapState, rival) : undefined
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <StatCard eyebrow="Compound" value={<CompoundPill compound={driver.compound} />} />
+        <StatCard eyebrow="Tyre age" value={driver.tyre_life} hint="laps" />
+        <StatCard eyebrow="Gap ahead" value={formatGap(driver.gap_ahead_s)} />
+        <StatCard eyebrow="Last lap" value={formatLapTime(driver.lap_time_s)} />
+        <StatCard eyebrow="SC prob (3 laps)" value={scLabel} />
+      </div>
+      {rivalMatch ? <DuelRow driver={driver} rival={rivalMatch} /> : null}
+    </div>
+  )
+}

--- a/webapp/src/features/strategy/components/StintTimeline.tsx
+++ b/webapp/src/features/strategy/components/StintTimeline.tsx
@@ -1,0 +1,346 @@
+// StintTimeline (#35) — a schematic lap axis showing the pit plan: where "now"
+// sits, when the box lap is planned, and roughly where the current stint is
+// expected to run out. Pure SVG, not ECharts — this isn't a data plot, it's a
+// small annotated ruler with at most four marks on it, and a charting lib
+// would be pure overhead for that.
+//
+// Every mark past "now" comes from the LLM synthesis step and can be absent —
+// a sparse/no-LLM run leaves most of `StrategyRecommendation`'s optional
+// fields unset (see that type's own docstring). `isRenderableLap` treats a
+// missing, non-finite, OR out-of-window lap the same as "don't draw it"
+// rather than clamping it onto the axis, which would misrepresent the plan.
+//
+// The viewBox width tracks the container's actual measured pixel width (via
+// `useMeasuredWidth`) instead of a fixed constant. This chart is placed
+// full-width by the page, and a fixed viewBox squeezed by `preserveAspectRatio`
+// into whatever column width it's given scales every glyph down with it — an
+// 11px label was rendering at roughly 6px. Matching the viewBox to the real
+// width keeps 1 SVG unit == 1 CSS px, so text always renders at its authored
+// size regardless of how wide the container ends up being.
+
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import { ChartCard } from '@/components/ChartCard'
+import { CompoundPill } from '@/components/CompoundPill'
+import type { LapState, StrategyCompound, StrategyRecommendation } from '@/lib/api/strategy'
+
+const VIEWBOX_HEIGHT = 130
+const CONTAINER_HEIGHT_PX = 130
+const PADDING_X = 44
+const BASELINE_Y = 76
+
+const NOW_TICK_HALF_PX = 15
+const EVENT_TICK_HALF_PX = 9
+const ABOVE_LABEL_OFFSET_Y = 20
+const PIT_LABEL_OFFSET_Y = 34
+const AXIS_LABEL_OFFSET_Y = 22
+const STINT_END_LABEL_OFFSET_Y = 38
+
+const COMPOUND_PILL_WIDTH = 60
+const COMPOUND_PILL_HEIGHT = 22
+const COMPOUND_PILL_GAP_Y = 12
+
+// How close (in px) the box-lap tick can sit to the "now" tick before their
+// centered labels start to overlap — both sit at a similar height, so
+// anything closer than this reads as a smear of characters, not two labels.
+const NOW_LABEL_COLLISION_PX = 90
+// When the collision guard fires, how far past the tick to nudge the
+// left-aligned box label so it clears the "now" label instead of sitting
+// centered on top of it.
+const COLLISION_LABEL_OFFSET_X = 6
+
+// How far back from `now` the visible window starts. `lap_state` carries no
+// stint-start lap (only a stint INDEX, `driver.stint`), so a fixed lookback is
+// the simplest honest window rather than guessing a stint-start lap.
+const LOOKBACK_LAPS = 2
+
+/** Lap -> x pixel, linear across `[axisStart, axisEnd]` within the padded
+ *  viewBox. `span <= 0` (a single-lap window) falls back to dead center
+ *  instead of dividing by zero. `viewBoxWidth` is the caller's live measured
+ *  width (see `useMeasuredWidth`), not a fixed constant, so every marker
+ *  recomputes its x from the same up-to-date value. */
+function lapToX(lap: number, axisStart: number, axisEnd: number, viewBoxWidth: number): number {
+  const usableWidth = viewBoxWidth - PADDING_X * 2
+  const span = axisEnd - axisStart
+  const fraction = span > 0 ? (lap - axisStart) / span : 0.5
+  return PADDING_X + fraction * usableWidth
+}
+
+/** True only for a present, finite lap that actually falls within the visible
+ *  axis window — the null-tolerance boundary every optional marker is gated
+ *  on. An out-of-window value is treated as absent rather than clamped, so
+ *  the drawing never implies a lap the plan didn't actually give. */
+function isRenderableLap(
+  lap: number | null | undefined,
+  axisStart: number,
+  axisEnd: number,
+): lap is number {
+  return typeof lap === 'number' && Number.isFinite(lap) && lap >= axisStart && lap <= axisEnd
+}
+
+/** ML predictions can land on a fractional lap; the axis label always shows
+ *  the nearest whole lap. */
+function roundLap(lap: number): number {
+  return Math.round(lap)
+}
+
+/** One sentence summarizing the timeline for screen readers — the SVG itself
+ *  is `aria-hidden`, so this is the only description of what's drawn. */
+function buildAriaLabel(
+  now: number,
+  totalLaps: number,
+  pitLap: number | null,
+  stintEndLap: number | null,
+): string {
+  const parts = [`now at lap ${now} of ${totalLaps}`]
+  if (pitLap != null) parts.push(`pit box planned for lap ${roundLap(pitLap)}`)
+  if (stintEndLap != null) parts.push(`stint expected to end around lap ${roundLap(stintEndLap)}`)
+  return `Stint timeline: ${parts.join(', ')}`
+}
+
+/** Tracks a wrapping element's live pixel width via `ResizeObserver`, so the
+ *  SVG's viewBox can match the real container instead of a fixed constant
+ *  (see module docstring for why that mismatch shrank the text). Starts at 0
+ *  before the first observation fires; callers must treat 0 as "not measured
+ *  yet" and skip rendering rather than divide by it. */
+function useMeasuredWidth(): [RefObject<HTMLDivElement | null>, number] {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return undefined
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) setWidth(entry.contentRect.width)
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  return [ref, width]
+}
+
+/** When the box-lap tick sits within `NOW_LABEL_COLLISION_PX` of the "now"
+ *  tick, a centered box label would print right through the "now" label.
+ *  Left-aligning it with a small offset instead keeps both readable without
+ *  dropping either mark. */
+function boxLabelPlacement(x: number, nowX: number): { anchor: 'middle' | 'start'; x: number } {
+  const isNearNow = Math.abs(x - nowX) < NOW_LABEL_COLLISION_PX
+  return isNearNow ? { anchor: 'start', x: x + COLLISION_LABEL_OFFSET_X } : { anchor: 'middle', x }
+}
+
+interface PitMarkerProps {
+  pitLap: number
+  axisStart: number
+  axisEnd: number
+  viewBoxWidth: number
+  nowX: number
+  compound: StrategyCompound | null | undefined
+}
+
+/** The planned box lap: a tick, a "▲" glyph, a "box lap N" label, and (when
+ *  the orchestrator named one) the next compound as a pill underneath. The
+ *  label nudges clear of the "now" label when the two ticks sit close
+ *  together (see `boxLabelPlacement`). */
+function PitMarker({ pitLap, axisStart, axisEnd, viewBoxWidth, nowX, compound }: PitMarkerProps) {
+  const x = lapToX(pitLap, axisStart, axisEnd, viewBoxWidth)
+  const label = boxLabelPlacement(x, nowX)
+  return (
+    <g>
+      <line
+        x1={x}
+        y1={BASELINE_Y - EVENT_TICK_HALF_PX}
+        x2={x}
+        y2={BASELINE_Y + EVENT_TICK_HALF_PX}
+        strokeWidth={1.5}
+        className="stroke-accent"
+      />
+      <text
+        x={x}
+        y={BASELINE_Y - EVENT_TICK_HALF_PX - 4}
+        textAnchor="middle"
+        className="fill-accent text-[13px]"
+      >
+        ▲
+      </text>
+      <text
+        x={label.x}
+        y={BASELINE_Y - PIT_LABEL_OFFSET_Y}
+        textAnchor={label.anchor}
+        className="fill-fg-1 font-mono text-[11px] font-medium tabular-nums"
+      >
+        box lap {roundLap(pitLap)}
+      </text>
+      {compound ? (
+        <foreignObject
+          x={x - COMPOUND_PILL_WIDTH / 2}
+          y={BASELINE_Y + EVENT_TICK_HALF_PX + COMPOUND_PILL_GAP_Y}
+          width={COMPOUND_PILL_WIDTH}
+          height={COMPOUND_PILL_HEIGHT}
+        >
+          <div className="flex h-full w-full items-center justify-center">
+            <CompoundPill compound={compound} />
+          </div>
+        </foreignObject>
+      ) : null}
+    </g>
+  )
+}
+
+interface StintEndMarkerProps {
+  stintEndLap: number
+  axisStart: number
+  axisEnd: number
+  viewBoxWidth: number
+}
+
+/** A softer, dashed tick for where the CURRENT stint is expected to run out —
+ *  a tyre-life estimate, not a committed action, so it's styled to read as
+ *  less certain than the pit-box tick. */
+function StintEndMarker({ stintEndLap, axisStart, axisEnd, viewBoxWidth }: StintEndMarkerProps) {
+  const x = lapToX(stintEndLap, axisStart, axisEnd, viewBoxWidth)
+  return (
+    <g>
+      <line
+        x1={x}
+        y1={BASELINE_Y - EVENT_TICK_HALF_PX}
+        x2={x}
+        y2={BASELINE_Y + EVENT_TICK_HALF_PX}
+        strokeWidth={1.5}
+        strokeDasharray="3,3"
+        className="stroke-fg-3"
+      />
+      <text
+        x={x}
+        y={BASELINE_Y + STINT_END_LABEL_OFFSET_Y}
+        textAnchor="middle"
+        className="fill-fg-3 font-mono text-[11px]"
+      >
+        ⌁ stint end
+      </text>
+    </g>
+  )
+}
+
+export interface StintTimelineProps {
+  lapState: LapState
+  result: StrategyRecommendation
+}
+
+/**
+ * Schematic lap axis for the pit plan. Axis window: `[max(1, now-2), max(totalLaps, now)]`
+ * — a short lookback before `now` plus the rest of the race, clamped so a
+ * stale/short parquet can never push the "now" tick off the right edge.
+ *
+ * Degrades gracefully: `pit_lap_target` and `expected_stint_end` are both
+ * optional on `StrategyRecommendation` (sparse on a no-LLM or partial run), so
+ * with both absent this still renders a valid, minimal timeline — the axis
+ * plus the "now" tick alone.
+ *
+ * The SVG's viewBox width tracks the container's own measured width (see
+ * `useMeasuredWidth`), so the SVG itself doesn't render until that first
+ * measurement lands — nothing to divide by zero, and no flash of a
+ * mis-scaled fallback while waiting for layout.
+ */
+export function StintTimeline({ lapState, result }: StintTimelineProps) {
+  const [containerRef, width] = useMeasuredWidth()
+
+  const now = lapState.lap_number
+  const totalLaps = lapState.session_meta.total_laps
+  const axisStart = Math.max(1, now - LOOKBACK_LAPS)
+  const axisEnd = Math.max(totalLaps, now)
+
+  const pitLap = isRenderableLap(result.pit_lap_target, axisStart, axisEnd)
+    ? result.pit_lap_target
+    : null
+  const stintEndLap = isRenderableLap(result.expected_stint_end, axisStart, axisEnd)
+    ? result.expected_stint_end
+    : null
+
+  const nowX = lapToX(now, axisStart, axisEnd, width)
+  const ariaLabel = buildAriaLabel(now, totalLaps, pitLap, stintEndLap)
+
+  return (
+    <ChartCard title="Stint timeline">
+      <div
+        ref={containerRef}
+        role="img"
+        aria-label={ariaLabel}
+        style={{ height: CONTAINER_HEIGHT_PX }}
+      >
+        {width === 0 ? null : (
+          <svg
+            viewBox={`0 0 ${width} ${VIEWBOX_HEIGHT}`}
+            width="100%"
+            height="100%"
+            preserveAspectRatio="xMidYMid meet"
+            aria-hidden="true"
+          >
+            <line
+              x1={PADDING_X}
+              y1={BASELINE_Y}
+              x2={width - PADDING_X}
+              y2={BASELINE_Y}
+              strokeWidth={2}
+              className="stroke-hairline"
+            />
+            <text
+              x={PADDING_X}
+              y={BASELINE_Y + AXIS_LABEL_OFFSET_Y}
+              textAnchor="start"
+              className="fill-fg-3 font-mono text-[11px] tabular-nums"
+            >
+              Lap {roundLap(axisStart)}
+            </text>
+            <text
+              x={width - PADDING_X}
+              y={BASELINE_Y + AXIS_LABEL_OFFSET_Y}
+              textAnchor="end"
+              className="fill-fg-3 font-mono text-[11px] tabular-nums"
+            >
+              Lap {roundLap(axisEnd)}
+            </text>
+
+            {/* now — always renders; lap_number is a required lap_state field */}
+            <line
+              x1={nowX}
+              y1={BASELINE_Y - NOW_TICK_HALF_PX}
+              x2={nowX}
+              y2={BASELINE_Y + NOW_TICK_HALF_PX}
+              strokeWidth={2}
+              className="stroke-accent"
+            />
+            <text
+              x={nowX}
+              y={BASELINE_Y - ABOVE_LABEL_OFFSET_Y}
+              textAnchor="middle"
+              className="fill-fg-1 font-mono text-[11px] font-medium tabular-nums"
+            >
+              now · lap {now}
+            </text>
+
+            {pitLap != null ? (
+              <PitMarker
+                pitLap={pitLap}
+                axisStart={axisStart}
+                axisEnd={axisEnd}
+                viewBoxWidth={width}
+                nowX={nowX}
+                compound={result.compound_next}
+              />
+            ) : null}
+            {stintEndLap != null ? (
+              <StintEndMarker
+                stintEndLap={stintEndLap}
+                axisStart={axisStart}
+                axisEnd={axisEnd}
+                viewBoxWidth={width}
+              />
+            ) : null}
+          </svg>
+        )}
+      </div>
+    </ChartCard>
+  )
+}

--- a/webapp/src/features/strategy/queries.ts
+++ b/webapp/src/features/strategy/queries.ts
@@ -1,0 +1,118 @@
+// TanStack Query data layer for the Strategy tab.
+//
+// Two kinds of call:
+//  - Deterministic metadata + ML sub-agents (gps / drivers / lap-range / the 4
+//    agent POSTs) → useQuery with staleTime:Infinity. Given a (gp, driver, lap)
+//    the parquet + ML output never change, so cache forever and the agent tabs
+//    lazy-fetch on first open (`enabled`) and stay cached across tab switches.
+//  - The orchestrator run (POST /recommend) → useMutation: it is non-deterministic
+//    (LLM synthesis), rate-limited (5/min), and must be cancellable, none of
+//    which fit a query. The page drives it and appends the result to the store.
+
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/queryKeys'
+import {
+  fetchLapRange,
+  fetchLapState,
+  fetchStrategyDrivers,
+  fetchStrategyGps,
+  runAgent,
+  runRecommend,
+  type AgentName,
+  type AgentResultMap,
+  type LapRange,
+  type LapState,
+  type StrategyRecommendation,
+} from '@/lib/api/strategy'
+import { analysedLap, type StrategySearch } from './search'
+
+// Historical/deterministic data: cache forever, one retry so a downed backend
+// fails fast instead of a multi-minute exponential backoff on slow calls.
+const STATIC = { staleTime: Infinity, gcTime: Infinity, retry: 1 } as const
+
+/** GPs available in the 2025 featured parquet. */
+export function useStrategyGps() {
+  return useQuery({
+    queryKey: queryKeys.strategy.gps(),
+    queryFn: () => fetchStrategyGps(),
+    ...STATIC,
+  })
+}
+
+/** Driver codes for a GP (gated on GP, like the Streamlit cascade). */
+export function useStrategyDrivers(gp: string | undefined) {
+  return useQuery({
+    queryKey: gp ? queryKeys.strategy.drivers(gp) : ['strategy', 'drivers', 'idle'],
+    queryFn: () => fetchStrategyDrivers(gp!),
+    enabled: !!gp,
+    ...STATIC,
+  })
+}
+
+/** Min/max lap for a (gp, driver) — bounds the lap-window slider. */
+export function useLapRange(gp: string | undefined, driver: string | undefined) {
+  return useQuery({
+    queryKey:
+      gp && driver ? queryKeys.strategy.lapRange(gp, driver) : ['strategy', 'lap-range', 'idle'],
+    queryFn: (): Promise<LapRange> => fetchLapRange(gp!, driver!),
+    enabled: !!gp && !!driver,
+    ...STATIC,
+  })
+}
+
+/**
+ * Run one sub-agent for the active run's lap state. Lazy: `enabled` only once
+ * the tab is opened AND a lap state exists (from a completed run), so the 4
+ * agent tabs each fire their single ML call on first view and stay cached.
+ */
+export function useAgent<A extends AgentName>(
+  agent: A,
+  lapState: LapState | undefined,
+  enabled: boolean,
+) {
+  const d = lapState?.driver
+  return useQuery({
+    queryKey:
+      d != null
+        ? queryKeys.strategy.agent(
+            agent,
+            lapState!.session_meta.gp_name,
+            d.driver,
+            lapState!.lap_number,
+          )
+        : ['strategy', 'agent', agent, 'idle'],
+    queryFn: (): Promise<AgentResultMap[A]> => runAgent(agent, lapState!),
+    enabled: enabled && lapState != null,
+    ...STATIC,
+  })
+}
+
+/** Variables for a run: the scenario + an abort signal (Cancel button). */
+export interface RecommendVars {
+  search: StrategySearch
+  signal: AbortSignal
+}
+
+/** What a completed run yields — the inputs and the recommendation. */
+export interface RecommendData {
+  lapState: LapState
+  result: StrategyRecommendation
+}
+
+/**
+ * The orchestrator run as a mutation. Fetches the lap state for the analysed lap
+ * (right edge of the window), then runs the full N31 pipeline. The page wires
+ * `onSuccess` to append a RunRecord to the store; here we only own the two
+ * network steps + cancellation. Requires gp/driver/laps to be set (the Run
+ * button is disabled otherwise), so the non-null assertions are safe.
+ */
+export function useRecommend() {
+  return useMutation<RecommendData, Error, RecommendVars>({
+    mutationFn: async ({ search, signal }) => {
+      const lap = analysedLap(search)!
+      const lapState = await fetchLapState(search.gp!, search.driver!, lap)
+      const result = await runRecommend(lapState, search.risk, signal)
+      return { lapState, result }
+    },
+  })
+}

--- a/webapp/src/features/strategy/search.test.ts
+++ b/webapp/src/features/strategy/search.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateStrategySearch,
+  applyStrategyPatch,
+  fromRaw,
+  toRaw,
+  analysedLap,
+  DEFAULT_RISK,
+  type StrategySearch,
+} from './search'
+
+describe('validateStrategySearch — cascade + coercion', () => {
+  it('drops an orphan driver when no GP is set', () => {
+    const out = validateStrategySearch({ driver: 'NOR', rival: 'PIA' })
+    expect(out.driver).toBeUndefined()
+    expect(out.rival).toBeUndefined()
+  })
+
+  it('keeps a driver + rival once a GP is present', () => {
+    const out = validateStrategySearch({ gp: 'Hungarian Grand Prix', driver: 'NOR', rival: 'PIA' })
+    expect(out).toMatchObject({ gp: 'Hungarian Grand Prix', driver: 'NOR', rival: 'PIA' })
+  })
+
+  it('drops a rival equal to the driver (you cannot duel yourself)', () => {
+    const out = validateStrategySearch({ gp: 'GP', driver: 'VER', rival: 'VER' })
+    expect(out.rival).toBeUndefined()
+  })
+
+  it('parses and orders a lap window, dropping it without a driver', () => {
+    expect(validateStrategySearch({ gp: 'GP', driver: 'VER', laps: '28-8' }).laps).toBe('8-28')
+    expect(validateStrategySearch({ gp: 'GP', laps: '8-28' }).laps).toBeUndefined()
+  })
+
+  it('omits risk when absent and clamps it to [0,1] when present', () => {
+    expect(validateStrategySearch({}).risk).toBeUndefined()
+    expect(validateStrategySearch({ risk: 5 }).risk).toBe(1)
+    expect(validateStrategySearch({ risk: -2 }).risk).toBe(0)
+  })
+})
+
+describe('fromRaw / toRaw — round trip', () => {
+  it('round-trips a full scenario', () => {
+    const raw = { gp: 'GP', driver: 'NOR', rival: 'PIA', laps: '8-28', risk: 0.55 }
+    const search = fromRaw(raw)
+    expect(search).toEqual({
+      gp: 'GP',
+      driver: 'NOR',
+      rival: 'PIA',
+      laps: [8, 28],
+      risk: 0.55,
+    })
+    expect(toRaw(search)).toEqual(raw)
+  })
+
+  it('applies the default risk on the way in and drops it on the way out', () => {
+    expect(fromRaw({ gp: 'GP' }).risk).toBe(DEFAULT_RISK)
+    expect(toRaw({ gp: 'GP', risk: DEFAULT_RISK }).risk).toBeUndefined()
+  })
+})
+
+describe('applyStrategyPatch — cascade + no-op identity', () => {
+  const base: StrategySearch = {
+    gp: 'GP',
+    driver: 'NOR',
+    rival: 'PIA',
+    laps: [8, 28],
+    risk: 0.5,
+  }
+
+  it('returns the SAME reference when re-picking an unchanged upstream value', () => {
+    expect(applyStrategyPatch(base, { gp: 'GP' })).toBe(base)
+    expect(applyStrategyPatch(base, { driver: 'NOR' })).toBe(base)
+  })
+
+  it('clears driver/rival/laps when the GP changes', () => {
+    const next = applyStrategyPatch(base, { gp: 'Other GP' })
+    expect(next).toMatchObject({
+      gp: 'Other GP',
+      driver: undefined,
+      rival: undefined,
+      laps: undefined,
+    })
+  })
+
+  it('clears rival/laps but keeps GP when the driver changes', () => {
+    const next = applyStrategyPatch(base, { driver: 'VER' })
+    expect(next).toMatchObject({ gp: 'GP', driver: 'VER', rival: undefined, laps: undefined })
+  })
+
+  it('drops a rival that would equal the new driver', () => {
+    const next = applyStrategyPatch({ ...base, rival: 'VER' }, { driver: 'VER' })
+    expect(next.rival).toBeUndefined()
+  })
+})
+
+describe('analysedLap', () => {
+  it('is the right edge of the lap window, or undefined', () => {
+    expect(analysedLap({ risk: 0.5, laps: [8, 28] })).toBe(28)
+    expect(analysedLap({ risk: 0.5 })).toBeUndefined()
+  })
+})

--- a/webapp/src/features/strategy/search.ts
+++ b/webapp/src/features/strategy/search.ts
@@ -1,0 +1,137 @@
+// URL search-param contract for the Strategy tab. The scenario config lives in
+// the URL — `?gp=...&driver=NOR&rival=PIA&laps=8-28&risk=0.55` reproduces the
+// screen so a scenario is a shareable link (the big UX unlock). Same raw↔component
+// boundary as the Dashboard's search.ts.
+//
+// Deep links reproduce the CONFIG only — they never auto-fire the orchestrator
+// run (an LLM call, rate-limited, non-deterministic). A shared link lands on a
+// prefilled idle state with Run highlighted (wired in StrategyPage).
+//
+// Two shapes, one boundary:
+//  - RawStrategySearch — what lives in the URL / what `validateSearch` returns.
+//    `laps` is the string "a-b"; `risk` a number.
+//  - StrategySearch — the component-facing shape (`laps` as a [start, end] tuple,
+//    `risk` always present with the 0.5 default applied).
+// Year is a constant (the featured parquet is 2025-only), so it is NOT in the URL.
+
+export const STRATEGY_YEAR = 2025
+export const DEFAULT_RISK = 0.5
+
+/** Component-facing scenario config. */
+export interface StrategySearch {
+  gp?: string
+  driver?: string
+  rival?: string
+  /** [start, end] lap window; the orchestrator analyses the END lap. */
+  laps?: [number, number]
+  risk: number
+}
+
+/** URL / validated scenario config. */
+export interface RawStrategySearch {
+  gp?: string
+  driver?: string
+  rival?: string
+  laps?: string
+  risk?: number
+}
+
+function coerceStr(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined
+}
+
+function clampRisk(raw: unknown): number {
+  const n = Number(raw)
+  if (Number.isNaN(n)) return DEFAULT_RISK
+  return Math.min(1, Math.max(0, n))
+}
+
+/** Parse a "a-b" lap window into an ordered [start, end] tuple, or undefined. */
+function parseLaps(raw: unknown): [number, number] | undefined {
+  if (typeof raw !== 'string' || raw === '') return undefined
+  const parts = raw.split('-').map((p) => Number(p.trim()))
+  if (parts.length !== 2 || parts.some((n) => Number.isNaN(n))) return undefined
+  const [a, b] = parts
+  return a <= b ? [a, b] : [b, a]
+}
+
+/**
+ * `validateSearch` for the /strategy route: coerce raw router search AND enforce
+ * the cascade (rival/laps need a driver, driver needs a GP). A hand-edited link
+ * with an orphan rival or lap window therefore drops it instead of rendering a
+ * broken half-selected state. `rival` is dropped when it equals `driver`.
+ */
+export function validateStrategySearch(raw: Record<string, unknown>): RawStrategySearch {
+  const gp = coerceStr(raw.gp)
+  const driver = gp ? coerceStr(raw.driver) : undefined
+  const rivalRaw = driver ? coerceStr(raw.rival) : undefined
+  const rival = rivalRaw && rivalRaw !== driver ? rivalRaw : undefined
+  const laps = driver ? parseLaps(raw.laps) : undefined
+  // Only carry risk in the URL when it was explicitly set — so every field is
+  // optional at the boundary and `<Link to="/strategy">` (no search) compiles,
+  // with fromRaw applying the 0.5 default.
+  const hasRisk = raw.risk != null && raw.risk !== ''
+  const risk = hasRisk ? clampRisk(raw.risk) : undefined
+  return {
+    ...(gp ? { gp } : {}),
+    ...(driver ? { driver } : {}),
+    ...(rival ? { rival } : {}),
+    ...(laps ? { laps: `${laps[0]}-${laps[1]}` } : {}),
+    ...(risk != null ? { risk } : {}),
+  }
+}
+
+/**
+ * Apply a single-key scenario patch with the cascading reset of dependent
+ * levels. Changing an upstream level clears everything below it (gp → driver →
+ * rival + laps). Re-picking the SAME upstream value is a no-op and returns the
+ * ORIGINAL object (referential equality), so callers can `if (next === search)
+ * return` to skip a redundant navigate. Pure — no navigation, no side effects.
+ */
+export function applyStrategyPatch(
+  search: StrategySearch,
+  patch: Partial<StrategySearch>,
+): StrategySearch {
+  if ('gp' in patch && patch.gp === search.gp) return search
+  if ('driver' in patch && patch.driver === search.driver) return search
+
+  const next: StrategySearch = { ...search, ...patch }
+  if ('gp' in patch) {
+    next.driver = undefined
+    next.rival = undefined
+    next.laps = undefined
+  } else if ('driver' in patch) {
+    next.rival = undefined
+    next.laps = undefined
+  }
+  // A rival equal to the driver is meaningless (you can't duel yourself).
+  if (next.rival && next.rival === next.driver) next.rival = undefined
+  return next
+}
+
+/** URL shape → component shape. */
+export function fromRaw(raw: RawStrategySearch): StrategySearch {
+  return {
+    gp: raw.gp,
+    driver: raw.driver,
+    rival: raw.rival,
+    laps: parseLaps(raw.laps),
+    risk: raw.risk != null ? clampRisk(raw.risk) : DEFAULT_RISK,
+  }
+}
+
+/** Component shape → URL shape (empty fields dropped; default risk omitted). */
+export function toRaw(search: StrategySearch): RawStrategySearch {
+  return {
+    ...(search.gp ? { gp: search.gp } : {}),
+    ...(search.driver ? { driver: search.driver } : {}),
+    ...(search.rival && search.rival !== search.driver ? { rival: search.rival } : {}),
+    ...(search.laps ? { laps: `${search.laps[0]}-${search.laps[1]}` } : {}),
+    ...(search.risk !== DEFAULT_RISK ? { risk: search.risk } : {}),
+  }
+}
+
+/** The lap the orchestrator analyses = the right edge of the lap window. */
+export function analysedLap(search: StrategySearch): number | undefined {
+  return search.laps?.[1]
+}

--- a/webapp/src/features/strategy/store.ts
+++ b/webapp/src/features/strategy/store.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand'
+import type { LapState, StrategyRecommendation } from '@/lib/api/strategy'
+import type { StrategySearch } from './search'
+
+// Strategy run history (Zustand, NOT persisted). Each orchestrator run is
+// non-deterministic and rate-limited (5/min), so we keep every result in memory
+// for the session: the active run feeds the Decision Brief, and the full list
+// powers the run-history rail (click a past run to restore it) and the lap-walk.
+// Not persisted — a stale LLM call from yesterday shouldn't resurrect on reload;
+// results live only as long as the session.
+
+/** One completed orchestrator run: the scenario config + inputs + output. */
+export interface RunRecord {
+  id: string
+  /** The scenario (gp/driver/rival/laps/risk) that produced this result. */
+  config: StrategySearch
+  /** The lap_state fed to the orchestrator (for the situation strip + JSON). */
+  lapState: LapState
+  result: StrategyRecommendation
+  ranAt: number
+}
+
+/** Keep memory bounded — a session rarely needs more than the last ~20 runs. */
+const MAX_RUNS = 20
+
+interface StrategyState {
+  runs: RunRecord[]
+  /** id of the run whose brief is shown; null before the first run. */
+  activeRunId: string | null
+  /** Append a run (newest first), cap the list, and make it active. */
+  addRun: (record: RunRecord) => void
+  setActiveRun: (id: string) => void
+  clearRuns: () => void
+}
+
+export const useStrategyStore = create<StrategyState>((set) => ({
+  runs: [],
+  activeRunId: null,
+  addRun: (record) =>
+    set((s) => ({
+      runs: [record, ...s.runs].slice(0, MAX_RUNS),
+      activeRunId: record.id,
+    })),
+  setActiveRun: (id) => set({ activeRunId: id }),
+  clearRuns: () => set({ runs: [], activeRunId: null }),
+}))
+
+/** The active run record, or undefined before any run / after a clear. */
+export function selectActiveRun(s: StrategyState): RunRecord | undefined {
+  return s.runs.find((r) => r.id === s.activeRunId)
+}

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -1,0 +1,323 @@
+// Strategy API types + raw-fetch client for the N25-N31 multi-agent pipeline.
+//
+// The strategy endpoints return `{ agent, result: Dict[str, Any] }` — the
+// backend ships no response models, so the generated OpenAPI schema types every
+// body as `unknown`. We hand-write the result shapes here (one place, so every
+// consumer gets real types) and unwrap the envelope. Requests go through a thin
+// raw `fetch` (same base-URL handling as the telemetry client): same-origin via
+// the Vite proxy / nginx, or VITE_API_BASE for a split origin.
+//
+// --- WHERE TO CHANGE IF THE BACKEND CONTRACT CHANGES ---
+// backend/api/v1/endpoints/strategy.py   (endpoints + request bodies)
+// src/agents/strategy_orchestrator.py:319 (StrategyRecommendation v2 schema)
+// The 4 agent result shapes mirror the PaceResult/TireResult/SituationResult/
+// PitResult Pydantic models in strategy.py.
+
+// ── Enums (mirror the orchestrator's Literal fields) ────────────────────────
+
+/** Discrete v2 action. `ALERT` is new in v2; `EXTEND_STINT` was removed. */
+export type StrategyAction = 'STAY_OUT' | 'PIT_NOW' | 'UNDERCUT' | 'OVERCUT' | 'ALERT'
+export type PaceMode = 'PUSH' | 'NEUTRAL' | 'MANAGE' | 'LIFT_AND_COAST'
+export type RiskPosture = 'AGGRESSIVE' | 'BALANCED' | 'DEFENSIVE'
+export type StrategyCompound = 'SOFT' | 'MEDIUM' | 'HARD'
+export type ContingencyPriority = 'HIGH' | 'MEDIUM' | 'LOW'
+
+// ── lap_state (GET /lap-state) ──────────────────────────────────────────────
+
+/** Our driver — full telemetry (single-driver boundary: rivals get less). */
+export interface LapStateDriver {
+  driver: string
+  team: string
+  lap_number: number
+  lap_time_s: number
+  position: number
+  compound: string
+  compound_id: number
+  tyre_life: number
+  stint: number
+  fresh_tyre: boolean
+  speed_i1: number
+  speed_i2: number
+  speed_fl: number
+  speed_st: number
+  fuel_load: number
+  driver_number: number
+  sector1_s: number
+  sector2_s: number
+  sector3_s: number
+  gap_ahead_s: number
+}
+
+/** A rival — timing-screen data only (mirrors a real pit wall). */
+export interface LapStateRival {
+  driver: string
+  team: string
+  position: number
+  lap_time_s: number
+  compound: string
+  tyre_life: number
+  gap_ahead_s: number
+}
+
+export interface Weather {
+  air_temp: number
+  track_temp: number
+  humidity: number
+  rainfall: number
+}
+
+export interface SessionMeta {
+  gp_name: string
+  year: number
+  driver: string
+  team: string
+  total_laps: number
+}
+
+/** The canonical lap_state dict — the single contract passed to every agent. */
+export interface LapState {
+  lap_number: number
+  driver: LapStateDriver
+  rivals: LapStateRival[]
+  weather: Weather
+  session_meta: SessionMeta
+}
+
+// ── Sub-agent result shapes (POST /pace|/tire|/situation|/pit) ──────────────
+
+export interface PaceResult {
+  lap_time_pred: number
+  delta_vs_prev: number
+  delta_vs_median: number
+  ci_p10: number
+  ci_p90: number
+  reasoning: string
+}
+
+export interface TireResult {
+  compound: string
+  current_tyre_life: number
+  deg_rate: number
+  laps_to_cliff_p10: number
+  laps_to_cliff_p50: number
+  laps_to_cliff_p90: number
+  warning_level: string
+  reasoning: string
+}
+
+export interface SituationResult {
+  overtake_prob: number
+  sc_prob_3lap: number
+  threat_level: string
+  gap_ahead_s: number
+  pace_delta_s: number
+  reasoning: string
+}
+
+export interface PitResult {
+  action: string
+  recommended_lap: number | null
+  compound_recommendation: string
+  stop_duration_p05: number
+  stop_duration_p50: number
+  stop_duration_p95: number
+  undercut_prob: number | null
+  undercut_target: string | null
+  sc_reactive: boolean
+  reasoning: string
+}
+
+/** Which sub-agent an AgentTab fetches. Maps 1:1 to a POST /strategy/<name>. */
+export type AgentName = 'pace' | 'tire' | 'situation' | 'pit'
+
+export interface AgentResultMap {
+  pace: PaceResult
+  tire: TireResult
+  situation: SituationResult
+  pit: PitResult
+}
+
+// ── Orchestrator v2 recommendation (POST /recommend) ────────────────────────
+
+/** One Monte-Carlo scored strategy candidate. */
+export interface ScenarioScore {
+  E: number
+  P10: number
+  P90: number
+  score: number
+}
+
+/** A conditional branch the LLM planned for upcoming laps (IF trigger → action). */
+export interface Contingency {
+  trigger: string
+  /** Replacement action — same 5-value enum as the primary action. */
+  switch_to: StrategyAction
+  priority: ContingencyPriority
+  rationale: string
+}
+
+/**
+ * The 14-field v2 recommendation. Every Optional field renders CONDITIONALLY —
+ * a no-LLM run (or a sparse response) omits most of them, so consumers must be
+ * null-tolerant throughout. `scenario_scores` and `regulation_context` are
+ * attached in code after the LLM call (always present, possibly empty).
+ */
+export interface StrategyRecommendation {
+  action: StrategyAction
+  reasoning: string
+  confidence: number
+  pit_lap_target?: number | null
+  compound_next?: StrategyCompound | null
+  undercut_target?: string | null
+  pace_mode: PaceMode
+  target_lap_time_s?: number | null
+  risk_posture: RiskPosture
+  contingencies: Contingency[]
+  key_risks: string[]
+  expected_stint_end?: number | null
+  scenario_scores: Record<string, ScenarioScore>
+  regulation_context: string
+}
+
+/** Request body for POST /recommend (mirrors RecommendRequest). */
+export interface RecommendRequest {
+  lap_state: LapState
+  gp_name?: string
+  year?: number
+  gap_ahead_s?: number
+  pace_delta_s?: number
+  risk_tolerance?: number
+}
+
+// ── Error type — carries HTTP status so the UI can branch (404/422/429/500) ──
+
+/** Structured error payload from the strategy endpoints (`_agent_error`). */
+export interface StrategyErrorBody {
+  error: string
+  agent: string
+  detail: string
+}
+
+export class StrategyApiError extends Error {
+  readonly status: number
+  readonly body: unknown
+  constructor(status: number, message: string, body: unknown) {
+    super(message)
+    this.name = 'StrategyApiError'
+    this.status = status
+    this.body = body
+  }
+  /** True for the 5/min rate limit on /recommend and /rag. */
+  get isRateLimited(): boolean {
+    return this.status === 429
+  }
+}
+
+// ── Fetch helpers ───────────────────────────────────────────────────────────
+
+const YEAR = 2025
+
+function base(): string {
+  return import.meta.env.VITE_API_BASE ?? ''
+}
+
+/** Extract a human message from FastAPI's `{detail}` (string or structured). */
+function messageFromBody(status: number, body: unknown): string {
+  const detail = (body as { detail?: unknown } | null)?.detail
+  if (typeof detail === 'string') return detail
+  if (detail && typeof detail === 'object' && 'detail' in detail) {
+    return String((detail as StrategyErrorBody).detail)
+  }
+  return `Request failed (${status})`
+}
+
+async function parseOrThrow<T>(res: Response): Promise<T> {
+  const body: unknown = await res.json().catch(() => null)
+  if (!res.ok) throw new StrategyApiError(res.status, messageFromBody(res.status, body), body)
+  return body as T
+}
+
+async function getJson<T>(path: string, query: Record<string, string | number>): Promise<T> {
+  const params = new URLSearchParams(
+    Object.entries(query).map(([k, v]) => [k, String(v)]),
+  ).toString()
+  const res = await fetch(`${base()}/api/v1/strategy/${path}?${params}`)
+  return parseOrThrow<T>(res)
+}
+
+async function postJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(`${base()}/api/v1/strategy/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  })
+  return parseOrThrow<T>(res)
+}
+
+/** Every strategy endpoint wraps its payload as `{ agent, result }`. */
+interface Envelope<T> {
+  agent: string
+  result: T
+}
+
+// ── Client functions ────────────────────────────────────────────────────────
+
+export async function fetchStrategyGps(year = YEAR): Promise<string[]> {
+  const data = await getJson<{ gps?: string[] }>('available-gps', { year })
+  return data.gps ?? []
+}
+
+export async function fetchStrategyDrivers(gp: string, year = YEAR): Promise<string[]> {
+  const data = await getJson<{ drivers?: string[] }>('available-drivers', { gp, year })
+  return data.drivers ?? []
+}
+
+export interface LapRange {
+  min_lap: number
+  max_lap: number
+}
+
+export async function fetchLapRange(gp: string, driver: string, year = YEAR): Promise<LapRange> {
+  return getJson<LapRange>('lap-range', { gp, driver, year })
+}
+
+export async function fetchLapState(
+  gp: string,
+  driver: string,
+  lap: number,
+  year = YEAR,
+): Promise<LapState> {
+  return getJson<LapState>('lap-state', { gp, driver, lap, year })
+}
+
+/** Run one sub-agent for a lap state (pure ML — no LLM, no rate limit). */
+export async function runAgent<A extends AgentName>(
+  agent: A,
+  lapState: LapState,
+): Promise<AgentResultMap[A]> {
+  const data = await postJson<Envelope<AgentResultMap[A]>>(agent, { lap_state: lapState })
+  return data.result
+}
+
+/**
+ * Run the full N31 orchestrator (all sub-agents + 500-sample MC + LLM synthesis).
+ * Rate-limited to 5/min on the backend → surfaces as a 429 StrategyApiError.
+ * `gap_ahead_s` defaults to the driver's own gap (2.0 fallback, as Streamlit).
+ */
+export async function runRecommend(
+  lapState: LapState,
+  riskTolerance: number,
+  signal?: AbortSignal,
+): Promise<StrategyRecommendation> {
+  const body: RecommendRequest = {
+    lap_state: lapState,
+    gp_name: lapState.session_meta.gp_name,
+    year: lapState.session_meta.year,
+    gap_ahead_s: lapState.driver.gap_ahead_s || 2.0,
+    pace_delta_s: 0,
+    risk_tolerance: riskTolerance,
+  }
+  const data = await postJson<Envelope<StrategyRecommendation>>('recommend', body, signal)
+  return data.result
+}

--- a/webapp/src/lib/drivers.ts
+++ b/webapp/src/lib/drivers.ts
@@ -3,6 +3,10 @@
 // charts keep IDENTICAL colours. Each driver gets their team's colour for that
 // season (2023-2025 lineups). Keep in sync with the Python source if lineups
 // change.
+//
+// Lives in `src/lib/` (not a feature folder) because two features consume it:
+// Dashboard (chart line colours) and Strategy (team-coloured driver / rival
+// names). Shared → app-level, so features stay decoupled siblings.
 
 const RED_BULL = '#3671C6'
 const RED_BULL_2 = '#1B3D8E'

--- a/webapp/src/lib/queryKeys.ts
+++ b/webapp/src/lib/queryKeys.ts
@@ -18,4 +18,11 @@ export const queryKeys = {
     health: () => ['chat', 'health'] as const,
     models: () => ['chat', 'models'] as const,
   },
+  strategy: {
+    gps: () => ['strategy', 'gps'] as const,
+    drivers: (gp: string) => ['strategy', 'drivers', gp] as const,
+    lapRange: (gp: string, driver: string) => ['strategy', 'lap-range', gp, driver] as const,
+    agent: (agent: string, gp: string, driver: string, lap: number) =>
+      ['strategy', 'agent', agent, gp, driver, lap] as const,
+  },
 } as const

--- a/webapp/src/styles/tokens.css
+++ b/webapp/src/styles/tokens.css
@@ -59,6 +59,8 @@
   --tire-hard: #e6e6e6; /* white */
   --tire-inter: #2dd47a; /* green */
   --tire-wet: #2d8fff; /* blue */
+  --tire-ink: #0c0d14; /* fixed dark text for compound pills — tyre colours are
+    identity, not themeable, so this never flips in light theme (see below) */
 
   /* ---------- DIVIDERS / SURFACES ---------- */
   --divider: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
Closes #35.

## What
The **Strategy** tab: the UI of the N31 multi-agent orchestrator (the crown jewel of the TFG). A three-act experience: **configure** a scenario (GP / driver / rival / lap window / risk) then watch the agent council **deliberate** then read a **decision brief** with its full evidence trail.

## Why
The Streamlit page rendered only ~6 of the orchestrator's 14-field v2 recommendation and treated the run as a form dump. This surfaces the whole schema and makes the run a genuine pit-wall moment, matching the Dashboard's migrated grammar.

## How
- **Data layer:** `lib/api/strategy.ts` (hand types + raw-fetch client), `features/strategy/{search,store,queries}.ts` (URL = scenario, Zustand = run history, TanStack Query = data). URL-bound scenarios are shareable; deep links prefill config but never auto-fire the rate-limited LLM run.
- **7 components:** ScenarioBar, AgentDeliberation, SituationStrip (+ rival duel), DecisionCard (+ ContingencyList playbook), ScenarioScoresChart (E bar + P10-P90 whiskers + delta-to-winner), StintTimeline (SVG, responsive), AgentTabs (lazy per-agent evidence). Five states: idle / running / complete / error / stale.
- **3 new shared primitives:** ActionBadge, ConfidenceDial, CompoundPill. Lifted the driver-colour palette to `@/lib/drivers` (Dashboard + Strategy share it).
- **A11y/design pass** (dashboard-analytics UI audit): moved chart value labels off the whiskers, de-collided the x-axis, honest zero-baseline bars, humanised enum labels, full-width legible timeline, and fixed compound pills for **WCAG legibility in the light theme** (dark ink + hairline border).

## Verification
- tsc + oxlint + prettier + vitest (58 pass, incl. new search + DecisionCard tests) + production build all green.
- Browser-verified idle / config / deliberation / complete brief in **both** light and dark themes (run flow driven with a mocked orchestrator, since the local backend lacks the ML/LLM stack).

## Out of scope (documented follow-ups)
Run-history rail + pin/compare, risk-sweep, the optional 5th Radio agent tab, and streaming race-mode (the deliberation + brief are already pure functions of a RunRecord so a streaming producer can drive them later).