### PR TITLE
refactor(backend): consume the parent's laps augmentation instead of owning a copy

### DIFF
--- a/backend/utils/laps_cache.py
+++ b/backend/utils/laps_cache.py
@@ -16,113 +16,12 @@ logger = logging.getLogger(__name__)
 
 _cache: Dict[int, pd.DataFrame] = {}
 
-# Columns N04 drops from the featured parquet that the agents were nonetheless trained
-# on, mapped to the name the training code expects.
-#
-# `Time` is the important one: N04's drop list calls it "already converted to *_s", but
-# no `Time_s` survives in the output, so the session-elapsed information is genuinely
-# gone — while N11 trained the overtake gap as `abs(row_x["Time_s"] - row_y["Time_s"])`.
-# Without it the agent falls back to a lap-time difference, so two cars 20 s apart but
-# lapping within 0.5 s of each other read as "in the DRS window" (#447).
-#
-# `PitInTime` is deliberately NOT restored here, even though the raw frame has it: a car
-# only carries a PitInTime on the lap it actually pits, and those are precisely the laps
-# N04's `IsAccurate` filter drops. Measured: 44/1067 raw Lusail laps have one, and 0% of
-# them survive into the featured frame — so a merge can only ever restore nulls. The SC
-# model's `active_pitstop_count` has to be derived from `Stint`/`TyreLife` resets instead;
-# tracked in #447 rather than faked with a column that is structurally always empty.
-_RAW_COLUMNS_TO_RESTORE: Dict[str, str] = {
-    "Time": "Time_s",          # timedelta -> seconds, matching the trained feature
-    "TrackStatus": "TrackStatus",
-}
-
-_JOIN_KEYS = ["GP_Name", "Driver", "LapNumber"]
-
-# Inverted from gp_slugs.FOLDER_ALIASES (which is keyed folder -> friendly) so the one
-# place that owns circuit renames stays the one place. Reversing at import keeps this
-# from becoming a second, drifting copy.
-try:
-    from src.f1_strat_manager.gp_slugs import FOLDER_ALIASES as _FOLDER_ALIASES
-
-    _FRIENDLY_TO_FOLDER: Dict[str, str] = {v: k for k, v in _FOLDER_ALIASES.items()}
-except Exception:  # pragma: no cover - the parent package is absent in some deploys
-    _FRIENDLY_TO_FOLDER = {"Miami": "Miami_Gardens"}
-
-
-def _raw_race_dir(year: int, gp_name: str):
-    """Raw per-race directory for a featured `GP_Name`.
-
-    Three forms have to be tried, and the third is not optional: the raw dirs mostly
-    match `GP_Name` exactly, the underscore variant covers the space-vs-underscore forms
-    FastF1 emits (`Marina Bay` -> `Marina_Bay`), and a small number of circuits were
-    simply renamed on disk (`Miami` -> `Miami_Gardens`). Skipping the rename cost Miami
-    its whole augmentation on the first pass — 3.8% of the season silently unfixed —
-    which is exactly the silent-miss class this epic is about. `FOLDER_ALIASES` in
-    `gp_slugs` already owns that mapping; it is keyed folder -> friendly, so invert it
-    rather than write a second copy.
-    """
-    base = get_data_root() / "raw" / str(year)
-    for candidate in (
-        base / gp_name,
-        base / gp_name.replace(" ", "_"),
-        base / _FRIENDLY_TO_FOLDER.get(gp_name, gp_name),
-    ):
-        if candidate.exists():
-            return candidate
-    return base / gp_name
-
-
-def _augment_from_raw(df: pd.DataFrame, year: int) -> pd.DataFrame:
-    """Restore `Time_s` / `TrackStatus` onto the featured frame.
-
-    --- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
-    This runs at LOAD time on purpose, not as a rewrite of the parquet. The featured
-    parquet is published on Hugging Face and pulled by `scripts/download_data.py`, so a
-    locally-patched file would be silently reverted by the next download; and its only
-    producer is a read-only notebook (N04). Merging here is immune to both: nothing to
-    re-upload, no divergence from the published dataset, and no fork of the pipeline.
-
-    The join is safe: `(GP_Name, Driver, LapNumber)` is unique in the featured frame and
-    every featured row is a subset of raw. A race whose raw parquet is absent is skipped
-    with a warning rather than failing the request — the agents' existing fallbacks then
-    behave exactly as they do today, which is the pre-#447 status quo, not a new failure.
-    """
-    if "GP_Name" not in df.columns:
-        return df
-
-    frames = []
-    missing: list[str] = []
-    for gp_name in df["GP_Name"].dropna().unique():
-        path = _raw_race_dir(year, str(gp_name)) / "laps.parquet"
-        if not path.exists():
-            missing.append(str(gp_name))
-            continue
-        raw = pd.read_parquet(path)
-        if not set(_RAW_COLUMNS_TO_RESTORE).issubset(raw.columns):
-            missing.append(str(gp_name))
-            continue
-        slice_ = raw[["Driver", "LapNumber", *_RAW_COLUMNS_TO_RESTORE]].copy()
-        slice_["GP_Name"] = gp_name
-        # `Time` is a session-elapsed timedelta; the models were trained on seconds.
-        slice_["Time"] = pd.to_timedelta(slice_["Time"]).dt.total_seconds()
-        frames.append(slice_.rename(columns=_RAW_COLUMNS_TO_RESTORE))
-
-    if missing:
-        logger.warning(
-            "Raw laps unavailable for %d GP(s) in %d: %s — their laps keep the "
-            "pre-#447 behaviour (overtake gap degrades to a lap-time delta)",
-            len(missing), year, sorted(missing),
-        )
-    if not frames:
-        return df
-
-    augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
-    restored = augmented["Time_s"].notna().sum()
-    logger.info(
-        "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw "
-        "parquets (#447)", restored, len(augmented), year,
-    )
-    return augmented
+# The featured parquet's missing columns are restored by the PARENT package, because the
+# parent owns the data layer and every consumer needs the same answer. This module used
+# to carry its own copy, which meant the backend was fixed and the CLI — `f1-sim`, the
+# TFG's PMV — read the parquet straight from disk and shipped the degraded overtake gap
+# on 100% of calls. One implementation, every consumer.
+from src.f1_strat_manager.laps_augment import augment_featured_laps  # noqa: E402
 
 
 def get_laps_df(year: int = 2025) -> Optional[pd.DataFrame]:
