### PR TITLE
fix(strategy): compute /lap-state gaps from elapsed time, not summed lap times

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -17,15 +17,15 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
 # Repo-root injection — `src/agents/` must be importable from here
 # ---------------------------------------------------------------------------
 from backend.core.paths import get_data_root, get_repo_root
 from backend.core.rate_limit import rate_limit
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
 _REPO_ROOT = get_repo_root()
 if str(_REPO_ROOT) not in sys.path:
@@ -384,13 +384,7 @@ def get_lap_state(
         except AttributeError:
             return val
 
-    # Compute cumulative lap times per driver up to this lap for real gaps
-    laps_up_to = gp_df[gp_df["LapNumber"] <= lap].copy()
-    cum_times = (
-        laps_up_to.sort_values(["Driver", "LapNumber"])
-        .groupby("Driver")["LapTime_s"]
-        .sum()
-    )
+    cum_times = _elapsed_times_at_lap(gp_df, lap)
     driver_cum = cum_times.get(driver, 0.0)
 
     # Build position-sorted list for gap computation at this lap
@@ -575,6 +569,33 @@ def predict_pace_range(request: PaceRangeRequest):
             })
 
     return {"predictions": results, "count": len(results)}
+
+
+def _elapsed_times_at_lap(gp_df, lap: int):
+    """Session elapsed time per driver at the end of ``lap``, for gap computation.
+
+    Reads ``Time_s`` (elapsed since session start), which is what FastF1 itself uses
+    for gaps and what `RaceStateManager._compute_session_times` settled on. NOT a
+    cumulative sum of ``LapTime_s``: the featured parquet drops each driver's SC, pit
+    and out laps, so drivers lose different amounts of time from the sum and the
+    resulting "gap" is meaningless. Measured at Lusail 2025 lap 20, the sum put NOR
+    80.868 s behind PIA where the real gap was 3.578 s, and TSU was off by 173.7 s
+    (#437). Elapsed time has no such hole: it is a reading, not a reconstruction.
+
+    Falls back to the old sum, loudly, if ``Time_s`` is absent. The loader restores it
+    from the raw per-race parquet (#447), so absence means that restoration failed and
+    the caller should know the gaps are degraded rather than silently trust them.
+    """
+    if "Time_s" not in gp_df.columns:
+        logger.warning(
+            "Time_s absent from the laps frame: falling back to cumulative LapTime_s "
+            "sums, which understate gaps wherever laps were dropped (#437/#447)"
+        )
+        laps_up_to = gp_df[gp_df["LapNumber"] <= lap]
+        return laps_up_to.sort_values(["Driver", "LapNumber"]).groupby("Driver")["LapTime_s"].sum()
+
+    at_lap = gp_df[gp_df["LapNumber"] == lap]
+    return at_lap.set_index("Driver")["Time_s"].dropna()
 
 
 def _stint_baseline_tyre_life(gp_df, driver: str, stint) -> Optional[int]:


### PR DESCRIPTION
## What

Switches `/lap-state`'s gap computation from cumulative `LapTime_s` sums to `Time_s` (session elapsed time).

## Why

The featured parquet drops each driver's SC, pit and out laps. Summing lap times therefore loses a *different* amount of time per driver, and the resulting gap is meaningless. Measured at Lusail 2025 lap 20:

| | summed LapTime_s (what it served) | elapsed Time_s (the truth) | error |
|---|---|---|---|
| NOR gap to PIA | **80.868 s** | **3.578 s** | 77.3 s |
| TSU gap to leader | | | **173.7 s** |

That 173.7 s matches the symptom #437 was filed on: a `Δgap -174.6s` between team-mates on the same lap.

## How

Reads `Time_s`, which is what FastF1 itself uses for gaps and what `RaceStateManager._compute_session_times` settled on long ago. Elapsed time is a reading; a cumulative sum is a reconstruction, and it has holes exactly where laps were dropped.

**This is the consumer half of #447.** That PR restored `Time_s` onto the featured frame at load time for the overtake agent's benefit; nobody switched `/lap-state`'s own gap math over to it. The data was there and the endpoint kept reconstructing.

Falls back to the old sum with a **loud warning** if `Time_s` is absent: absence means the raw-parquet restoration failed, and the caller should know the gaps are degraded rather than silently trust them.

## Checks

- Real call: `/lap-state` now returns **3.578 s** for NOR at Lusail lap 20 (was 80.868 s).
- Submodule CI gate (`ruff check --select=E9,F63,F7,F82 .`) green repo-wide.

Refs #437