### PR TITLE
fix(strategy): derive Time_s on the raw fallback frame too

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -322,6 +322,14 @@ def _get_race_laps_df(year: int, gp: str) -> Optional[pd.DataFrame]:
 
     df = pd.read_parquet(path)
     df["LapTime_s"] = pd.to_timedelta(df["LapTime"]).dt.total_seconds()
+    # Session elapsed time, and it is load-bearing: this raw frame exists to serve the
+    # SC / pit / out laps the featured parquet drops, and those are exactly the laps a
+    # cumulative LapTime_s sum gets wrong. Without Time_s here, _elapsed_times_at_lap
+    # falls back to that sum and any driver with an earlier NaN lap has it silently
+    # skipped: at Lusail lap 20 OCO reads as 126.751 s AHEAD of the leader when the
+    # truth is 33.950 s BEHIND, because OCO's lap 9 has no LapTime. #447 restores this
+    # column onto the FEATURED frame; the fallback frame needs its own line (#437).
+    df["Time_s"] = pd.to_timedelta(df["Time"]).dt.total_seconds()
     for src_col, dst_col in (
         ("Sector1Time", "Sector1_s"),
         ("Sector2Time", "Sector2_s"),

--- a/backend/utils/laps_cache.py
+++ b/backend/utils/laps_cache.py
@@ -73,7 +73,7 @@ def _raw_race_dir(year: int, gp_name: str):
 
 
 def _augment_from_raw(df: pd.DataFrame, year: int) -> pd.DataFrame:
-    """Restore `Time_s` / `TrackStatus` / `PitInTime` onto the featured frame.
+    """Restore `Time_s` / `TrackStatus` onto the featured frame.
 
     --- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
     This runs at LOAD time on purpose, not as a rewrite of the parquet. The featured
@@ -119,7 +119,7 @@ def _augment_from_raw(df: pd.DataFrame, year: int) -> pd.DataFrame:
     augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
     restored = augmented["Time_s"].notna().sum()
     logger.info(
-        "Restored Time_s/TrackStatus/PitInTime onto %d/%d laps of %d from the raw "
+        "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw "
         "parquets (#447)", restored, len(augmented), year,
     )
     return augmented


### PR DESCRIPTION
## What

Adds one line to `_get_race_laps_df`: `df["Time_s"] = pd.to_timedelta(df["Time"]).dt.total_seconds()`.

## Why: this is a fix breaking a fix

Found by the epic's final adversarial audit, which is exactly the interaction it was run to catch.

- **#437** made `/lap-state` compute gaps from `Time_s` instead of summing lap times.
- **#447** restores `Time_s` onto the **featured** frame.
- But `/lap-state` **rebinds `gp_df` to the raw per-race frame** whenever the featured one lacks the lap. That fallback exists for one reason: to serve the **SC, pit and out laps** N04's `IsAccurate` gate drops.
- `_get_race_laps_df` derived `LapTime_s` and the sector columns from the raw timedeltas, but **never `Time_s`**. So the fallback landed in #437's degraded branch, which sums `LapTime_s`.

And a cumulative sum silently skips laps with a NaN `LapTime` — which live on **exactly the incidents the fallback is for**. At Lusail 2025 there are three: HUL L7, **OCO L9**, HAD L55.

| OCO gap vs PIA at lap 20 | |
|---|---|
| truth (`Time_s`) | **+33.950 s** (behind) |
| what the fallback served | **−126.751 s** (ahead) |
| error | **160.701 s, sign flipped** |

The raw parquet has `Time` all along. It just was not being converted, so the SC-lap path — the one added to make those laps runnable at all — served gaps that put a car half a minute behind the leader 126 s ahead of it.

## Also

Stops `laps_cache`'s docstring and INFO log claiming `PitInTime` is restored. It is deliberately excluded a few lines above (it only exists on pit laps, which the featured frame drops, so coverage was 0%), and the log would mislead the next person debugging a missing column.

## Checks

- Raw fallback now returns **OCO +33.950 s** at Lusail lap 20 (was −126.751 s).
- Confirmed the NaN-`LapTime` laps that corrupted the sum: HUL L7, OCO L9, HAD L55.
- Submodule CI gate (`ruff check --select=E9,F63,F7,F82 .`) green; parent `ruff check .` + `format --check .` green; 22 tests pass.

Refs #437, #447