### PR TITLE
fix(backend): drop position-less cars from the rivals list instead of coercing them to 0

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -428,11 +428,24 @@ def get_lap_state(
         "gap_ahead_s": round(gap_ahead_s, 3),
     }
 
-    # Rivals: all other drivers at the same lap, with real gaps
-    rivals_df = lap_snapshot[lap_snapshot["Driver"] != driver]
+    # Rivals: every other driver still CLASSIFIED on this lap, with real gaps.
+    #
+    # The null-Position filter is load-bearing, and it fixes two bugs at once
+    # (#428, #430). A crashed or retired car keeps a row on the lap it went out but
+    # its Position is NaN. Feeding that through `_safe` coerced it to 0, and 0 is a
+    # real, searchable key: the pit and situation agents look for the car ahead with
+    # `position == driver_pos - 1`, which for the RACE LEADER is exactly 0. So the
+    # leader's "car ahead" became, by arithmetic, whichever car had just crashed —
+    # the single most absurd car to undercut. Dropping position-less cars here means
+    # they are neither targeted nor counted, and no sentinel can collide with a real
+    # position. This is what `RaceStateManager` already does (it preserves NaN as
+    # None and retired cars fall out naturally); the API path just has to match it.
+    rivals_df = lap_snapshot[
+        (lap_snapshot["Driver"] != driver) & (lap_snapshot["Position"].notna())
+    ]
     rivals = []
     for _, rr in rivals_df.iterrows():
-        rival_pos = int(_safe(rr.get("Position", 0)))
+        rival_pos = int(rr["Position"])
         rival_gap = 0.0
         if rival_pos > 1:
             ahead = lap_snapshot[lap_snapshot["Position"] == rival_pos - 1]


### PR DESCRIPTION
Kills the **"undercut HUL"** bug at the root, and closes two issues with one filter.

## The bug, in one paragraph

A crashed or retired car keeps a row on the lap it went out, but its `Position` is `NaN`. `_safe` coerced that to **0** — and 0 is a real, searchable key. The pit and situation agents look for the car ahead with `position == driver_pos - 1`, which **for the race leader is exactly 0**. So the leader's "car ahead" became, by arithmetic, whichever car had just crashed. At Lusail 2025 lap 7 that was **HUL, who had caused the Safety Car by crashing**, and the system duly recommended undercutting him.

It was systematically reproducible: any P1 driver, on any lap where any car has a NaN position.

## The fix

The rivals list now keeps only cars **still classified on that lap**. A position-less car is neither targeted nor counted, and no sentinel can collide with a real position.

`RaceStateManager` already does exactly this (preserves NaN as `None`, retired cars fall out naturally, sorts with a `99` placeholder that cannot collide). The API path just had to match the reference the codebase already had.

## Verification (real data, no LLM run)

Against the actual Lusail lap-7 parquet:

```
>>> PIA is P1 (the leader)
>>> rivals returned: 18
>>> any rival at position 0 (the leader's 'car ahead'): NONE
>>> HUL (crashed, caused the SC) present: False
>>> car ahead of the leader: NONE (correct)
>>> VER is P3; car ahead resolves to: ['NOR'] (must be a real driver)
>>> ALL ASSERTIONS PASSED
```

The last assertion is the important one: normal rival resolution is untouched.

## Scope

Deliberately minimal. The related items stay open: the agents' `position or 1` cascade and `gap_ahead_s || 2.0` (#428's extension notes), and the cross-GP contamination (#429), which is the other half of the "random rivals" symptom.

Closes #428
Closes #430
