### PR TITLE
fix(tire-range): scope the agent to the requested GP, not the whole season

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -732,11 +732,17 @@ def predict_tire_range(
     # invoke the LLM (slow) and leaves the model in MC-train mode, which corrupts
     # the eval-mode prediction scale — the manual setup keeps the forward clean.
     team = str(drv_df.iloc[0].get("Team", "")) if not drv_df.empty else ""
-    agent.laps_df = laps_df.copy()
-    lt_col = "LapTime_s" if "LapTime_s" in laps_df.columns else "LapTime"
-    lap_times = pd.to_numeric(laps_df[lt_col], errors="coerce").dropna()
-    if "TrackStatus" in laps_df.columns:
-        clean_mask = laps_df["TrackStatus"].astype(str) == "1"
+    # Scope the agent to THIS Grand Prix, not the whole season. `laps_df` from the
+    # dependency holds all 24 races, and `_get_driver_stint` matches on Driver +
+    # Compound + TyreLife; without the GP scope a MEDIUM stint at this circuit also
+    # matches every other race's MEDIUM stint, so the TCN window mixed 8 GPs and read a
+    # later race's lap as "current". `gp_df` is the same single-race frame `run_lap`
+    # passes the agents via `_scope_laps_to_gp` (#429/#480).
+    agent.laps_df = gp_df.copy()
+    lt_col = "LapTime_s" if "LapTime_s" in gp_df.columns else "LapTime"
+    lap_times = pd.to_numeric(gp_df[lt_col], errors="coerce").dropna()
+    if "TrackStatus" in gp_df.columns:
+        clean_mask = gp_df["TrackStatus"].astype(str) == "1"
         clean_times = lap_times[clean_mask] if clean_mask.sum() > 0 else lap_times
     else:
         clean_times = lap_times
@@ -772,6 +778,13 @@ def predict_tire_range(
                 if compound.startswith("C")
                 else _compound_name_to_id(compound, request.gp, request.year)
             )
+            # Feed the same stint/lap scope keys run_from_state sets, so the TCN window
+            # is this driver's current stint up to this lap, not every stint on the
+            # compound and not future laps (#449/#485). Set per lap since the loop walks
+            # the stint forward.
+            if not pd.isna(row.get("Stint")):
+                agent.session_meta[f"{request.driver}_stint"] = int(row["Stint"])
+            agent.session_meta["current_lap"] = lap
             stint = agent._get_driver_stint(request.driver, tyre_life)
             if stint is not None and compound_id in agent.bundles:
                 tensor = agent._build_stint_tensor(stint, compound_id, agent.session_meta)


### PR DESCRIPTION
The `/tire-range` handler (the webapp's Tyres agent-tab chart) set `agent.laps_df` to the **season-wide** frame from `_require_laps_df`, and hand-built `session_meta` without the stint/lap scope keys `run_from_state` supplies. `_get_driver_stint` matches on Driver + Compound + TyreLife, so a MEDIUM stint at the requested circuit also matched every other race's MEDIUM stint.

Measured, HAM Barcelona 2024, request lap 12:

| | before | after |
|---|---|---|
| stint window | **108 rows** | 11 rows |
| GPs mixed | **8** | 1 |
| stints mixed | **{1,2,3}** | {1} |
| last lap in window | **63 (Zandvoort)** | 12 |

The TCN reads the window's last row as "current", so the chart's forward pass was reading a later race's lap.

## Fix

Uses `gp_df` (the same single-race frame `run_lap` passes the agents via `_scope_laps_to_gp`, #429) and sets `{driver}_stint` + `current_lap` per lap so the window is this stint up to this lap (#449/#485). Same pattern `run_from_state` already uses.

## Checks

- Verified against the real 2024 Barcelona frame: 108 rows / 8 GPs / last lap 63 becomes 11 rows / 1 GP / last lap 12.
- Requires the parent's #485 tire_agent fixes (already on `dev`); this consumes them.

Refs #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tire-range predictions by restricting analysis to the selected Grand Prix.
  * Corrected lap-time and track-condition filtering to prevent data from other races affecting results.
  * Improved per-lap prediction accuracy by maintaining the current lap and stint context during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->