@@ -133,7 +32,10 @@ def get_laps_df(year: int = 2025) -> Optional[pd.DataFrame]:
     if not path.exists():
         logger.warning("Featured parquet not found: %s", path)
         return None
-    df = _augment_from_raw(pd.read_parquet(path), year)
+    # The backend's data root honours $F1_STRAT_DATA_ROOT and its own .git walk, so
+    # pass it in rather than letting the parent resolve one that misses the submodule
+    # gitlink (#27).
+    df = augment_featured_laps(pd.read_parquet(path), year, data_root=get_data_root())
     _cache[year] = df
     logger.info("Loaded laps_df %d: %d rows", year, len(df))
     return df


### PR DESCRIPTION
## Why

The final verification audit found that `#447`'s gap fix **never reached the CLI**, which is `f1-sim`, the TFG's PMV and its demo surface.

The augmentation that restores `Time_s` lived **here**, in the backend's loader. `scripts/run_simulation_cli.py:1339` does a plain `pd.read_parquet`, and **no published featured parquet carries `Time_s`** (verified across all three years). So N11's overtake gap fell back to a lap-time delta on **100% of CLI calls**.

Measured, Lusail 2024, 656 position-adjacent pairs:

| | what the CLI fed N12 | truth |
|---|---|---|
| mean gap | **0.488 s** | **3.290 s** |
| "in DRS window" | **89.9%** of pairs | **20.3%** |

Worst pair the audit found: BOT vs LAW lap 27 — model told **0.130 s**, real gap **21.066 s**.

## What changes

The augmentation moves to `src/f1_strat_manager/laps_augment.py` in the **parent**. The parent owns the data layer and the submodule consumes it, not the other way round, so there is **one implementation** and every consumer gets the same answer.

The backend keeps passing its own data root, which honours `$F1_STRAT_DATA_ROOT` and its own `.git` walk (#27), rather than letting the parent resolve one that misses the submodule gitlink.

This is the same failure as the epic's key insight, for the third time: **a fix landed on one path while a sibling kept reading the unaugmented frame.** Putting it behind one function is what stops the fourth.

## Checks

- `get_laps_df(2025)` still returns an augmented frame: 22,760 rows, `Time_s` present.
- Submodule CI gate green; parent `ruff check .` + `format --check .` green; 193 tests pass.

Refs #447