### PR TITLE
fix(telemetry): compute /race-data gaps from elapsed time, not summed lap times

### DIFF
--- a/backend/api/v1/endpoints/telemetry.py
+++ b/backend/api/v1/endpoints/telemetry.py
@@ -1,7 +1,9 @@
+import logging
 from typing import Optional
 
 import numpy as np
 import pandas as pd
+from backend.services.telemetry.session_cache import prewarm_session
 from backend.services.telemetry.telemetry_service import (
     get_available_drivers,
     get_available_gps,
@@ -10,9 +12,10 @@ from backend.services.telemetry.telemetry_service import (
     get_lap_times,
     get_telemetry_data_from_db,
 )
-from backend.services.telemetry.session_cache import prewarm_session
 from backend.utils.laps_cache import get_laps_df
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/telemetry", tags=["telemetry"])
 
@@ -167,15 +170,39 @@ def get_lap_telemetry_endpoint(
 
 
 def _compute_gaps(df: pd.DataFrame) -> pd.DataFrame:
-    """Compute GapToCarAhead / GapToCarBehind from cumulative lap times.
+    """Compute GapToCarAhead / GapToCarBehind from session elapsed time.
 
-    For each lap, drivers are sorted by Position.  The cumulative sum of
-    LapTime_s per driver approximates session elapsed time (the real Time
-    column is dropped in N04).  The difference between adjacent positions
-    gives the inter-car gap in seconds.
+    For each lap, drivers are sorted by Position and the difference between adjacent
+    positions gives the inter-car gap in seconds.
+
+    Reads `Time_s`, the session elapsed time. This used to cumsum `LapTime_s` per driver
+    and its docstring justified that with "the real Time column is dropped in N04" — true
+    when written, false since the loader restores it from the raw parquets (#447).
+
+    The sum is not an approximation, it is wrong: the featured frame drops each driver's
+    SC, pit and out laps, so a per-driver cumsum is short by exactly the laps that driver
+    lost, and every driver loses a different set. Measured on Lusail 2024 across 656
+    position-adjacent pairs: mean gap **69.583 s** against a truth of **3.290 s**, 63.7%
+    of pairs wrong by more than a second, worst case TSU on lap 56 shipped as **402.282 s**
+    where the real gap was **2.966 s**.
+
+    This is the same fault #437 fixed in `/lap-state`, in a second endpoint that was never
+    switched over — the fifth instance of "a datum was restored and one consumer kept
+    reconstructing it".
+
+    Falls back to the old sum, loudly, if `Time_s` is absent: that means the raw
+    augmentation failed, and the caller should know the gaps are degraded rather than
+    trust them.
     """
     df = df.sort_values(["Driver", "LapNumber"])
-    df["_cum_time"] = df.groupby("Driver")["LapTime_s"].cumsum()
+    if "Time_s" in df.columns:
+        df["_cum_time"] = df["Time_s"]
+    else:
+        logger.warning(
+            "Time_s absent from the laps frame: falling back to cumulative LapTime_s "
+            "sums, which understate gaps wherever laps were dropped (#447)"
+        )
+        df["_cum_time"] = df.groupby("Driver")["LapTime_s"].cumsum()
 
     parts = []
     for _, lap_df in df.groupby("LapNumber"):


### PR DESCRIPTION
## The fifth instance of the same failure

A datum was restored and one consumer kept reconstructing it. `get_laps_df` already calls `augment_featured_laps`, so `Time_s` **is on the frame**; `_compute_gaps` never read it and kept doing `df.groupby("Driver")["LapTime_s"].cumsum()`.

Its docstring even justified it: *"the real Time column is dropped in N04"* — true when written, **false since #447**.

## The sum is not an approximation, it is wrong

The featured frame drops each driver's SC, pit and out laps, so a per-driver cumsum is short by exactly the laps **that driver** lost, and every driver loses a different set.

Measured, Lusail 2024, 656 position-adjacent pairs:

| | shipped | truth |
|---|---|---|
| mean gap | **69.583 s** | **3.290 s** |
| pairs wrong by >1 s | **63.7%** | |
| pairs wrong by >30 s | **40.4%** | |
| **worst: TSU lap 56** | **402.282 s** | **2.966 s** |

It also poisons `_compute_gap_consistency`, which feeds the `consistent_gap_ahead/behind_laps` undercut and overcut windows.

## After

```
TSU lap 56 GapToCarAhead: 2.966s     (was 402.282s)
mean gap:                 3.290s     (was 69.583s)
pairs over 30s:           0.0%       (was 40.4%)
```

Falls back to the old sum with a **loud warning** if `Time_s` is absent: that means the augmentation failed, and the caller should know the gaps are degraded rather than trust them.

Refs #447, #437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved race gap calculations by using recorded elapsed times when available.
  * Added a fallback for data missing elapsed-time values, with diagnostic warnings to support troubleshooting.
  * Increased the accuracy of gaps shown between cars ahead and behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->