### PR TITLE
fix(backend): scope the laps frame to the analysed Grand Prix before the agents see it

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -961,12 +961,24 @@ def recommend_strategy(
         # Safety-Car override: when the caller didn't supply RCM events, load them
         # for this lap so an active Safety Car reaches N27 (arcade parity — without
         # this the orchestrator never sees the neutralisation and stays out).
+        gp = request.gp_name or request.lap_state.get("session_meta", {}).get("gp_name", "")
+
         rcm_events = request.rcm_events
         if rcm_events is None:
-            gp = request.gp_name or request.lap_state.get("session_meta", {}).get("gp_name", "")
             lap = int(request.lap_state.get("lap_number", 0) or 0)
             if gp and lap:
                 rcm_events = _rcm_events_for_lap(request.year, gp, laps_df, lap)
+
+        # Scope the frame to THIS race before the agents see it (#429). The cached
+        # parquet holds the whole season, and every agent lookup that takes it
+        # (_get_lap_row, _get_position_map, _get_undercut_candidates,
+        # _get_driver_stint, the SC feature builder) filters by Driver/LapNumber but
+        # NOT by GP — so they silently resolved to whichever race sorted first or
+        # last in the file. Measured before this filter: the lap-7 position map came
+        # from Zandvoort and PIA's lap-7 row from Barcelona, while analysing Lusail.
+        # Every one of those lookups wants the single race, so one filter here fixes
+        # them all without touching the agents.
+        race_laps_df = laps_df[laps_df["GP_Name"] == gp] if gp else laps_df
 
         race_state = build_race_state(
             request.lap_state,
@@ -979,7 +991,7 @@ def recommend_strategy(
 
         result = run_strategy_orchestrator_from_state(
             race_state=race_state,
-            laps_df=laps_df,
+            laps_df=race_laps_df,
             lap_state=request.lap_state,
         )
         return StrategyResponse(agent="orchestrator", result=_to_dict(result))


### PR DESCRIPTION
The root of the "it picks random rivals from the grid" symptom.

## The bug

The cached parquet holds the **whole 2025 season** (22,760 rows, 24 GPs). Every agent lookup that receives it (`_get_lap_row`, `_get_position_map`, `_get_undercut_candidates`, `_get_driver_stint`, the SC feature builder) filters by `Driver` and `LapNumber` but **never by GP**, so each silently resolved to whichever race sorted first or last in the file.

Measured on the real parquet while analysing **Lusail**: the lap-7 position map came from **Zandvoort**, and PIA's lap-7 row from **Barcelona**.

## The fix

One filter at the boundary. Every one of those lookups wants the single race, so this fixes them all **without touching the agents**.

## Verification (real data, no LLM run)

| lap | unscoped map == real Lusail grid? | scoped map == real grid? |
|---|---|---|
| 20 (green) | yes (coincidence) | **yes** |
| 30 (green) | **NO** | **yes** |

Lap 30 is the proof: the unscoped frame was handing the agents a grid that was simply **not this race's**.

## An honest note on Safety-Car laps

On Lusail **lap 7** (the SC lap) the scoped frame is **empty**, because the featured parquet drops SC/pit/out laps per driver. So this trades "confidently wrong data from another race" for "no data", which is the better failure: it fails **visibly**, and the agents already have a `no rival in range` path. The underlying gap is real and tracked in **#447** (the featured parquet is missing laps and columns the agents need). Worth watching whether SC-lap recommendations get thinner until #447 lands.

## Scope

Webapp `/recommend` only. The CLI, the arcade and `/simulate` pass the same unfiltered season frame (see #429's scope extension) and still need the same one-line filter at their own load boundaries.

Refs #429
