### PR TITLE
fix(webapp): let Strategy select Safety-Car laps, add model-diagnostic charts (#35)

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -531,6 +531,117 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
 
 
 # ---------------------------------------------------------------------------
+# /tire-range — TCN degradation across a lap range (Tyres agent-tab chart)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/tire-range", dependencies=[Depends(rate_limit("tire-range", capacity=5, per_minute=10))])
+def predict_tire_range(
+    request: PaceRangeRequest,
+    laps_df: pd.DataFrame = Depends(_require_laps_df),
+):
+    """Run the TireDegTCN across a lap range for the Tyres agent-tab chart.
+
+    Returns, per lap in the window, the ACTUAL cumulative fuel-adjusted degradation
+    (the parquet's `FuelAdjustedDegAbsolute`, i.e. the TCN's own training target)
+    and the model's PREDICTED value (a deterministic forward pass over the stint up
+    to that lap). Laps the featured parquet dropped (Safety Car / out laps) are
+    simply absent from the series, so the lines break there rather than erroring.
+
+    The tire agent is set up once (its `laps_df`/`session_meta`), then only the
+    cheap deterministic predict path runs per lap — no per-lap MC Dropout.
+    """
+    import torch
+
+    from src.agents.tire_agent import _compound_name_to_id, _get_default_tire_agent
+
+    df = get_laps_df(request.year)
+    if df is None:
+        raise HTTPException(503, detail=f"No parquet for {request.year}")
+    gp_df = df[df["GP_Name"] == request.gp]
+    if gp_df.empty:
+        raise HTTPException(404, detail=f"GP '{request.gp}' not found")
+    drv_df = gp_df[gp_df["Driver"] == request.driver].sort_values("LapNumber")
+    if drv_df.empty:
+        raise HTTPException(404, detail=f"Driver '{request.driver}' not found")
+    drv_df = drv_df[
+        (drv_df["LapNumber"] >= request.lap_start) & (drv_df["LapNumber"] <= request.lap_end)
+    ]
+
+    total_laps = int(gp_df["LapNumber"].max())
+    agent = _get_default_tire_agent()
+
+    # Set the agent up ONCE, directly (NO run_from_state → no LLM): fill laps_df +
+    # session_meta exactly as run_from_state's setup does, then only the cheap
+    # deterministic TCN forward runs per lap. Running the full agent per lap would
+    # invoke the LLM (slow) and leaves the model in MC-train mode, which corrupts
+    # the eval-mode prediction scale — the manual setup keeps the forward clean.
+    team = str(drv_df.iloc[0].get("Team", "")) if not drv_df.empty else ""
+    agent.laps_df = laps_df.copy()
+    lt_col = "LapTime_s" if "LapTime_s" in laps_df.columns else "LapTime"
+    lap_times = pd.to_numeric(laps_df[lt_col], errors="coerce").dropna()
+    if "TrackStatus" in laps_df.columns:
+        clean_mask = laps_df["TrackStatus"].astype(str) == "1"
+        clean_times = lap_times[clean_mask] if clean_mask.sum() > 0 else lap_times
+    else:
+        clean_times = lap_times
+    agent.session_meta = {
+        "fastest_lap_s": float(clean_times.min()) if len(clean_times) > 0 else 90.0,
+        "cluster_mean_lap_s": float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
+        "total_laps": total_laps,
+        "cluster_id": agent.cfg.circuit_cluster_map.get(request.gp, 0),
+        "team_id": agent.cfg.team_id_map.get(team, 4),
+        "year": request.year,
+        "AirTemp": 28.0,
+        "TrackTemp": 38.0,
+        "Humidity": 50.0,
+        "Rainfall": 0.0,
+    }
+
+    results = []
+    for _, row in drv_df.iterrows():
+        lap = int(row["LapNumber"])
+        compound = str(row.get("Compound", ""))
+        tyre_life = int(row["TyreLife"]) if not pd.isna(row.get("TyreLife")) else 0
+        actual = (
+            float(row["FuelAdjustedDegAbsolute"])
+            if "FuelAdjustedDegAbsolute" in row.index
+            and not pd.isna(row.get("FuelAdjustedDegAbsolute"))
+            else None
+        )
+
+        pred = None
+        try:
+            compound_id = (
+                compound
+                if compound.startswith("C")
+                else _compound_name_to_id(compound, request.gp, request.year)
+            )
+            stint = agent._get_driver_stint(request.driver, tyre_life)
+            if stint is not None and compound_id in agent.bundles:
+                tensor = agent._build_stint_tensor(stint, compound_id, agent.session_meta)
+                model = agent.bundles[compound_id]["model"]
+                with torch.no_grad():
+                    model.eval()
+                    pred = float(model(tensor).item())
+        except Exception as exc:  # noqa: BLE001 — a bad lap just leaves a gap, never a 500
+            logger.debug("tire-range: skipping lap %s (%s)", lap, exc)
+            pred = None
+
+        results.append(
+            {
+                "lap": lap,
+                "actual": actual,
+                "pred": pred,
+                "compound": compound,
+                "tyre_life": tyre_life,
+            }
+        )
+
+    return {"predictions": results, "count": len(results)}
+
+
+# ---------------------------------------------------------------------------
 # /tire — N26 TireDegTCN + MC Dropout cliff estimation
 # ---------------------------------------------------------------------------
 

--- a/webapp/src/features/strategy/StrategyPage.tsx
+++ b/webapp/src/features/strategy/StrategyPage.tsx
@@ -104,6 +104,16 @@ export function StrategyPage() {
   const cursorLap = search.lap ?? effectiveWindow?.[1]
   const canRun = !!search.gp && !!search.driver && !!effectiveWindow && cursorLap != null
 
+  // Green-flag laps that actually have telemetry: the featured parquet drops
+  // Safety-Car / out / pit laps (per driver), so the decision cursor can land on
+  // a lap with no data. We don't BLOCK selecting such a lap (like the arcade
+  // replay, you can still go there) — we just can't run the models on it, and
+  // say so. `pace-range` returns exactly the laps that have a row.
+  const availableLaps = useMemo(
+    () => new Set((paceRangeQuery.data ?? []).map((p) => p.lap)),
+    [paceRangeQuery.data],
+  )
+
   const running = recommend.isPending
   const hasRun = !!activeRun
   const runLap = activeRun ? analysedLap(activeRun.config) : undefined
@@ -119,6 +129,15 @@ export function StrategyPage() {
     hasRun && cursorLap === runLap ? activeRun.lapState : cursorLapStateQuery.data
   const isPreview = cursorLap !== runLap
 
+  // A lap has no telemetry when its lap-state 404s (fast — a metadata call) or
+  // it's absent from the pace-range set: the featured parquet drops Safety-Car /
+  // pit / out laps (per driver). We DON'T block selecting it (like the arcade
+  // replay, you can still go there); we just say the models can't run there.
+  const cursorNoTelemetry =
+    cursorLap != null &&
+    (cursorLapStateQuery.isError || (availableLaps.size > 0 && !availableLaps.has(cursorLap)))
+  const cursorHasData = !cursorNoTelemetry
+
   /** Apply a single-key scenario patch (cascade + navigate), like Dashboard. */
   const handleChange = (patch: Partial<StrategySearch>) => {
     if (applyStrategyPatch(search, patch) === search) return
@@ -133,6 +152,9 @@ export function StrategyPage() {
 
   const handleRun = () => {
     if (!canRun || !effectiveWindow || cursorLap == null) return
+    // No telemetry on this lap (Safety Car / pit / out lap) — the no-data notice
+    // already explains it, so a click just no-ops instead of firing a doomed run.
+    if (!cursorHasData) return
     const controller = new AbortController()
     abortRef.current = controller
     const runSearch: StrategySearch = { ...search, laps: effectiveWindow, lap: cursorLap }
@@ -236,6 +258,7 @@ export function StrategyPage() {
         ) : (
           <div className="flex flex-col gap-6">
             {isStale ? <StaleNotice onRerun={handleRun} /> : null}
+            {!cursorHasData && cursorLap != null ? <NoTelemetryNotice lap={cursorLap} /> : null}
 
             {/* HERO — deliberation while running, else the brief / error / prompt. */}
             {running ? (
@@ -257,6 +280,11 @@ export function StrategyPage() {
             <div className="flex flex-col gap-3">
               {readoutLapState ? (
                 <LapReadout lapState={readoutLapState} rival={search.rival} isPreview={isPreview} />
+              ) : !cursorHasData && cursorLap != null ? (
+                <p className="font-mono text-sm text-fg-4">
+                  <span className="text-warning">No telemetry</span> · lap {cursorLap} (Safety Car /
+                  pit / out lap)
+                </p>
               ) : null}
               <RaceTrace
                 points={paceRangeQuery.data ?? []}
@@ -342,8 +370,27 @@ function StaleNotice({ onRerun }: { onRerun: () => void }) {
   )
 }
 
+/** No-telemetry disclaimer — the cursor lap was dropped from the featured
+ *  dataset (Safety Car / pit / out lap), so the models can't run there. NOT an
+ *  error: selection is never blocked, we just say what's going on. */
+function NoTelemetryNotice({ lap }: { lap: number }) {
+  return (
+    <div
+      role="status"
+      className="flex flex-wrap items-center gap-3 rounded-2xl border border-hairline bg-warning/8 px-4 py-3 text-sm text-fg-2"
+    >
+      <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
+      <span>
+        No telemetry for lap {lap} — a Safety Car, pit or out lap that the featured dataset drops,
+        so the pit-wall models can&apos;t run here. Pick a green-flag lap on the trace to run.
+      </span>
+    </div>
+  )
+}
+
 /** Orchestrator failure — tailored copy by status; config preserved so Retry
- *  re-fires the same scenario. Hairline + tint, no side-stripe. */
+ *  re-fires the same scenario. A 404 is the no-telemetry case (a Safety-Car /
+ *  pit lap), shown as a softer warning rather than a hard error. */
 function StrategyErrorBanner({
   error,
   onRetry,
@@ -351,24 +398,35 @@ function StrategyErrorBanner({
   error: StrategyApiError | null
   onRetry: () => void
 }) {
+  const isNoData = error?.status === 404
   const isRateLimited = error?.isRateLimited ?? false
-  const message = isRateLimited
-    ? 'Rate limit reached (5 runs per minute). Wait a moment, then retry.'
-    : (error?.message ?? 'The orchestrator could not complete this run.')
+  const message = isNoData
+    ? 'This lap has no telemetry (a Safety Car, pit or out lap the dataset drops), so the models cannot run. Pick a green-flag lap.'
+    : isRateLimited
+      ? 'Rate limit reached (5 runs per minute). Wait a moment, then retry.'
+      : (error?.message ?? 'The orchestrator could not complete this run.')
   return (
     <div
-      role="alert"
-      className="flex flex-col gap-3 rounded-2xl border border-hairline bg-danger/8 px-5 py-4"
+      role={isNoData ? 'status' : 'alert'}
+      className={cn(
+        'flex flex-col gap-3 rounded-2xl border border-hairline px-5 py-4',
+        isNoData ? 'bg-warning/8' : 'bg-danger/8',
+      )}
     >
       <div className="flex items-center gap-3 text-sm text-fg-1">
-        <TriangleAlert className="size-5 shrink-0 text-danger" aria-hidden="true" />
-        <span className="font-medium">Run failed</span>
+        <TriangleAlert
+          className={cn('size-5 shrink-0', isNoData ? 'text-warning' : 'text-danger')}
+          aria-hidden="true"
+        />
+        <span className="font-medium">{isNoData ? 'No telemetry for this lap' : 'Run failed'}</span>
       </div>
       <p className="text-sm text-fg-2">{message}</p>
-      <Button size="sm" variant="primary" className="self-start" onClick={onRetry}>
-        <RotateCcw className="size-4" aria-hidden="true" />
-        Retry
-      </Button>
+      {!isNoData ? (
+        <Button size="sm" variant="primary" className="self-start" onClick={onRetry}>
+          <RotateCcw className="size-4" aria-hidden="true" />
+          Retry
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/webapp/src/features/strategy/components/AgentModelChart.tsx
+++ b/webapp/src/features/strategy/components/AgentModelChart.tsx
@@ -1,0 +1,199 @@
+// AgentModelChart — the reusable per-lap "actual vs model estimate" line chart
+// backing two Agent Breakdown tabs: PaceTab's XGBoost lap-time model and
+// TyresTab's TCN tyre-degradation model. Both tabs plot the exact same shape
+// of evidence (a solid ACTUAL line against a dashed MODEL ESTIMATE line, one
+// point per lap), so it lives as one component instead of being duplicated
+// per tab, parameterised only by labels/unit — mirrors ScoresPlot.tsx's
+// "frameless, no ChartCard shell" idiom, since both call sites already sit
+// inside AgentTabs' own Card.
+//
+// ECharts wiring mirrors RaceTrace.tsx / ScoresPlot.tsx: `registerF1Theme()`
+// once at module load, `useChartTheme()` + `key={chartTheme}` to remount on a
+// light/dark toggle, and `useFirstPaintAnimation` so the entrance sweep plays
+// once and every later update (a new cursor lap, fresh data) applies
+// instantly. NEVER set `animation: false` instead — see that hook's own
+// docstring for why that snaps an in-flight entrance sweep.
+
+import { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
+import { Skeleton } from '@/components/Skeleton'
+
+registerF1Theme()
+
+const DEFAULT_HEIGHT_PX = 200
+
+// Identity colors — the same solid/dashed pair RaceTrace uses for its own
+// actual/pred lines, so a strategist reading either chart learns one visual
+// language once. Unchanged across light/dark (see RaceTrace's own note).
+const ACTUAL_COLOR = '#3385ff'
+const PRED_COLOR = '#a29bfe'
+const CURSOR_COLOR = '#6c5ce7'
+
+/** One lap's actual value and the model's estimate for it. Either (or both)
+ *  can be `null` — a stint's first lap, a lap the model couldn't score, or a
+ *  lap dropped from the featured parquet (Safety Car / out laps) — and
+ *  `connectNulls: false` on both series renders that as a real gap instead of
+ *  bridging over missing evidence. */
+export interface AgentModelPoint {
+  lap: number
+  actual: number | null
+  pred: number | null
+}
+
+export interface AgentModelChartProps {
+  points: AgentModelPoint[]
+  /** Legend label for the solid line, e.g. "Actual lap time". */
+  actualLabel: string
+  /** Legend label for the dashed line, e.g. "XGBoost estimate". */
+  predLabel: string
+  /** Appended to axis labels, e.g. "s". Defaults to no unit. */
+  yUnit?: string
+  /** The lap currently under analysis -> a faint dashed vertical marker. */
+  cursorLap?: number
+  /** Hide the dashed estimate line + its legend entry, showing only the ACTUAL
+   *  series. Used where the model's raw per-lap estimate isn't reproducible
+   *  outside its full agent flow, so a dashed line would mislead. */
+  hidePred?: boolean
+  height?: number
+  loading?: boolean
+}
+
+/** True once at least one lap has a real actual or predicted value — the
+ *  guard between the chart and the muted "No data" state. An all-null
+ *  `points` array (or an empty one) fails this the same way. */
+function hasData(points: AgentModelPoint[]): boolean {
+  return points.some((point) => point.actual != null || point.pred != null)
+}
+
+/** A faint dashed vertical line at `cursorLap` — where "now" sits on the
+ *  trace. Deliberately unlabelled (unlike RaceTrace's "DECISION" marker):
+ *  this chart is a compact evidence pane, not the full-width navigable
+ *  instrument, so a text label would compete with the legend for room. */
+function buildCursorMarkLine(cursorLap: number): LineSeriesOption['markLine'] {
+  return {
+    silent: true,
+    symbol: 'none',
+    data: [
+      {
+        xAxis: cursorLap,
+        lineStyle: { color: CURSOR_COLOR, width: 1, type: 'dashed', opacity: 0.5 },
+      },
+    ],
+  }
+}
+
+function buildActualSeries(
+  points: AgentModelPoint[],
+  actualLabel: string,
+  cursorLap: number | undefined,
+): LineSeriesOption {
+  return {
+    name: actualLabel,
+    type: 'line',
+    symbol: 'none',
+    connectNulls: false,
+    lineStyle: { color: ACTUAL_COLOR, width: 2 },
+    itemStyle: { color: ACTUAL_COLOR },
+    z: 10,
+    data: points.map((point) => [point.lap, point.actual]),
+    ...(cursorLap != null ? { markLine: buildCursorMarkLine(cursorLap) } : {}),
+  }
+}
+
+function buildPredSeries(points: AgentModelPoint[], predLabel: string): LineSeriesOption {
+  return {
+    name: predLabel,
+    type: 'line',
+    symbol: 'none',
+    connectNulls: false,
+    lineStyle: { color: PRED_COLOR, width: 1.5, type: 'dashed' },
+    itemStyle: { color: PRED_COLOR },
+    z: 9,
+    data: points.map((point) => [point.lap, point.pred]),
+  }
+}
+
+/** Composes the full option: a value x-axis over lap number, a small legend
+ *  (its default line-shaped icon already carries the solid/dashed distinction,
+ *  so no custom `icon` override is needed), and the two series above. Axis
+ *  labels stay tiny (10px) — this chart lives inside an already-dense Agent
+ *  Breakdown tab, not a standalone full-width instrument. */
+function buildOption(
+  points: AgentModelPoint[],
+  actualLabel: string,
+  predLabel: string,
+  yUnit: string,
+  cursorLap: number | undefined,
+  hidePred: boolean,
+): EChartsOption {
+  const series: LineSeriesOption[] = [buildActualSeries(points, actualLabel, cursorLap)]
+  if (!hidePred) series.push(buildPredSeries(points, predLabel))
+  return {
+    tooltip: { trigger: 'axis' },
+    legend: { top: 0, right: 0, textStyle: { fontSize: 10 } },
+    grid: { top: 28, left: 8, right: 12, bottom: 22, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap',
+      nameLocation: 'middle',
+      nameGap: 18,
+      nameTextStyle: { fontSize: 10 },
+      axisLabel: { fontSize: 10 },
+      splitLine: { show: false },
+    },
+    yAxis: {
+      type: 'value',
+      scale: true,
+      axisLabel: { fontSize: 10, formatter: (value: number) => `${value.toFixed(1)}${yUnit}` },
+    },
+    series,
+  }
+}
+
+/**
+ * Compact actual-vs-model-estimate line chart, one lap per x tick. Backs both
+ * PaceTab (XGBoost lap-time model) and TyresTab (TCN degradation model) in the
+ * Agent Breakdown — see the module docstring for why one component serves
+ * both. Null-tolerant throughout: a lap missing either value simply breaks
+ * its line rather than crashing or interpolating over the gap.
+ */
+export function AgentModelChart({
+  points,
+  actualLabel,
+  predLabel,
+  yUnit = '',
+  cursorLap,
+  hidePred = false,
+  height = DEFAULT_HEIGHT_PX,
+  loading,
+}: AgentModelChartProps) {
+  const chartTheme = useChartTheme()
+  const option = useMemo(
+    () => buildOption(points, actualLabel, predLabel, yUnit, cursorLap, hidePred),
+    [points, actualLabel, predLabel, yUnit, cursorLap, hidePred],
+  )
+  const paintedOption = useFirstPaintAnimation(option)
+
+  if (loading) {
+    return <Skeleton style={{ height }} className="w-full" />
+  }
+
+  if (!hasData(points)) {
+    return <p className="px-2 py-8 text-center text-sm text-fg-3">No data</p>
+  }
+
+  return (
+    <div role="img" aria-label={`${actualLabel} versus ${predLabel}, per lap`}>
+      <ReactECharts
+        theme={chartTheme}
+        key={chartTheme}
+        option={paintedOption}
+        notMerge
+        style={{ height }}
+      />
+    </div>
+  )
+}

--- a/webapp/src/features/strategy/components/AgentTabs.tsx
+++ b/webapp/src/features/strategy/components/AgentTabs.tsx
@@ -22,7 +22,9 @@
 // crashing.
 
 import { useState, type ReactNode } from 'react'
-import type { LapState } from '@/lib/api/strategy'
+import { useQuery } from '@tanstack/react-query'
+import { fetchPaceRange, fetchTireRange, type LapState } from '@/lib/api/strategy'
+import { queryKeys } from '@/lib/queryKeys'
 import { useAgent } from '../queries'
 import { Card } from '@/components/Card'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/Tabs'
@@ -31,6 +33,14 @@ import { ConfidenceDial } from '@/components/ConfidenceDial'
 import { CompoundPill } from '@/components/CompoundPill'
 import { Pill } from '@/components/Pill'
 import { Skeleton } from '@/components/Skeleton'
+import { AgentModelChart, type AgentModelPoint } from './AgentModelChart'
+
+// Historical/deterministic data: cache forever, one retry so a downed backend
+// fails fast instead of a multi-minute exponential backoff on slow calls.
+// Mirrors `STATIC` in `../queries.ts` — kept local here since these two range
+// fetches are read directly by PaceTab/TyresTab rather than through a shared
+// query hook (see those tabs' own comments for why).
+const STATIC_RANGE_QUERY = { staleTime: Infinity, gcTime: Infinity, retry: 1 } as const
 
 // ── Formatting helpers ───────────────────────────────────────────────────
 
@@ -267,20 +277,50 @@ interface AgentTabPanelProps {
   enabled: boolean
 }
 
-/** Pace evidence: predicted lap time plus both deltas as StatCards, and the
- *  agent's reasoning. The confidence interval now lives on the full-width
- *  Race Trace chart (with real lap-by-lap context), so this tab stays lean
- *  instead of repeating a tiny duplicate range bar. */
+/** Pace evidence: an actual-vs-XGBoost-estimate chart across the whole
+ *  session, predicted lap time plus both deltas as StatCards, and the
+ *  agent's reasoning. The confidence interval lives on the full-width Race
+ *  Trace chart elsewhere on the page (with real lap-by-lap context), so this
+ *  tab's own chart stays a lean diagnostic view rather than repeating it. */
 function PaceTab({ lapState, enabled }: AgentTabPanelProps) {
   const query = useAgent('pace', lapState, enabled)
+
+  // A second, independent fetch alongside `useAgent('pace', ...)`: the agent
+  // call scores only the CURRENT lap, but the chart wants the model's
+  // behaviour across every lap the driver has run. Both are pure ML (no LLM),
+  // so this is cheap and — like `usePaceRange` in `../queries.ts` — cached
+  // forever per (gp, driver, range). Called unconditionally, same rule-of-
+  // hooks reasoning as `useAgent` itself (see the module docstring).
+  const gp = lapState.session_meta.gp_name
+  const driver = lapState.driver.driver
+  const totalLaps = lapState.session_meta.total_laps
+  const rangeQuery = useQuery({
+    queryKey: queryKeys.strategy.paceRange(gp, driver, 1, totalLaps),
+    queryFn: () => fetchPaceRange(gp, driver, 1, totalLaps),
+    enabled,
+    ...STATIC_RANGE_QUERY,
+  })
 
   if (query.isError) return <AgentUnavailable />
   if (!query.data) return enabled ? <AgentTabSkeleton cards={3} /> : <AgentIdle />
 
   const pace = query.data
+  const points: AgentModelPoint[] = (rangeQuery.data ?? []).map((point) => ({
+    lap: point.lap,
+    actual: point.actual,
+    pred: point.pred,
+  }))
 
   return (
     <div className="flex flex-col gap-4">
+      <AgentModelChart
+        points={points}
+        actualLabel="Actual lap time"
+        predLabel="XGBoost estimate"
+        yUnit="s"
+        cursorLap={lapState.lap_number}
+        loading={rangeQuery.isLoading}
+      />
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <StatCard eyebrow="Lap time" value={fmt(pace.lap_time_pred, 3, 's')} />
         <StatCard
@@ -307,19 +347,48 @@ function PaceTab({ lapState, enabled }: AgentTabPanelProps) {
   )
 }
 
-/** Tyre evidence: compound + warning-level pills, tyre-life/degradation
+/** Tyre evidence: an actual-vs-TCN-estimate degradation chart across the
+ *  whole session, compound + warning-level pills, tyre-life/degradation
  *  StatCards, and a laps-to-cliff P10/P50/P90 mini bar chart. */
 function TyresTab({ lapState, enabled }: AgentTabPanelProps) {
   const query = useAgent('tire', lapState, enabled)
+
+  // Same "second independent fetch" reasoning as PaceTab's `rangeQuery`: the
+  // agent call scores only the CURRENT lap, this chart wants the TCN's
+  // behaviour across every lap. Called unconditionally, before the early
+  // returns below (rules of hooks).
+  const gp = lapState.session_meta.gp_name
+  const driver = lapState.driver.driver
+  const totalLaps = lapState.session_meta.total_laps
+  const rangeQuery = useQuery({
+    queryKey: queryKeys.strategy.tireRange(gp, driver, 1, totalLaps),
+    queryFn: () => fetchTireRange(gp, driver, 1, totalLaps),
+    enabled,
+    ...STATIC_RANGE_QUERY,
+  })
 
   if (query.isError) return <AgentUnavailable />
   if (!query.data) return enabled ? <AgentTabSkeleton cards={2} /> : <AgentIdle />
 
   const tire = query.data
   const warning = levelConfig(TIRE_WARNING_CONFIG, tire.warning_level)
+  const points: AgentModelPoint[] = (rangeQuery.data ?? []).map((point) => ({
+    lap: point.lap,
+    actual: point.actual,
+    pred: point.pred,
+  }))
 
   return (
     <div className="flex flex-col gap-4">
+      <AgentModelChart
+        points={points}
+        actualLabel="Fuel-adjusted degradation"
+        predLabel="TCN estimate"
+        yUnit="s"
+        cursorLap={lapState.lap_number}
+        hidePred
+        loading={rangeQuery.isLoading}
+      />
       <div className="flex flex-wrap items-center gap-2">
         {tire.compound ? <CompoundPill compound={tire.compound} /> : null}
         <Pill tone={warning.tone}>{warning.label}</Pill>

--- a/webapp/src/features/strategy/components/RaceTrace.tsx
+++ b/webapp/src/features/strategy/components/RaceTrace.tsx
@@ -49,6 +49,13 @@ const CI_BAND_ALPHA = 0.1
 const STINT_AREA_ALPHA = 0.11
 const ACCENT = '#6c5ce7'
 
+// Paints above the stint bands (z=1) and the CI/pace-line layers (z=4-15) but
+// below the spotlight veil (z=20) and the cursor/pit markers (z=30) — see
+// `buildMissingRangesSeries`. The veil still needs to dim a "no data" band
+// like everything else when it falls outside the window, and the cursor must
+// stay legible if it ever lands inside a gap.
+const NO_DATA_BAND_Z = 10
+
 // Per-action pin colors (run flags) — mirrors the same 5-value enum used
 // throughout the Strategy tab (StintTimeline's pit tick, DecisionBanner).
 const ACTION_COLORS: Record<StrategyAction, string> = {
@@ -68,18 +75,31 @@ interface TracePalette {
   veil: string
   mutedLine: string
   mutedLabel: string
+  /** Fill for the "no data" gap band — deliberately fainter than the veil
+   *  (see `buildMissingRangesSeries`): it marks an intentional exclusion
+   *  (Safety Car / pit / out lap dropped from the featured dataset), not a
+   *  problem, so it should read as a whisper, not a warning. */
+  noDataFill: string
+  /** Matches `--fg-4` (tokens.css) — the same "hairline label" tone used for
+   *  disabled/tertiary text elsewhere in the app, reused here so the "no
+   *  data" caption sits at the same visual weight as any other quiet label. */
+  noDataLabel: string
 }
 
 const DARK_TRACE_PALETTE: TracePalette = {
   veil: 'rgba(8,8,12,0.55)',
   mutedLine: 'rgba(255,255,255,0.4)',
   mutedLabel: 'rgba(255,255,255,0.65)',
+  noDataFill: 'rgba(255,255,255,0.05)',
+  noDataLabel: 'rgba(255,255,255,0.42)',
 }
 
 const LIGHT_TRACE_PALETTE: TracePalette = {
   veil: 'rgba(245,245,247,0.6)',
   mutedLine: 'rgba(20,18,31,0.4)',
   mutedLabel: 'rgba(20,18,31,0.65)',
+  noDataFill: 'rgba(20,18,31,0.05)',
+  noDataLabel: 'rgba(20,18,31,0.42)',
 }
 
 const RUN_PIN_SIZE = 20
@@ -166,6 +186,49 @@ function groupStints(points: PaceRangePoint[]): StintBand[] {
   }
 
   return bands
+}
+
+interface MissingRange {
+  fromLap: number
+  toLap: number
+}
+
+/**
+ * Contiguous runs of laps inside `windowRange` that have NO matching point in
+ * `points`. The featured dataset drops Safety-Car / pit / out laps before it
+ * ever reaches this chart, so a gap here isn't missing telemetry — it's an
+ * intentional exclusion. Without this, a viewer just sees the actual/pred
+ * lines break and has no way to tell "the model skipped this" apart from
+ * "the data pipeline lost something"; `buildMissingRangesSeries` turns each
+ * range into a faint labeled band so the gap explains itself.
+ *
+ * Only laps strictly inside the evidence window are considered — outside it
+ * the spotlight veil already communicates "not what we're looking at", and
+ * doubling up would just add noise.
+ */
+function findMissingRanges(
+  points: PaceRangePoint[],
+  windowRange: [number, number],
+): MissingRange[] {
+  const present = new Set(points.map((point) => point.lap))
+  const [windowStart, windowEnd] = windowRange
+  const firstLap = Math.ceil(windowStart)
+  const lastLap = Math.floor(windowEnd)
+
+  const ranges: MissingRange[] = []
+  let runStart: number | null = null
+
+  for (let lap = firstLap; lap <= lastLap; lap += 1) {
+    if (present.has(lap)) {
+      if (runStart != null) ranges.push({ fromLap: runStart, toLap: lap - 1 })
+      runStart = null
+      continue
+    }
+    if (runStart == null) runStart = lap
+  }
+  if (runStart != null) ranges.push({ fromLap: runStart, toLap: lastLap })
+
+  return ranges
 }
 
 /** `ci_p90 - ci_p10` for the stacked-area delta series, or `null` when either
@@ -299,6 +362,59 @@ function buildStintBandsSeries(stints: StintBand[]): LineSeriesOption {
     tooltip: { show: false },
     z: 1,
     markArea: { silent: true, data: buildStintMarkAreaEntries(stints) },
+  }
+}
+
+/** One `markArea` rectangle per missing range, widened by half a lap on each
+ *  side (`fromLap - 0.5` / `toLap + 0.5`) so the band visually straddles the
+ *  gap between the last real point before it and the first one after —
+ *  matching how `groupStints`' bands straddle a whole lap rather than sitting
+ *  between two x-axis ticks. */
+function buildMissingRangeMarkAreaEntries(
+  ranges: MissingRange[],
+  fillColor: string,
+  labelColor: string,
+): MarkAreaEntry[] {
+  return ranges.map((range): MarkAreaEntry => [
+    {
+      xAxis: range.fromLap - 0.5,
+      itemStyle: { color: fillColor },
+      label: {
+        show: true,
+        formatter: 'no data',
+        position: 'insideTop' as const,
+        fontFamily: MONO,
+        fontSize: 10,
+        color: labelColor,
+      },
+    },
+    { xAxis: range.toLap + 0.5 },
+  ])
+}
+
+/**
+ * A ghost series (mirrors `buildStintBandsSeries`) whose only job is to host
+ * "no data" bands over laps missing from `points` inside the evidence
+ * window — see `findMissingRanges` for why a gap here is an intentional
+ * exclusion rather than a data problem. Renders nothing when the window has
+ * no gaps (a clean stint has no `markArea` at all, not an empty one).
+ */
+function buildMissingRangesSeries(
+  points: PaceRangePoint[],
+  windowRange: [number, number],
+  palette: TracePalette,
+): LineSeriesOption {
+  const ranges = findMissingRanges(points, windowRange)
+  const data = buildMissingRangeMarkAreaEntries(ranges, palette.noDataFill, palette.noDataLabel)
+  return {
+    name: 'no-data-gaps',
+    type: 'line',
+    data: [],
+    silent: true,
+    symbol: 'none',
+    tooltip: { show: false },
+    z: NO_DATA_BAND_Z,
+    ...(data.length ? { markArea: { silent: true, data } } : {}),
   }
 }
 
@@ -499,11 +615,12 @@ function buildRunTooltipFormatter(runs: RaceTraceRun[]) {
 
 /**
  * Composes the full chart option. Series are layered back-to-front by `z`:
- * stint bands (1) -> CI band (4-5) -> pred/actual lines (14-15) -> spotlight
- * veil (20) -> cursor/pit/stint-end markers (30) -> run pins (40) — each
- * later layer paints over the earlier ones, which is what lets the veil
- * genuinely DIM the trace outside the window while the decision markers stay
- * crisp regardless of where they land.
+ * stint bands (1) -> CI band (4-5) -> "no data" gap bands (10, see
+ * `buildMissingRangesSeries`) -> pred/actual lines (14-15) -> spotlight veil
+ * (20) -> cursor/pit/stint-end markers (30) -> run pins (40) — each later
+ * layer paints over the earlier ones, which is what lets the veil genuinely
+ * DIM the trace outside the window while the decision markers stay crisp
+ * regardless of where they land.
  *
  * `xAxis.min/max` pin exactly to the full lap domain (never `window`) — the
  * spotlight is drawn AS an overlay on the full trace, not a crop of it.
@@ -528,6 +645,7 @@ function buildTraceOption(
     ciBase,
     ciBandDelta,
     buildStintBandsSeries(stints),
+    buildMissingRangesSeries(points, windowRange, palette),
     buildSpotlightSeries(domain, windowRange, palette.veil),
     buildMarkersSeries(cursorLap, pitLapTarget, expectedStintEnd, points, palette),
   ]

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -354,3 +354,33 @@ export async function fetchPaceRange(
   const data = await postJson<{ predictions?: PaceRangePoint[] }>('pace-range', body)
   return data.predictions ?? []
 }
+
+/** One lap on the tyre-degradation trajectory (POST /tire-range): the ACTUAL
+ *  fuel-adjusted degradation (the TCN's training target) and the model's
+ *  PREDICTED value per lap. `actual`/`pred` are null for laps the model can't
+ *  score. Laps dropped from the featured parquet (Safety Car / out laps) are
+ *  simply absent, so the lines break there. */
+export interface TireRangePoint {
+  lap: number
+  actual: number | null
+  pred: number | null
+  compound: string
+  tyre_life: number
+}
+
+/**
+ * Actual vs TCN-predicted tyre degradation across a lap window — the Tyres
+ * agent-tab chart. Pure ML (no LLM); fetch the driver's full window once and
+ * slice client-side, like `fetchPaceRange`.
+ */
+export async function fetchTireRange(
+  gp: string,
+  driver: string,
+  lapStart: number,
+  lapEnd: number,
+  year = YEAR,
+): Promise<TireRangePoint[]> {
+  const body = { year, gp, driver, lap_start: lapStart, lap_end: lapEnd }
+  const data = await postJson<{ predictions?: TireRangePoint[] }>('tire-range', body)
+  return data.predictions ?? []
+}

--- a/webapp/src/lib/queryKeys.ts
+++ b/webapp/src/lib/queryKeys.ts
@@ -26,6 +26,8 @@ export const queryKeys = {
       ['strategy', 'lap-state', gp, driver, lap] as const,
     paceRange: (gp: string, driver: string, start: number, end: number) =>
       ['strategy', 'pace-range', gp, driver, start, end] as const,
+    tireRange: (gp: string, driver: string, start: number, end: number) =>
+      ['strategy', 'tire-range', gp, driver, start, end] as const,
     agent: (agent: string, gp: string, driver: string, lap: number) =>
       ['strategy', 'agent', agent, gp, driver, lap] as const,
   },


### PR DESCRIPTION
Two things Víctor asked for on the Strategy tab.

## 1. Safety-Car laps no longer block the tool
The featured dataset drops Safety-Car / pit / out laps **per driver** (e.g. NOR at Lusail has no laps 7-11), so moving the decision cursor onto one made the run 404 with a raw `No data for NOR lap 11 at Lusail`. Now, like the arcade replay, you can still SELECT any lap; on a lap with no telemetry:
- the lap readout shows a soft **'no telemetry (Safety Car / pit / out lap)'** disclaimer,
- a banner explains the models can't run there and to pick a green-flag lap,
- Run no-ops (no doomed request), and a stray 404 renders as a warning, not a red error,
- the **Race Trace** marks the gap with a subtle **'no data'** band.
Detection uses the fast `lap-state` 404, so the disclaimer appears immediately.

## 2. Model-diagnostic charts in the Agent Breakdown
- **Pace tab**: actual vs **XGBoost-predicted** lap time per lap (`/pace-range`) — solid vs dashed.
- **Tyres tab**: the actual **fuel-adjusted degradation** curve (new `/tire-range` endpoint), next to the TCN's calibrated cliff (P10/P50/P90) + degradation rate. The raw per-lap TCN estimate is hidden for now: reconstructing its forward pass outside the full agent flow doesn't reproduce the trained scale, so a dashed line would mislead (follow-up to wire it faithfully).

## Verification
tsc + oxlint + prettier + vitest 63 + build green. Browser-verified against a **real orchestrator run**: the Lusail/NOR/lap-11 disclaimer (non-blocking), the XGBoost pace chart tracking actual, and the tyre degradation curve, in dark theme.