### PR TITLE
fix(webapp): wire Safety-Car context into /recommend, add trace scrubber + single re-run (#35)

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -862,6 +862,74 @@ def query_rag(request: RagRequest):
 
 
 # ---------------------------------------------------------------------------
+# Safety-Car context — RCM events for the analysed lap
+# ---------------------------------------------------------------------------
+# The orchestrator only recommends PIT_NOW under a Safety Car when the
+# SAFETY_CAR_DEPLOYED race-control message reaches the Race Situation agent (N27),
+# which then flips sc_currently_active -> forces sc_prob_3lap=1.0 -> routes the pit
+# + RAG agents (RCMContextResolver, thesis 6.3). A "SAFETY CAR DEPLOYED" message is
+# a one-shot row at the deploy lap, so a single-lap run several laps into the
+# neutralisation would miss it. This mirrors the arcade/CLI exactly: replay every
+# lap's RCM window in order through a stateful RaceControlStateTracker and re-assert
+# (inject a synthetic event) on laps that carry no fresh message. RCM only — no
+# Whisper / radio transcription (disable_transcription keeps it out of the request
+# path; radio_msgs, which feed only N29, stay empty as before).
+
+_RADIO_RUNNER_CACHE: Dict[tuple, Any] = {}
+
+
+def _get_radio_runner(year: int, gp: str, laps_df: pd.DataFrame):
+    """A transcription-disabled RadioPipelineRunner for (year, gp), or None.
+
+    Cached per (year, gp). `disable_transcription` keeps Whisper out of the
+    request path — only the pre-parsed rcm.parquet is needed for the SC override.
+    A missing corpus degrades to None (no RCM), never an error.
+    """
+    key = (year, gp)
+    if key in _RADIO_RUNNER_CACHE:
+        return _RADIO_RUNNER_CACHE[key]
+    runner = None
+    try:
+        from src.nlp.radio_runner import RadioPipelineRunner
+
+        runner = RadioPipelineRunner(
+            year=year,
+            gp_name=gp,
+            laps_df=laps_df,
+            data_root=get_data_root(),
+            disable_transcription=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - corpus is optional; degrade to no RCM
+        logger.warning("Radio/RCM corpus unavailable for %s %d: %s", gp, year, exc)
+    _RADIO_RUNNER_CACHE[key] = runner
+    return runner
+
+
+def _rcm_events_for_lap(year: int, gp: str, laps_df: pd.DataFrame, lap: int) -> List[Dict[str, Any]]:
+    """RCM events active at *lap*, replaying the stateful SC tracker from lap 1.
+
+    Returns the lap's own RCM rows plus a synthetic SAFETY CAR DEPLOYED when a
+    neutralisation is still in force but this lap carried no fresh message
+    (mirrors ``src/arcade/strategy.py``). Empty list when the corpus is missing.
+    """
+    runner = _get_radio_runner(year, gp, laps_df)
+    if runner is None:
+        return []
+    from src.nlp.rcm_state import RaceControlStateTracker
+
+    tracker = RaceControlStateTracker()
+    rcm_at_lap: List[Dict[str, Any]] = []
+    for n in range(1, lap + 1):
+        _radios, rcm = runner.radios_for_lap(n)
+        tracker.ingest(n, rcm)
+        if n == lap:
+            rcm_at_lap = list(rcm)
+    if tracker.should_inject(lap):
+        rcm_at_lap.append(tracker.synthetic_event())
+    return rcm_at_lap
+
+
+# ---------------------------------------------------------------------------
 # /recommend — N31 full orchestrator (all sub-agents + MC simulation + LLM)
 # ---------------------------------------------------------------------------
 
@@ -877,13 +945,23 @@ def recommend_strategy(
 
         from src.agents.strategy_orchestrator import run_strategy_orchestrator_from_state
 
+        # Safety-Car override: when the caller didn't supply RCM events, load them
+        # for this lap so an active Safety Car reaches N27 (arcade parity — without
+        # this the orchestrator never sees the neutralisation and stays out).
+        rcm_events = request.rcm_events
+        if rcm_events is None:
+            gp = request.gp_name or request.lap_state.get("session_meta", {}).get("gp_name", "")
+            lap = int(request.lap_state.get("lap_number", 0) or 0)
+            if gp and lap:
+                rcm_events = _rcm_events_for_lap(request.year, gp, laps_df, lap)
+
         race_state = build_race_state(
             request.lap_state,
             gap_ahead_s=request.gap_ahead_s,
             pace_delta_s=request.pace_delta_s,
             risk_tolerance=request.risk_tolerance,
             radio_msgs=request.radio_msgs,
-            rcm_events=request.rcm_events,
+            rcm_events=rcm_events,
         )
 
         result = run_strategy_orchestrator_from_state(

--- a/webapp/src/features/strategy/StrategyPage.tsx
+++ b/webapp/src/features/strategy/StrategyPage.tsx
@@ -247,7 +247,6 @@ export function StrategyPage() {
           <IdleEmpty search={search} hasGps={(gpsQuery.data?.length ?? 0) > 0} />
         ) : (
           <div className="flex flex-col gap-6">
-            {isStale ? <StaleNotice onRerun={handleRun} /> : null}
             {!cursorHasData && cursorLap != null ? <NoTelemetryNotice lap={cursorLap} /> : null}
 
             {/* HERO — deliberation while running, else the brief / error / prompt. */}
@@ -287,6 +286,9 @@ export function StrategyPage() {
                 onSelectRun={handleSelectRun}
                 loading={paceRangeQuery.isLoading}
               />
+              {hasRun && cursorHasData ? (
+                <RerunBar lap={cursorLap} onRerun={handleRun} running={running} stale={isStale} />
+              ) : null}
             </div>
 
             {/* EVIDENCE — playbook/risks + agent breakdown (dimmed during a re-run). */}
@@ -315,9 +317,9 @@ function ReadyHero({ cursorLap }: { cursorLap: number | undefined }) {
     <Card className="flex flex-col gap-1 px-6 py-5">
       <p className="font-display text-lg text-fg-1">Ready to run</p>
       <p className="text-sm text-fg-3">
-        The trace below shows the pace across your window. Click a lap to set the decision point
-        {cursorLap != null ? ` (now lap ${cursorLap})` : ''}, then run the pit wall from the bar
-        above.
+        The trace below shows the pace across your window. Drag the cursor (or click) to set the
+        decision point{cursorLap != null ? ` (now lap ${cursorLap})` : ''}, then run the pit wall
+        from the bar above.
       </p>
     </Card>
   )
@@ -341,20 +343,37 @@ function IdleEmpty({ search, hasGps }: { search: StrategySearch; hasGps: boolean
   )
 }
 
-/** Scenario-changed notice — hairline + tint, no side-stripe (de-slop). */
-function StaleNotice({ onRerun }: { onRerun: () => void }) {
+/** The single re-run affordance, sat directly under the trace so it pairs with
+ *  the scrubber: drag the cursor to a lap, then re-run there. Folds in the
+ *  "scenario changed" hint (this was the separate StaleNotice) so there is
+ *  exactly one re-run on the page, not one here and one in the collapsed bar. */
+function RerunBar({
+  lap,
+  onRerun,
+  running,
+  stale,
+}: {
+  lap: number | undefined
+  onRerun: () => void
+  running: boolean
+  stale: boolean
+}) {
   return (
     <div
       role="status"
-      className="flex flex-wrap items-center gap-3 rounded-2xl border border-hairline bg-warning/8 px-4 py-3 text-sm text-fg-2"
+      className="flex flex-wrap items-center gap-3 rounded-2xl border border-hairline bg-bg-1 px-4 py-3 text-sm text-fg-3"
     >
-      <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
-      <span>
-        The scenario has changed since this run — the brief below is from the previous one.
-      </span>
-      <Button size="sm" variant="ghost" className="ml-auto" onClick={onRerun}>
+      {stale ? (
+        <span className="flex items-center gap-2 text-fg-2">
+          <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
+          Scenario changed since this run — the brief is from the previous one.
+        </span>
+      ) : (
+        <span>Drag the cursor on the trace to pick a lap, then re-run there.</span>
+      )}
+      <Button size="sm" className="ml-auto" onClick={onRerun} disabled={running || lap == null}>
         <RotateCcw className="size-4" aria-hidden="true" />
-        Re-run
+        {lap != null ? `Re-run at lap ${lap}` : 'Re-run'}
       </Button>
     </div>
   )

--- a/webapp/src/features/strategy/components/RaceTrace.tsx
+++ b/webapp/src/features/strategy/components/RaceTrace.tsx
@@ -5,8 +5,9 @@
 // the full trace, everything outside it is veiled. That framing is the point
 // of the redesign — a strategist can see the shape of the whole race while
 // staying oriented on which slice of it produced the current recommendation,
-// and can click (or arrow-key) anywhere inside the window to move the
-// decision cursor without losing that context.
+// and can drag the cursor like a video-editor scrubber (or click, or arrow-key)
+// anywhere inside the window to move the decision cursor without losing that
+// context; where the drag stops is the lap the re-run below the chart analyses.
 //
 // ECharts wiring mirrors ScenarioScoresChart.tsx: `registerF1Theme()` once at
 // module load, `useChartTheme()` + `key={chartTheme}` to remount on a
@@ -15,7 +16,7 @@
 // instantly — see that hook's own docstring and the note on
 // `buildTraceOption` below for why this matters here specifically.
 
-import { useCallback, useMemo, useRef, type KeyboardEvent } from 'react'
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import ReactECharts from 'echarts-for-react'
 import type {
   ECharts,
@@ -86,9 +87,6 @@ const RUN_PIN_SIZE = 20
 const RUN_PIN_SIZE_ACTIVE = 26
 const RUN_PIN_HIT_RADIUS_PX = 16
 const PIT_MARKER_PIXEL_OFFSET: [number, number] = [0, -14]
-// A real drag (pan/box-zoom) must not also register as a lap pick — mirrors
-// LapChart's `DRAG_CLICK_GUARD_PX`.
-const DRAG_CLICK_GUARD_PX = 4
 
 const RUNS_SERIES_NAME = 'runs'
 const EMPTY_OPTION: EChartsOption = { series: [] }
@@ -567,14 +565,17 @@ interface ZrPointerEvent {
   offsetY: number
 }
 
-/** What the zrender click handler reads on every click. Mirrored into a ref
- *  (see `RaceTrace`) because the handler is bound once in `onChartReady`, so
- *  it must read fresh props through a ref rather than close over stale ones. */
+/** What the zrender pointer handlers read on every event. Mirrored into a ref
+ *  (see `RaceTrace`) because the handlers are bound once in `onChartReady`, so
+ *  they must read fresh props through a ref rather than close over stale ones.
+ *  `setDragLap` feeds the live scrub preview: the handlers write the lap under
+ *  the pointer while dragging and clear it (null) on release / leave. */
 interface TraceInteractionRef {
   runPoints: RunPoint[]
   windowRange: [number, number]
   onSelectLap: (lap: number) => void
   onSelectRun?: (id: string) => void
+  setDragLap: (lap: number | null) => void
 }
 
 /** Nearest run-flag pin to a click, in pixel space (mirrors LapChart's
@@ -614,43 +615,69 @@ function lapFromPixel(chart: ECharts, x: number, y: number): number {
 }
 
 /**
- * Registers the click picker directly on zrender, once per chart instance
- * (called from `onChartReady`, which — unlike `onEvents` — only fires on
+ * Registers the video-editor-style scrubber directly on zrender, once per chart
+ * instance (called from `onChartReady`, which — unlike `onEvents` — only fires on
  * mount, so this never double-binds across the option rebuilds `notMerge`
- * triggers on every cursor move). Two guards, mirroring LapChart: (1) a real
- * mousedown->click drag is ignored via the pixel-delta check, so panning
- * never fires a phantom lap pick; (2) `containPixel` rejects clicks outside
- * the plot area. A hit on a run pin resolves to `onSelectRun`; everything
- * else resolves to the nearest lap via `onSelectLap`.
+ * triggers on every cursor move). Pointer model:
+ *  - press inside the plot begins a scrub — the cursor jumps to that lap and
+ *    follows the pointer on `mousemove` via `setDragLap` (live preview only, no
+ *    navigation yet, so dragging never spams the URL);
+ *  - release (`mouseup`) or leaving the chart (`globalout`) commits the lap once
+ *    via `onSelectLap` and clears the preview;
+ *  - a press that lands on a run pin selects that run instead of scrubbing.
+ * A plain click is just a zero-distance scrub (press + release on one lap), so
+ * clicking to pick a lap keeps working. `containPixel` rejects presses outside
+ * the plot area.
  */
 function bindTraceInteractions(
   chart: ECharts,
   interactionRef: { current: TraceInteractionRef },
 ): void {
   const zr = chart.getZr()
-  let downPoint: { x: number; y: number } | null = null
+  let scrubbing = false
+  let scrubLap: number | null = null
+  let pendingPinId: string | null = null
+
+  const lapAt = (event: ZrPointerEvent): number => {
+    const { windowRange } = interactionRef.current
+    return clampLap(Math.round(lapFromPixel(chart, event.offsetX, event.offsetY)), windowRange)
+  }
 
   zr.on('mousedown', (event: ZrPointerEvent) => {
-    downPoint = { x: event.offsetX, y: event.offsetY }
-  })
-
-  zr.on('click', (event: ZrPointerEvent) => {
-    const dragged =
-      downPoint != null &&
-      Math.hypot(event.offsetX - downPoint.x, event.offsetY - downPoint.y) >= DRAG_CLICK_GUARD_PX
-    downPoint = null
-    if (dragged) return
-    if (!chart.containPixel({ gridIndex: 0 }, [event.offsetX, event.offsetY])) return
-
-    const { runPoints, windowRange, onSelectLap, onSelectRun } = interactionRef.current
+    const { runPoints } = interactionRef.current
     const hitRun = findNearestRunPin(chart, runPoints, event.offsetX, event.offsetY)
-    if (hitRun && onSelectRun) {
-      onSelectRun(hitRun.id)
+    if (hitRun) {
+      pendingPinId = hitRun.id // a pin press selects the run, not a scrub
       return
     }
+    if (!chart.containPixel({ gridIndex: 0 }, [event.offsetX, event.offsetY])) return
+    scrubbing = true
+    scrubLap = lapAt(event)
+    interactionRef.current.setDragLap(scrubLap)
+  })
 
-    const lap = lapFromPixel(chart, event.offsetX, event.offsetY)
-    onSelectLap(clampLap(Math.round(lap), windowRange))
+  zr.on('mousemove', (event: ZrPointerEvent) => {
+    if (!scrubbing) return
+    scrubLap = lapAt(event)
+    interactionRef.current.setDragLap(scrubLap)
+  })
+
+  const commit = (): void => {
+    const { onSelectLap, onSelectRun, setDragLap } = interactionRef.current
+    if (pendingPinId != null) {
+      onSelectRun?.(pendingPinId)
+    } else if (scrubbing && scrubLap != null) {
+      onSelectLap(scrubLap)
+    }
+    scrubbing = false
+    scrubLap = null
+    pendingPinId = null
+    setDragLap(null)
+  }
+
+  zr.on('mouseup', commit)
+  zr.on('globalout', () => {
+    if (scrubbing || pendingPinId != null) commit()
   })
 }
 
@@ -720,20 +747,25 @@ export function RaceTrace({
   const chartTheme = useChartTheme()
   const palette = chartTheme === F1_LIGHT_THEME ? LIGHT_TRACE_PALETTE : DARK_TRACE_PALETTE
 
+  // While scrubbing, the cursor follows the pointer live off this local override
+  // (committed to the URL only on release); at rest it tracks the `cursorLap` prop.
+  const [dragLap, setDragLap] = useState<number | null>(null)
+  const renderLap = dragLap ?? cursorLap
+
   const option = useMemo(
     () =>
       points.length > 0
         ? buildTraceOption(
             points,
             windowRange,
-            cursorLap,
+            renderLap,
             pitLapTarget,
             expectedStintEnd,
             runs,
             palette,
           )
         : null,
-    [points, windowRange, cursorLap, pitLapTarget, expectedStintEnd, runs, palette],
+    [points, windowRange, renderLap, pitLapTarget, expectedStintEnd, runs, palette],
   )
   const paintedOption = useFirstPaintAnimation(option ?? EMPTY_OPTION)
 
@@ -743,8 +775,9 @@ export function RaceTrace({
     windowRange,
     onSelectLap,
     onSelectRun,
+    setDragLap,
   })
-  interactionRef.current = { runPoints, windowRange, onSelectLap, onSelectRun }
+  interactionRef.current = { runPoints, windowRange, onSelectLap, onSelectRun, setDragLap }
 
   const handleChartReady = useCallback((chart: ECharts) => {
     bindTraceInteractions(chart, interactionRef)
@@ -787,8 +820,8 @@ export function RaceTrace({
         aria-label="Race trace decision cursor"
         aria-valuemin={windowRange[0]}
         aria-valuemax={windowRange[1]}
-        aria-valuenow={cursorLap}
-        aria-valuetext={`Lap ${cursorLap}`}
+        aria-valuenow={renderLap}
+        aria-valuetext={`Lap ${renderLap}`}
         onKeyDown={handleKeyDown}
         className="rounded-lg outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0"
       >

--- a/webapp/src/features/strategy/components/ScenarioBar.tsx
+++ b/webapp/src/features/strategy/components/ScenarioBar.tsx
@@ -14,7 +14,7 @@
 //    below get the vertical space instead of the full form staying open.
 
 import type { ReactNode } from 'react'
-import { Pencil, Play, RotateCcw } from 'lucide-react'
+import { Pencil, Play } from 'lucide-react'
 import type { StrategySearch } from '../search'
 import { STRATEGY_YEAR } from '../search'
 import type { LapRange } from '@/lib/api/strategy'
@@ -217,13 +217,12 @@ function ExpandedForm({
 
 interface CollapsedSummaryProps {
   search: StrategySearch
-  onRun: () => void
-  running: boolean
   onEdit: () => void
 }
 
-/** Compact post-run summary: the scenario as a pill row, plus Edit/Re-run. */
-function CollapsedSummary({ search, onRun, running, onEdit }: CollapsedSummaryProps) {
+/** Compact post-run summary: the scenario as a pill row, plus Edit. Re-run lives
+ *  under the trace now (see StrategyPage's RerunBar), so it is not repeated here. */
+function CollapsedSummary({ search, onEdit }: CollapsedSummaryProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl border border-hairline bg-bg-3 p-3">
       {search.gp && <Pill tone="neutral">{search.gp}</Pill>}
@@ -249,10 +248,6 @@ function CollapsedSummary({ search, onRun, running, onEdit }: CollapsedSummaryPr
         <Button variant="ghost" size="sm" onClick={onEdit}>
           <Pencil className="size-4" aria-hidden="true" />
           Edit scenario
-        </Button>
-        <Button variant="ghost" size="sm" onClick={onRun} disabled={running}>
-          <RotateCcw className="size-4" aria-hidden="true" />
-          Re-run
         </Button>
       </div>
     </div>
@@ -298,7 +293,7 @@ export function ScenarioBar({
   onEdit,
 }: ScenarioBarProps) {
   if (collapsed) {
-    return <CollapsedSummary search={search} onRun={onRun} running={running} onEdit={onEdit} />
+    return <CollapsedSummary search={search} onEdit={onEdit} />
   }
 
   return (


### PR DESCRIPTION
Three Strategy-tab asks from Víctor.

## 1. Safety-Car context reaches the orchestrator
`/recommend` ran with `rcm_events` empty, so the N31 orchestrator never saw an active Safety Car (it was invisible) and always stayed out. It now loads the lap's race-control messages and **replays the stateful SC tracker** exactly as `src/arcade/strategy.py` does: ingest every lap's RCM window in order through `RaceControlStateTracker`, and inject a synthetic `SAFETY CAR DEPLOYED` on the laps a neutralisation persists without a fresh message (the deploy message is a one-shot row at the deploy lap). The Race Situation agent (N27) then flips `sc_currently_active` -> routes the pit + regulation agents (RCMContextResolver, thesis 6.3). RCM only, **no Whisper** (`disable_transcription`; `radio_msgs` stay empty as before).

Effect: the recommendation now reasons about the SC, cites the articles, and surfaces the pit-under-SC playbook. Verified: an in-process/HTTP run at Lusail/PIA/lap 7 gives `sc_currently_active=True`, `sc_prob=1.0`, routes N28+N30, and yields PIT_NOW. **Caveat (arcade parity):** the final synthesis is the same rich LLM the arcade uses, so on a borderline lap it can still land STAY_OUT (my 6 runs: 2 PIT_NOW / 4 STAY_OUT). A deterministic pit-under-SC guardrail is a possible follow-up.

## 2. Draggable trace scrubber + re-run below the chart
The decision cursor is now a **video-editor-style draggable handle**: press and drag anywhere in the window to move it live (URL commits once, on release), click and arrow keys still work. The re-run lives in **one** place now, a bar directly under the trace ("Re-run at lap N").

## 3. Single re-run (dedupe)
Removed the duplicate re-run: the collapsed scenario bar keeps only "Edit scenario", and the separate stale notice is folded into the RerunBar.

## Verification
tsc + oxlint + prettier + vitest 63 + build green. Browser-verified (real backend): scrubber drags the cursor lap 20->33 (live + commit), collapsed bar has no Re-run, RerunBar shows "Re-run at lap N", SC context flows in the brief.