### PR TITLE
fix(webapp): run strategy on Safety-Car laps via raw per-race fallback (#35)

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -266,6 +266,75 @@ def lap_range(gp: str, driver: str, year: int = 2025):
     }
 
 
+# ---------------------------------------------------------------------------
+# Raw per-race fallback — Safety Car / pit / out laps
+# ---------------------------------------------------------------------------
+# The featured parquet (get_laps_df) drops Safety-Car / pit / out laps PER
+# DRIVER because the ML models were not trained on them. The arcade replay,
+# by contrast, reads the RAW per-race parquet (data/raw/<year>/<location>/
+# laps.parquet), which keeps EVERY lap, so it can run strategy on any lap. To
+# reach arcade parity, /lap-state falls back to this raw source when the
+# featured parquet is missing the requested lap. The raw parquet already
+# carries every column the lap_state builder reads except the pre-converted
+# second columns, so we derive LapTime_s / Sector*_s and tag GP_Name, then feed
+# it through the SAME builder — the returned lap_state is byte-identical in
+# shape to the featured path.
+
+_RACE_LAPS_CACHE: Dict[tuple, Optional[pd.DataFrame]] = {}
+
+
+def _resolve_race_dir(year: int, gp: str) -> Path:
+    """Map a featured GP_Name to its data/raw/<year>/<location> folder.
+
+    Mirrors the arcade's resolver: GP_TO_LOCATION covers the country->circuit
+    aliases (Qatar->Lusail, Miami->Miami_Gardens); the underscore variant covers
+    the FastF1 space-vs-underscore mismatch (Las Vegas->Las_Vegas). Falls back to
+    the primary candidate so the caller's "not found" message stays clean.
+    """
+    from src.arcade.config import GP_TO_LOCATION
+
+    base = _REPO_ROOT / "data" / "raw" / str(year)
+    folder = GP_TO_LOCATION.get(gp, gp)
+    candidate = base / folder
+    if candidate.exists():
+        return candidate
+    return base / folder.replace(" ", "_")
+
+
+def _get_race_laps_df(year: int, gp: str) -> Optional[pd.DataFrame]:
+    """Load the RAW per-race laps parquet, normalised to the featured schema.
+
+    Returns None when the race folder or parquet is absent. Cached per
+    (year, gp) since the file never changes within a process. The derived
+    *_s columns and GP_Name tag are exactly the fields the featured parquet
+    pre-computes, so a raw row is interchangeable with a featured row in the
+    lap_state builder.
+    """
+    key = (year, gp)
+    if key in _RACE_LAPS_CACHE:
+        return _RACE_LAPS_CACHE[key]
+
+    path = _resolve_race_dir(year, gp) / "laps.parquet"
+    if not path.exists():
+        logger.warning("Raw race parquet not found: %s", path)
+        _RACE_LAPS_CACHE[key] = None
+        return None
+
+    df = pd.read_parquet(path)
+    df["LapTime_s"] = pd.to_timedelta(df["LapTime"]).dt.total_seconds()
+    for src_col, dst_col in (
+        ("Sector1Time", "Sector1_s"),
+        ("Sector2Time", "Sector2_s"),
+        ("Sector3Time", "Sector3_s"),
+    ):
+        df[dst_col] = pd.to_timedelta(df[src_col]).dt.total_seconds()
+    df["GP_Name"] = gp
+
+    _RACE_LAPS_CACHE[key] = df
+    logger.info("Loaded raw race laps %s %d: %d rows", gp, year, len(df))
+    return df
+
+
 @router.get("/lap-state")
 def get_lap_state(
     gp: str,
@@ -273,23 +342,35 @@ def get_lap_state(
     lap: int,
     year: int = 2025,
 ):
-    """Build the canonical lap_state dict from the featured parquet.
+    """Build the canonical lap_state dict for one (gp, driver, lap).
 
-    Returns the same structure that RaceStateManager.get_lap_state() produces
-    so it can be passed directly to any agent endpoint.
+    Reads the featured parquet first; when that lap was dropped from it
+    (Safety Car / pit / out lap), falls back to the raw per-race parquet so any
+    lap is runnable, exactly like the arcade replay. The returned structure
+    matches RaceStateManager.get_lap_state() either way, so it can be passed
+    directly to any agent endpoint.
     """
     from fastapi import HTTPException as _HTTPExc
 
+    def _lap_row(frame: Optional[pd.DataFrame]):
+        """The driver's row for this lap in *frame*, or None when unavailable."""
+        if frame is None:
+            return None
+        return frame[(frame["Driver"] == driver) & (frame["LapNumber"] == lap)]
+
     df = get_laps_df(year)
-    if df is None:
-        raise _HTTPExc(503, detail=f"No parquet for {year}")
+    gp_df = df[df["GP_Name"] == gp] if df is not None else None
+    row = _lap_row(gp_df)
 
-    gp_df = df[df["GP_Name"] == gp]
-    if gp_df.empty:
-        raise _HTTPExc(404, detail=f"GP '{gp}' not found")
+    if row is None or row.empty:
+        full = _get_race_laps_df(year, gp)
+        if full is not None:
+            gp_df = full
+            row = _lap_row(gp_df)
 
-    row = gp_df[(gp_df["Driver"] == driver) & (gp_df["LapNumber"] == lap)]
-    if row.empty:
+    if gp_df is None:
+        raise _HTTPExc(503, detail=f"No data source for {gp} {year}")
+    if row is None or row.empty:
         raise _HTTPExc(404, detail=f"No data for {driver} lap {lap} at {gp}")
 
     r = row.iloc[0]

--- a/webapp/src/features/strategy/StrategyPage.tsx
+++ b/webapp/src/features/strategy/StrategyPage.tsx
@@ -104,16 +104,6 @@ export function StrategyPage() {
   const cursorLap = search.lap ?? effectiveWindow?.[1]
   const canRun = !!search.gp && !!search.driver && !!effectiveWindow && cursorLap != null
 
-  // Green-flag laps that actually have telemetry: the featured parquet drops
-  // Safety-Car / out / pit laps (per driver), so the decision cursor can land on
-  // a lap with no data. We don't BLOCK selecting such a lap (like the arcade
-  // replay, you can still go there) — we just can't run the models on it, and
-  // say so. `pace-range` returns exactly the laps that have a row.
-  const availableLaps = useMemo(
-    () => new Set((paceRangeQuery.data ?? []).map((p) => p.lap)),
-    [paceRangeQuery.data],
-  )
-
   const running = recommend.isPending
   const hasRun = !!activeRun
   const runLap = activeRun ? analysedLap(activeRun.config) : undefined
@@ -129,13 +119,12 @@ export function StrategyPage() {
     hasRun && cursorLap === runLap ? activeRun.lapState : cursorLapStateQuery.data
   const isPreview = cursorLap !== runLap
 
-  // A lap has no telemetry when its lap-state 404s (fast — a metadata call) or
-  // it's absent from the pace-range set: the featured parquet drops Safety-Car /
-  // pit / out laps (per driver). We DON'T block selecting it (like the arcade
-  // replay, you can still go there); we just say the models can't run there.
-  const cursorNoTelemetry =
-    cursorLap != null &&
-    (cursorLapStateQuery.isError || (availableLaps.size > 0 && !availableLaps.has(cursorLap)))
+  // A lap is un-runnable ONLY when its lap-state 404s — a genuinely absent lap
+  // (DNF, out of range). Safety-Car / pit / out laps are dropped from the
+  // FEATURED parquet (so they gap the pace trace), but /lap-state falls back to
+  // the raw per-race parquet, so they DO return a state and ARE runnable, just
+  // like the arcade replay. Run-ability keys on lap-state alone, not pace-range.
+  const cursorNoTelemetry = cursorLap != null && cursorLapStateQuery.isError
   const cursorHasData = !cursorNoTelemetry
 
   /** Apply a single-key scenario patch (cascade + navigate), like Dashboard. */
@@ -152,8 +141,9 @@ export function StrategyPage() {
 
   const handleRun = () => {
     if (!canRun || !effectiveWindow || cursorLap == null) return
-    // No telemetry on this lap (Safety Car / pit / out lap) — the no-data notice
-    // already explains it, so a click just no-ops instead of firing a doomed run.
+    // Only a genuinely absent lap (lap-state 404 — DNF / out of range) blocks a
+    // run; the no-data notice explains it, so a click no-ops instead of firing a
+    // doomed request. Safety-Car / pit / out laps resolve via the raw fallback.
     if (!cursorHasData) return
     const controller = new AbortController()
     abortRef.current = controller
@@ -282,8 +272,8 @@ export function StrategyPage() {
                 <LapReadout lapState={readoutLapState} rival={search.rival} isPreview={isPreview} />
               ) : !cursorHasData && cursorLap != null ? (
                 <p className="font-mono text-sm text-fg-4">
-                  <span className="text-warning">No telemetry</span> · lap {cursorLap} (Safety Car /
-                  pit / out lap)
+                  <span className="text-warning">No data</span> · lap {cursorLap} (driver did not
+                  complete this lap)
                 </p>
               ) : null}
               <RaceTrace
@@ -370,9 +360,11 @@ function StaleNotice({ onRerun }: { onRerun: () => void }) {
   )
 }
 
-/** No-telemetry disclaimer — the cursor lap was dropped from the featured
- *  dataset (Safety Car / pit / out lap), so the models can't run there. NOT an
- *  error: selection is never blocked, we just say what's going on. */
+/** No-data disclaimer — the cursor lap is absent from BOTH the featured and the
+ *  raw per-race dataset: the driver has no recorded lap there (a retirement, or a
+ *  lap outside the race range), so there is nothing to run. NOT an error:
+ *  selection is never blocked, we just say what's going on. (Safety-Car / pit /
+ *  out laps DO resolve via the raw fallback, so they never reach here.) */
 function NoTelemetryNotice({ lap }: { lap: number }) {
   return (
     <div
@@ -381,16 +373,16 @@ function NoTelemetryNotice({ lap }: { lap: number }) {
     >
       <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
       <span>
-        No telemetry for lap {lap} — a Safety Car, pit or out lap that the featured dataset drops,
-        so the pit-wall models can&apos;t run here. Pick a green-flag lap on the trace to run.
+        No data for lap {lap} — this driver has no recorded lap here (a retirement, or a lap outside
+        the race). Pick another lap on the trace to run.
       </span>
     </div>
   )
 }
 
 /** Orchestrator failure — tailored copy by status; config preserved so Retry
- *  re-fires the same scenario. A 404 is the no-telemetry case (a Safety-Car /
- *  pit lap), shown as a softer warning rather than a hard error. */
+ *  re-fires the same scenario. A 404 is the no-data case (a lap the driver never
+ *  completed), shown as a softer warning rather than a hard error. */
 function StrategyErrorBanner({
   error,
   onRetry,
@@ -401,7 +393,7 @@ function StrategyErrorBanner({
   const isNoData = error?.status === 404
   const isRateLimited = error?.isRateLimited ?? false
   const message = isNoData
-    ? 'This lap has no telemetry (a Safety Car, pit or out lap the dataset drops), so the models cannot run. Pick a green-flag lap.'
+    ? 'This lap has no recorded data for the driver (a retirement, or a lap outside the race), so the models cannot run. Pick another lap.'
     : isRateLimited
       ? 'Rate limit reached (5 runs per minute). Wait a moment, then retry.'
       : (error?.message ?? 'The orchestrator could not complete this run.')

--- a/webapp/src/features/strategy/components/RaceTrace.tsx
+++ b/webapp/src/features/strategy/components/RaceTrace.tsx
@@ -49,13 +49,6 @@ const CI_BAND_ALPHA = 0.1
 const STINT_AREA_ALPHA = 0.11
 const ACCENT = '#6c5ce7'
 
-// Paints above the stint bands (z=1) and the CI/pace-line layers (z=4-15) but
-// below the spotlight veil (z=20) and the cursor/pit markers (z=30) — see
-// `buildMissingRangesSeries`. The veil still needs to dim a "no data" band
-// like everything else when it falls outside the window, and the cursor must
-// stay legible if it ever lands inside a gap.
-const NO_DATA_BAND_Z = 10
-
 // Per-action pin colors (run flags) — mirrors the same 5-value enum used
 // throughout the Strategy tab (StintTimeline's pit tick, DecisionBanner).
 const ACTION_COLORS: Record<StrategyAction, string> = {
@@ -75,31 +68,18 @@ interface TracePalette {
   veil: string
   mutedLine: string
   mutedLabel: string
-  /** Fill for the "no data" gap band — deliberately fainter than the veil
-   *  (see `buildMissingRangesSeries`): it marks an intentional exclusion
-   *  (Safety Car / pit / out lap dropped from the featured dataset), not a
-   *  problem, so it should read as a whisper, not a warning. */
-  noDataFill: string
-  /** Matches `--fg-4` (tokens.css) — the same "hairline label" tone used for
-   *  disabled/tertiary text elsewhere in the app, reused here so the "no
-   *  data" caption sits at the same visual weight as any other quiet label. */
-  noDataLabel: string
 }
 
 const DARK_TRACE_PALETTE: TracePalette = {
   veil: 'rgba(8,8,12,0.55)',
   mutedLine: 'rgba(255,255,255,0.4)',
   mutedLabel: 'rgba(255,255,255,0.65)',
-  noDataFill: 'rgba(255,255,255,0.05)',
-  noDataLabel: 'rgba(255,255,255,0.42)',
 }
 
 const LIGHT_TRACE_PALETTE: TracePalette = {
   veil: 'rgba(245,245,247,0.6)',
   mutedLine: 'rgba(20,18,31,0.4)',
   mutedLabel: 'rgba(20,18,31,0.65)',
-  noDataFill: 'rgba(20,18,31,0.05)',
-  noDataLabel: 'rgba(20,18,31,0.42)',
 }
 
 const RUN_PIN_SIZE = 20
@@ -186,49 +166,6 @@ function groupStints(points: PaceRangePoint[]): StintBand[] {
   }
 
   return bands
-}
-
-interface MissingRange {
-  fromLap: number
-  toLap: number
-}
-
-/**
- * Contiguous runs of laps inside `windowRange` that have NO matching point in
- * `points`. The featured dataset drops Safety-Car / pit / out laps before it
- * ever reaches this chart, so a gap here isn't missing telemetry — it's an
- * intentional exclusion. Without this, a viewer just sees the actual/pred
- * lines break and has no way to tell "the model skipped this" apart from
- * "the data pipeline lost something"; `buildMissingRangesSeries` turns each
- * range into a faint labeled band so the gap explains itself.
- *
- * Only laps strictly inside the evidence window are considered — outside it
- * the spotlight veil already communicates "not what we're looking at", and
- * doubling up would just add noise.
- */
-function findMissingRanges(
-  points: PaceRangePoint[],
-  windowRange: [number, number],
-): MissingRange[] {
-  const present = new Set(points.map((point) => point.lap))
-  const [windowStart, windowEnd] = windowRange
-  const firstLap = Math.ceil(windowStart)
-  const lastLap = Math.floor(windowEnd)
-
-  const ranges: MissingRange[] = []
-  let runStart: number | null = null
-
-  for (let lap = firstLap; lap <= lastLap; lap += 1) {
-    if (present.has(lap)) {
-      if (runStart != null) ranges.push({ fromLap: runStart, toLap: lap - 1 })
-      runStart = null
-      continue
-    }
-    if (runStart == null) runStart = lap
-  }
-  if (runStart != null) ranges.push({ fromLap: runStart, toLap: lastLap })
-
-  return ranges
 }
 
 /** `ci_p90 - ci_p10` for the stacked-area delta series, or `null` when either
@@ -362,59 +299,6 @@ function buildStintBandsSeries(stints: StintBand[]): LineSeriesOption {
     tooltip: { show: false },
     z: 1,
     markArea: { silent: true, data: buildStintMarkAreaEntries(stints) },
-  }
-}
-
-/** One `markArea` rectangle per missing range, widened by half a lap on each
- *  side (`fromLap - 0.5` / `toLap + 0.5`) so the band visually straddles the
- *  gap between the last real point before it and the first one after —
- *  matching how `groupStints`' bands straddle a whole lap rather than sitting
- *  between two x-axis ticks. */
-function buildMissingRangeMarkAreaEntries(
-  ranges: MissingRange[],
-  fillColor: string,
-  labelColor: string,
-): MarkAreaEntry[] {
-  return ranges.map((range): MarkAreaEntry => [
-    {
-      xAxis: range.fromLap - 0.5,
-      itemStyle: { color: fillColor },
-      label: {
-        show: true,
-        formatter: 'no data',
-        position: 'insideTop' as const,
-        fontFamily: MONO,
-        fontSize: 10,
-        color: labelColor,
-      },
-    },
-    { xAxis: range.toLap + 0.5 },
-  ])
-}
-
-/**
- * A ghost series (mirrors `buildStintBandsSeries`) whose only job is to host
- * "no data" bands over laps missing from `points` inside the evidence
- * window — see `findMissingRanges` for why a gap here is an intentional
- * exclusion rather than a data problem. Renders nothing when the window has
- * no gaps (a clean stint has no `markArea` at all, not an empty one).
- */
-function buildMissingRangesSeries(
-  points: PaceRangePoint[],
-  windowRange: [number, number],
-  palette: TracePalette,
-): LineSeriesOption {
-  const ranges = findMissingRanges(points, windowRange)
-  const data = buildMissingRangeMarkAreaEntries(ranges, palette.noDataFill, palette.noDataLabel)
-  return {
-    name: 'no-data-gaps',
-    type: 'line',
-    data: [],
-    silent: true,
-    symbol: 'none',
-    tooltip: { show: false },
-    z: NO_DATA_BAND_Z,
-    ...(data.length ? { markArea: { silent: true, data } } : {}),
   }
 }
 
@@ -615,9 +499,8 @@ function buildRunTooltipFormatter(runs: RaceTraceRun[]) {
 
 /**
  * Composes the full chart option. Series are layered back-to-front by `z`:
- * stint bands (1) -> CI band (4-5) -> "no data" gap bands (10, see
- * `buildMissingRangesSeries`) -> pred/actual lines (14-15) -> spotlight veil
- * (20) -> cursor/pit/stint-end markers (30) -> run pins (40) — each later
+ * stint bands (1) -> CI band (4-5) -> pred/actual lines (14-15) -> spotlight
+ * veil (20) -> cursor/pit/stint-end markers (30) -> run pins (40) — each later
  * layer paints over the earlier ones, which is what lets the veil genuinely
  * DIM the trace outside the window while the decision markers stay crisp
  * regardless of where they land.
@@ -645,7 +528,6 @@ function buildTraceOption(
     ciBase,
     ciBandDelta,
     buildStintBandsSeries(stints),
-    buildMissingRangesSeries(points, windowRange, palette),
     buildSpotlightSeries(domain, windowRange, palette.veil),
     buildMarkersSeries(cursorLap, pitLapTarget, expectedStintEnd, points, palette),
   ]


### PR DESCRIPTION
Corrects the Safety-Car-lap handling shipped in #114. That PR assumed those laps were un-runnable and blocked them with a disclaimer; in fact the arcade replay runs strategy on them fine, because it reads a different data source.

## Root cause
The webapp built `lap_state` only from the **featured** parquet, which drops Safety-Car / pit / out laps **per driver** (NOR at Lusail has no laps 7-11). So the decision cursor 404'd there: `No data for NOR lap 11 at Lusail`. The **arcade** works because `RaceReplayEngine` reads the **raw per-race** parquet (`data/raw/<year>/<location>/laps.parquet`), which keeps **every** lap and already carries the columns the agents need (CompoundID, TyreLife, FuelLoad, Position...).

## Fix
- **Backend**: `/lap-state` now falls back to that same raw per-race parquet when the featured parquet is missing the lap, normalised to the featured schema (derive `LapTime_s` / `Sector*_s`, tag `GP_Name`), then fed through the **same** builder. Green-flag laps are unchanged (featured first). GP->folder resolution reuses the arcade's `GP_TO_LOCATION`.
- **Frontend**: run-ability keys on the lap-state response alone (not the pace-range set), so Safety-Car laps enable **Run** instead of a blocker. The disclaimer is kept only for a **genuinely** absent lap (a retirement, or a lap outside the race). Removed the RaceTrace `no data` band added in #114 under the wrong assumption.

## Verification
- `/lap-state?gp=Lusail&driver=NOR&lap=11` -> HTTP **200** (was 404): NOR P2, MEDIUM, tyre 11, 18 rivals.
- In-process orchestrator on Lusail/NOR/lap 11 -> **STAY_OUT, conf 0.96** (a real recommendation, like the arcade).
- Browser (real backend): Run enabled, no disclaimer, no band, full trace + real lap-11 readout (`SC(3) 0.7%`).
- tsc + oxlint + prettier + vitest 63 + build green.