### PR TITLE
fix(strategy): thread the user-chosen rival into the race state

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -111,6 +111,10 @@ class RecommendRequest(BaseModel):
     risk_tolerance: float = 0.5
     radio_msgs: Optional[List[Dict[str, Any]]] = None
     rcm_events: Optional[List[Dict[str, Any]]] = None
+    # Three-letter code of the rival the user selected in the Strategy tab. When
+    # set, build_race_state measures gap_ahead_s / pace_delta_s against this car
+    # instead of the positional car ahead (#431). None keeps current behaviour.
+    rival: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +460,16 @@ def get_lap_state(
             ahead = lap_snapshot[lap_snapshot["Position"] == rival_pos - 1]
             if not ahead.empty:
                 rival_gap = abs(float(rr["_cum"] - ahead.iloc[0]["_cum"]))
+        # Driver-relative interval (rival elapsed time minus ours): the sign
+        # encodes ahead/behind, the magnitude is the on-track gap to OUR car.
+        # RaceStateManager already emits this per rival; mirroring it here lets a
+        # user-chosen rival be scored against our driver rather than against the
+        # car one position ahead of it (#431). Only real when both elapsed times
+        # are present — never defaulted to a searchable 0 (the #428 lesson).
+        rival_cum = rr["_cum"]
+        interval_to_driver = None
+        if pd.notna(rival_cum) and driver in cum_times and pd.notna(driver_cum):
+            interval_to_driver = round(float(rival_cum) - float(driver_cum), 3)
         rivals.append({
             "driver": str(rr.get("Driver", "")),
             "team": str(rr.get("Team", "")),
@@ -464,6 +478,7 @@ def get_lap_state(
             "compound": str(rr.get("Compound", "")),
             "tyre_life": int(_safe(rr.get("TyreLife", 0))),
             "gap_ahead_s": round(rival_gap, 3),
+            "interval_to_driver_s": interval_to_driver,
         })
 
     weather = {
@@ -518,7 +533,6 @@ def predict_pace(request: PaceRequest):
 @router.post("/pace-range", dependencies=[Depends(rate_limit("pace-range", capacity=5, per_minute=10))])
 def predict_pace_range(request: PaceRangeRequest):
     """Run Pace Agent across a lap range and return actual vs predicted."""
-    import numpy as np
 
     from src.agents.pace_agent import run_pace_agent_from_state
 
@@ -1061,6 +1075,7 @@ def recommend_strategy(
             risk_tolerance=request.risk_tolerance,
             radio_msgs=request.radio_msgs,
             rcm_events=rcm_events,
+            rival=request.rival,
         )
 
         result = run_strategy_orchestrator_from_state(

--- a/backend/utils/race_state_builder.py
+++ b/backend/utils/race_state_builder.py
@@ -1,6 +1,52 @@
 """Build a RaceState from a raw lap_state dict."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _targeting_against_rival(
+    lap_state: Dict[str, Any],
+    rival: str,
+    fallback_gap_s: float,
+    fallback_pace_s: float,
+) -> Tuple[float, float]:
+    """Gap and pace delta of our driver measured against a chosen ``rival``.
+
+    Returns ``(gap_ahead_s, pace_delta_s)`` framed around the rival the user
+    picked in the Strategy tab, so the recommendation reasons about the duel the
+    user actually asked for instead of about whichever car happens to sit one
+    position ahead (#431). Both values land on the RaceState, which feeds N27's
+    overtake scoring inputs and the orchestrator's synthesis prompt.
+
+    gap_ahead_s is the absolute on-track interval to the rival, read from the
+    rival's ``interval_to_driver_s`` (rival elapsed time minus ours: the sign
+    encodes ahead/behind, the magnitude is the gap). This is the same
+    driver-relative interval RaceStateManager already emits per rival, mirrored
+    onto the /lap-state rivals so both callers carry it.
+
+    pace_delta_s is our last lap time minus the rival's, matching N27's
+    convention (negative = we are faster).
+
+    Falls back to the caller-supplied values when the rival is absent from this
+    lap (e.g. it crashed out and the liveness filter dropped it, #428/#430) or
+    when a lap time is missing, so a stale selection degrades to current
+    behaviour rather than to a fabricated zero.
+    """
+    rivals = lap_state.get("rivals", []) or []
+    match = next((r for r in rivals if r.get("driver") == rival), None)
+    if match is None:
+        return fallback_gap_s, fallback_pace_s
+
+    interval = match.get("interval_to_driver_s")
+    gap_ahead_s = abs(float(interval)) if interval is not None else fallback_gap_s
+
+    driver_lap_s = lap_state.get("driver", {}).get("lap_time_s")
+    rival_lap_s = match.get("lap_time_s")
+    if driver_lap_s and rival_lap_s:
+        pace_delta_s = float(driver_lap_s) - float(rival_lap_s)
+    else:
+        pace_delta_s = fallback_pace_s
+
+    return round(gap_ahead_s, 3), round(pace_delta_s, 3)
 
 
 def build_race_state(
@@ -11,17 +57,30 @@ def build_race_state(
     risk_tolerance: float = 0.5,
     radio_msgs: Optional[List[dict]] = None,
     rcm_events: Optional[List[dict]] = None,
+    rival: Optional[str] = None,
 ):
     """Construct a RaceState from a raw lap_state dict.
 
     Centralises the field extraction logic that was previously duplicated
     in strategy.py (endpoint) and strategy_handler.py (chat handler).
+
+    When ``rival`` is set, ``gap_ahead_s`` and ``pace_delta_s`` are recomputed
+    against that specific car (the one the user selected in the Strategy tab)
+    rather than the positional car ahead, so the recommendation is framed around
+    the duel the user asked about (#431). When it is unset, or the rival is not
+    classified on this lap, the caller-supplied values are used unchanged, so the
+    no-rival path behaves exactly as before.
     """
     from src.agents.strategy_orchestrator import RaceState
 
     drv = lap_state.get("driver", {})
     weather = lap_state.get("weather", {})
     meta = lap_state.get("session_meta", {})
+
+    if rival:
+        gap_ahead_s, pace_delta_s = _targeting_against_rival(
+            lap_state, rival, gap_ahead_s, pace_delta_s,
+        )
 
     return RaceState(
         driver=drv.get("driver", "UNK"),

--- a/webapp/src/features/strategy/queries.ts
+++ b/webapp/src/features/strategy/queries.ts
@@ -158,7 +158,7 @@ export function useRecommend() {
     mutationFn: async ({ search, signal }) => {
       const lap = analysedLap(search)!
       const lapState = await fetchLapState(search.gp!, search.driver!, lap)
-      const result = await runRecommend(lapState, search.risk, signal)
+      const result = await runRecommend(lapState, search.risk, search.rival, signal)
       return { lapState, result }
     },
   })

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -57,6 +57,10 @@ export interface LapStateRival {
   compound: string
   tyre_life: number
   gap_ahead_s: number
+  /** On-track interval to OUR driver (rival elapsed time minus ours): sign
+   *  encodes ahead/behind, magnitude is the gap. Null when either car's elapsed
+   *  time is missing. Used to score a user-chosen rival against our car. */
+  interval_to_driver_s?: number | null
 }
 
 export interface Weather {
@@ -187,6 +191,10 @@ export interface RecommendRequest {
   gap_ahead_s?: number
   pace_delta_s?: number
   risk_tolerance?: number
+  /** Three-letter code of the user-chosen rival. When set, the backend measures
+   *  gap_ahead_s / pace_delta_s against this car instead of the positional car
+   *  ahead (#431). Omitted keeps the default behaviour. */
+  rival?: string
 }
 
 // ── Error type — carries HTTP status so the UI can branch (404/422/429/500) ──
@@ -304,10 +312,16 @@ export async function runAgent<A extends AgentName>(
  * Run the full N31 orchestrator (all sub-agents + 500-sample MC + LLM synthesis).
  * Rate-limited to 5/min on the backend → surfaces as a 429 StrategyApiError.
  * `gap_ahead_s` defaults to the driver's own gap (2.0 fallback, as Streamlit).
+ *
+ * When `rival` is set (the car the user picked in the Strategy tab), the backend
+ * recomputes gap_ahead_s / pace_delta_s against that specific car, so the
+ * recommendation is framed around the duel the user asked about (#431). Without
+ * it the request behaves exactly as before.
  */
 export async function runRecommend(
   lapState: LapState,
   riskTolerance: number,
+  rival?: string,
   signal?: AbortSignal,
 ): Promise<StrategyRecommendation> {
   const body: RecommendRequest = {
@@ -317,6 +331,7 @@ export async function runRecommend(
     gap_ahead_s: lapState.driver.gap_ahead_s || 2.0,
     pace_delta_s: 0,
     risk_tolerance: riskTolerance,
+    rival,
   }
   const data = await postJson<Envelope<StrategyRecommendation>>('recommend', body, signal)
   return data.result


### PR DESCRIPTION
## What
Threads the rival the user picks in the Strategy tab all the way into the race state, so the recommendation is computed against **that** car instead of whatever car happens to be one position ahead.

## Why
`RecommendRequest` had no rival field, `/lap-state` rivals carried no driver-relative interval, and `build_race_state` always measured `gap_ahead_s`/`pace_delta_s` against the positional car ahead. The user's selection never reached the engine.

## How
- `RecommendRequest.rival: Optional[str]` (None keeps current behaviour)
- `/lap-state` rivals gain `interval_to_driver_s`, computed from elapsed times, guarded with `pd.notna` and never a searchable default (the #428 lesson)
- `build_race_state(rival=...)` scores against the chosen car; unknown rival falls back to the positional gap

## Verify (no LLM, real Lusail 2025 parquet)
`build_race_state(..., rival='PIA')` -> gap_ahead_s 3.578 (real), unknown rival 'ZZZ' -> falls back to 2.0. `ruff check` clean.

Part of parent issue #431; the closing ref lands on the parent pointer-bump PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to select a specific rival when requesting strategy recommendations.
  * Strategy recommendations now frame race gaps and pace comparisons against the selected rival.
  * Lap-state rival data now includes the time interval to the target driver when available.

* **Bug Fixes**
  * Improved rival-based calculations by using elapsed timing data when available and retaining existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->