### PR TITLE
fix(strategy): harden the strategy backend against the Fable audit

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -347,6 +347,40 @@ def _get_race_laps_df(year: int, gp: str) -> Optional[pd.DataFrame]:
     return df
 
 
+def _safe(val):
+    """Convert numpy types to Python native; NaN -> 0.
+
+    Only for fields where 0 is a legitimate stand-in for "no reading" and is
+    never confused with a real, distinct value or used as a lookup key. See
+    `_safe_none` below for the fields where that confusion is exactly the bug.
+    """
+    if pd.isna(val):
+        return 0
+    try:
+        return val.item()
+    except AttributeError:
+        return val
+
+
+def _safe_none(val):
+    """Convert numpy types to Python native; NaN -> None.
+
+    Mirrors the reference contract in `src/simulation/race_state_manager.py`:
+    an absent reading stays absent instead of becoming a searchable sentinel.
+    Used for TyreLife, weather (AirTemp/TrackTemp/Humidity), SpeedST, and the
+    driver's own Position -- fields where 0 is already a real, distinct value
+    (a fresh tyre has TyreLife=0; the race leader has Position=1), so coercing
+    an absent reading to 0 collides with a genuine reading downstream (a
+    car-ahead lookup keyed on `position == 0`, the #428/#430 bug class) (#465).
+    """
+    if pd.isna(val):
+        return None
+    try:
+        return val.item()
+    except AttributeError:
+        return val
+
+
 @router.get("/lap-state")
 def get_lap_state(
     gp: str,
@@ -387,15 +421,6 @@ def get_lap_state(
 
     r = row.iloc[0]
 
-    def _safe(val):
-        """Convert numpy types to Python native; NaN → 0."""
-        if pd.isna(val):
-            return 0
-        try:
-            return val.item()
-        except AttributeError:
-            return val
-
     cum_times = _elapsed_times_at_lap(gp_df, lap)
     driver_cum = cum_times.get(driver, 0.0)
 
@@ -404,9 +429,13 @@ def get_lap_state(
     lap_snapshot["_cum"] = lap_snapshot["Driver"].map(cum_times)
     lap_snapshot = lap_snapshot.sort_values("Position")
 
-    drv_pos = int(_safe(r.get("Position", 0)))
+    # Position stays None on an unresolved lap (grid formation, incomplete lap)
+    # instead of a coerced 0 -- a value that is ALSO a real position and a real
+    # lookup key downstream (#465, same collision class as the #428/#430 rival
+    # fix a few lines below).
+    drv_pos = _safe_none(r.get("Position"))
     gap_ahead_s = 0.0
-    if drv_pos > 1:
+    if drv_pos is not None and drv_pos > 1:
         car_ahead = lap_snapshot[lap_snapshot["Position"] == drv_pos - 1]
         if not car_ahead.empty:
             gap_ahead_s = abs(float(driver_cum - car_ahead.iloc[0]["_cum"]))
@@ -416,19 +445,26 @@ def get_lap_state(
         "team": str(r.get("Team", "")),
         "lap_number": int(_safe(r.get("LapNumber", lap))),
         "lap_time_s": float(_safe(r.get("LapTime_s", 0))),
+        # The featured parquet's own previous-lap time (N04's Prev_LapTime
+        # column), NOT this lap's own lap_time_s reused as a stand-in -- that
+        # self-referential default fed the pace agent's own most recent
+        # prediction back in as "previous" and made pace self-fulfilling (#435).
+        "prev_lap_time": _prev_lap_time_for_row(r, gp_df, driver),
         "position": drv_pos,
         "compound": str(r.get("Compound", "")),
         "compound_id": int(_safe(r.get("CompoundID", 0))),
-        "tyre_life": int(_safe(r.get("TyreLife", 0))),
+        "tyre_life": _safe_none(r.get("TyreLife")),
         "stint": int(_safe(r.get("Stint", 1))),
         "stint_baseline_tyre_life": _stint_baseline_tyre_life(
-            gp_df, driver, r.get("Stint"),
+            gp_df,
+            driver,
+            r.get("Stint"),
         ),
         "fresh_tyre": bool(r.get("FreshTyre", False)),
         "speed_i1": float(_safe(r.get("SpeedI1", 0))),
         "speed_i2": float(_safe(r.get("SpeedI2", 0))),
         "speed_fl": float(_safe(r.get("SpeedFL", 0))),
-        "speed_st": float(_safe(r.get("SpeedST", 0))),
+        "speed_st": _safe_none(r.get("SpeedST")),
         "fuel_load": float(_safe(r.get("FuelLoad", 0))),
         "driver_number": int(_safe(r.get("DriverNumber", 0))),
         "sector1_s": float(_safe(r.get("Sector1_s", 0))),
@@ -470,21 +506,23 @@ def get_lap_state(
         interval_to_driver = None
         if pd.notna(rival_cum) and driver in cum_times and pd.notna(driver_cum):
             interval_to_driver = round(float(rival_cum) - float(driver_cum), 3)
-        rivals.append({
-            "driver": str(rr.get("Driver", "")),
-            "team": str(rr.get("Team", "")),
-            "position": rival_pos,
-            "lap_time_s": float(_safe(rr.get("LapTime_s", 0))),
-            "compound": str(rr.get("Compound", "")),
-            "tyre_life": int(_safe(rr.get("TyreLife", 0))),
-            "gap_ahead_s": round(rival_gap, 3),
-            "interval_to_driver_s": interval_to_driver,
-        })
+        rivals.append(
+            {
+                "driver": str(rr.get("Driver", "")),
+                "team": str(rr.get("Team", "")),
+                "position": rival_pos,
+                "lap_time_s": float(_safe(rr.get("LapTime_s", 0))),
+                "compound": str(rr.get("Compound", "")),
+                "tyre_life": _safe_none(rr.get("TyreLife")),
+                "gap_ahead_s": round(rival_gap, 3),
+                "interval_to_driver_s": interval_to_driver,
+            }
+        )
 
     weather = {
-        "air_temp": float(_safe(r.get("AirTemp", 25))),
-        "track_temp": float(_safe(r.get("TrackTemp", 40))),
-        "humidity": float(_safe(r.get("Humidity", 50))),
+        "air_temp": _safe_none(r.get("AirTemp")),
+        "track_temp": _safe_none(r.get("TrackTemp")),
+        "humidity": _safe_none(r.get("Humidity")),
         "rainfall": int(_safe(r.get("Rainfall", 0))),
     }
 
@@ -501,15 +539,21 @@ def get_lap_state(
             "driver": driver,
             "team": driver_dict["team"],
             "total_laps": total_laps,
+            "track_temp_start": _session_track_temp_start(gp_df),
         },
     }
+
 
 # ---------------------------------------------------------------------------
 # /pace — N25 XGBoost lap-time prediction + bootstrap CI
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pace", response_model=StrategyResponse, dependencies=[Depends(rate_limit("pace", capacity=20, per_minute=60))])
+@router.post(
+    "/pace",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("pace", capacity=20, per_minute=60))],
+)
 def predict_pace(request: PaceRequest):
     """Run the Pace Agent (N25) for a single lap."""
     try:
@@ -530,7 +574,9 @@ def predict_pace(request: PaceRequest):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pace-range", dependencies=[Depends(rate_limit("pace-range", capacity=5, per_minute=10))])
+@router.post(
+    "/pace-range", dependencies=[Depends(rate_limit("pace-range", capacity=5, per_minute=10))]
+)
 def predict_pace_range(request: PaceRangeRequest):
     """Run Pace Agent across a lap range and return actual vs predicted."""
 
@@ -549,8 +595,7 @@ def predict_pace_range(request: PaceRangeRequest):
         raise HTTPException(404, detail=f"Driver '{request.driver}' not found")
 
     drv_df = drv_df[
-        (drv_df["LapNumber"] >= request.lap_start)
-        & (drv_df["LapNumber"] <= request.lap_end)
+        (drv_df["LapNumber"] >= request.lap_start) & (drv_df["LapNumber"] <= request.lap_end)
     ]
 
     total_laps = int(gp_df["LapNumber"].max())
@@ -563,12 +608,17 @@ def predict_pace_range(request: PaceRangeRequest):
         # Skip laps without a valid previous lap time (lap 1 of each stint)
         prev_lt = row.get("Prev_LapTime")
         if pd.isna(prev_lt) or (prev_lt is not None and prev_lt < 60):
-            results.append({
-                "lap": lap_num, "actual": actual,
-                "pred": None, "ci_p10": None, "ci_p90": None,
-                "compound": str(row.get("Compound", "")),
-                "stint": int(row.get("Stint", 1)),
-            })
+            results.append(
+                {
+                    "lap": lap_num,
+                    "actual": actual,
+                    "pred": None,
+                    "ci_p10": None,
+                    "ci_p90": None,
+                    "compound": str(row.get("Compound", "")),
+                    "stint": int(row.get("Stint", 1)),
+                }
+            )
             continue
 
         # Build a minimal lap_state for this row
@@ -576,19 +626,29 @@ def predict_pace_range(request: PaceRangeRequest):
 
         try:
             out = run_pace_agent_from_state(lap_state)
-            results.append({
-                "lap": lap_num, "actual": actual,
-                "pred": out.lap_time_pred, "ci_p10": out.ci_p10, "ci_p90": out.ci_p90,
-                "compound": str(row.get("Compound", "")),
-                "stint": int(row.get("Stint", 1)),
-            })
+            results.append(
+                {
+                    "lap": lap_num,
+                    "actual": actual,
+                    "pred": out.lap_time_pred,
+                    "ci_p10": out.ci_p10,
+                    "ci_p90": out.ci_p90,
+                    "compound": str(row.get("Compound", "")),
+                    "stint": int(row.get("Stint", 1)),
+                }
+            )
         except Exception:
-            results.append({
-                "lap": lap_num, "actual": actual,
-                "pred": None, "ci_p10": None, "ci_p90": None,
-                "compound": str(row.get("Compound", "")),
-                "stint": int(row.get("Stint", 1)),
-            })
+            results.append(
+                {
+                    "lap": lap_num,
+                    "actual": actual,
+                    "pred": None,
+                    "ci_p10": None,
+                    "ci_p90": None,
+                    "compound": str(row.get("Compound", "")),
+                    "stint": int(row.get("Stint", 1)),
+                }
+            )
 
     return {"predictions": results, "count": len(results)}
 
@@ -607,11 +667,17 @@ def _elapsed_times_at_lap(gp_df, lap: int):
     Falls back to the old sum, loudly, if ``Time_s`` is absent. The loader restores it
     from the raw per-race parquet (#447), so absence means that restoration failed and
     the caller should know the gaps are degraded rather than silently trust them.
+
+    The all-NaN case is checked explicitly, not just column presence: a GP whose raw
+    parquet lacks Time (or failed the restore silently) still gets a Time_s COLUMN from
+    the merge, filled entirely with NaN, and ``"Time_s" not in gp_df.columns`` passes
+    right over that -- the exact "default only fires when the KEY is missing, never when
+    the VALUE is" bug class (#486).
     """
-    if "Time_s" not in gp_df.columns:
+    if "Time_s" not in gp_df.columns or not gp_df["Time_s"].notna().any():
         logger.warning(
-            "Time_s absent from the laps frame: falling back to cumulative LapTime_s "
-            "sums, which understate gaps wherever laps were dropped (#437/#447)"
+            "Time_s absent or entirely NaN in the laps frame: falling back to cumulative "
+            "LapTime_s sums, which understate gaps wherever laps were dropped (#437/#447)"
         )
         laps_up_to = gp_df[gp_df["LapNumber"] <= lap]
         return laps_up_to.sort_values(["Driver", "LapNumber"]).groupby("Driver")["LapTime_s"].sum()
@@ -646,8 +712,64 @@ def _stint_baseline_tyre_life(gp_df, driver: str, stint) -> Optional[int]:
     return int(tyre_life.min())
 
 
+def _session_track_temp_start(gp_df) -> Optional[float]:
+    """The session's first-sample TrackTemp for this GP, or None if unavailable.
+
+    N14 trains ``track_temp_delta = track_temp - track_temp_start`` as its 5th most
+    important feature (~6% gain). Its consumer (`race_situation_agent.py`) defaults
+    `track_temp_start` to the CURRENT lap's track_temp whenever this key is absent
+    from `session_meta`, which zeroes the delta on every lap of every race (#486).
+    `RaceStateManager` derives the equivalent value from a dedicated weather_df; the
+    API path only ever loads the laps frame, so the earliest chronological non-NaN
+    TrackTemp reading for this GP is the same session-opening value.
+    """
+    if "TrackTemp" not in gp_df.columns:
+        return None
+    ordered = gp_df.sort_values("LapNumber")["TrackTemp"].dropna()
+    if ordered.empty:
+        return None
+    return float(ordered.iloc[0])
+
+
+def _prev_lap_time_for_row(row, gp_df, driver: str) -> Optional[float]:
+    """This row's previous-lap time in seconds, or None when unavailable.
+
+    Prefers the featured parquet's own `Prev_LapTime` column (N04's pre-computed
+    previous-lap-time feature) when present. The raw per-race fallback frame
+    (`_get_race_laps_df`, serving Safety Car / pit / out laps the featured parquet
+    drops, #447) carries no such column, so it derives the value from the SAME
+    driver's `lap_number - 1` row instead. Missing either way -> None, never the
+    CURRENT lap's own time: that self-referential default is #435 -- it fed the
+    pace agent's own most recent prediction back in as "previous" and made pace
+    self-fulfilling.
+    """
+
+    def _to_seconds(val):
+        """Accept either a raw seconds float or a timedelta-like value."""
+        if pd.isna(val):
+            return None
+        if hasattr(val, "total_seconds"):
+            return float(val.total_seconds())
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return None
+
+    if "Prev_LapTime" in row.index:
+        return _to_seconds(row.get("Prev_LapTime"))
+
+    lap_number = row.get("LapNumber")
+    if pd.isna(lap_number):
+        return None
+    prior = gp_df[(gp_df["Driver"] == driver) & (gp_df["LapNumber"] == int(lap_number) - 1)]
+    if prior.empty:
+        return None
+    return _to_seconds(prior.iloc[0].get("LapTime_s"))
+
+
 def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -> dict:
     """Build the canonical lap_state dict from a single parquet row."""
+
     def _s(val, default=0):
         if pd.isna(val):
             return default
@@ -657,20 +779,24 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
             return val
 
     lap = int(row["LapNumber"])
+    driver_code = str(row.get("Driver", ""))
     return {
         "lap_number": lap,
         "driver": {
-            "driver": str(row.get("Driver", "")),
+            "driver": driver_code,
             "team": str(row.get("Team", "")),
             "lap_number": lap,
             "lap_time_s": float(_s(row.get("LapTime_s", 0))),
+            "prev_lap_time": _prev_lap_time_for_row(row, gp_df, driver_code),
             "position": int(_s(row.get("Position", 10))),
             "compound": str(row.get("Compound", "")),
             "compound_id": int(_s(row.get("CompoundID", 0))),
             "tyre_life": int(_s(row.get("TyreLife", 0))),
             "stint": int(_s(row.get("Stint", 1))),
             "stint_baseline_tyre_life": _stint_baseline_tyre_life(
-                gp_df, str(row.get("Driver", "")), row.get("Stint"),
+                gp_df,
+                driver_code,
+                row.get("Stint"),
             ),
             "fresh_tyre": bool(row.get("FreshTyre", False)),
             "speed_i1": float(_s(row.get("SpeedI1", 0))),
@@ -691,10 +817,12 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
             "rainfall": int(_s(row.get("Rainfall", 0))),
         },
         "session_meta": {
-            "gp_name": gp, "year": year,
-            "driver": str(row.get("Driver", "")),
+            "gp_name": gp,
+            "year": year,
+            "driver": driver_code,
             "team": str(row.get("Team", "")),
             "total_laps": total_laps,
+            "track_temp_start": _session_track_temp_start(gp_df),
         },
     }
 
@@ -704,7 +832,9 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
 # ---------------------------------------------------------------------------
 
 
-@router.post("/tire-range", dependencies=[Depends(rate_limit("tire-range", capacity=5, per_minute=10))])
+@router.post(
+    "/tire-range", dependencies=[Depends(rate_limit("tire-range", capacity=5, per_minute=10))]
+)
 def predict_tire_range(
     request: PaceRangeRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -828,7 +958,11 @@ def predict_tire_range(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/tire", response_model=StrategyResponse, dependencies=[Depends(rate_limit("tire", capacity=20, per_minute=60))])
+@router.post(
+    "/tire",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("tire", capacity=20, per_minute=60))],
+)
 def predict_tire(
     request: TireRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -854,7 +988,11 @@ def predict_tire(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/situation", response_model=StrategyResponse, dependencies=[Depends(rate_limit("situation", capacity=20, per_minute=60))])
+@router.post(
+    "/situation",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("situation", capacity=20, per_minute=60))],
+)
 def predict_situation(
     request: SituationRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -880,7 +1018,11 @@ def predict_situation(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/pit", response_model=StrategyResponse, dependencies=[Depends(rate_limit("pit", capacity=20, per_minute=60))])
+@router.post(
+    "/pit",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("pit", capacity=20, per_minute=60))],
+)
 def predict_pit(
     request: PitRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -906,7 +1048,11 @@ def predict_pit(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/radio", response_model=StrategyResponse, dependencies=[Depends(rate_limit("radio", capacity=20, per_minute=60))])
+@router.post(
+    "/radio",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("radio", capacity=20, per_minute=60))],
+)
 def analyze_radio(
     request: RadioRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -946,7 +1092,11 @@ def analyze_radio(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/rag", response_model=StrategyResponse, dependencies=[Depends(rate_limit("rag", capacity=5, per_minute=10))])
+@router.post(
+    "/rag",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("rag", capacity=5, per_minute=10))],
+)
 def query_rag(request: RagRequest):
     """Run the RAG Agent (N30) to answer a regulation question."""
     try:
@@ -1006,7 +1156,9 @@ def _get_radio_runner(year: int, gp: str, laps_df: pd.DataFrame):
     return runner
 
 
-def _rcm_events_for_lap(year: int, gp: str, laps_df: pd.DataFrame, lap: int) -> List[Dict[str, Any]]:
+def _rcm_events_for_lap(
+    year: int, gp: str, laps_df: pd.DataFrame, lap: int
+) -> List[Dict[str, Any]]:
     """RCM events active at *lap*, replaying the stateful SC tracker from lap 1.
 
     Returns the lap's own RCM rows plus a synthetic SAFETY CAR DEPLOYED when a
@@ -1035,7 +1187,11 @@ def _rcm_events_for_lap(year: int, gp: str, laps_df: pd.DataFrame, lap: int) -> 
 # ---------------------------------------------------------------------------
 
 
-@router.post("/recommend", response_model=StrategyResponse, dependencies=[Depends(rate_limit("recommend", capacity=5, per_minute=10))])
+@router.post(
+    "/recommend",
+    response_model=StrategyResponse,
+    dependencies=[Depends(rate_limit("recommend", capacity=5, per_minute=10))],
+)
 def recommend_strategy(
     request: RecommendRequest,
     laps_df: pd.DataFrame = Depends(_require_laps_df),
@@ -1193,12 +1349,14 @@ def radio_laps(gp: str, year: int = 2025, driver: Optional[str] = None):
         for _, row in grp.sort_values("lap_number").iterrows():
             audio_key = str(row.get("audio_path", "")).replace("\\", "/")
             tx = transcripts.get(audio_key, {})
-            laps_data.append({
-                "lap": int(row["lap_number"]),
-                "text": tx.get("text", ""),
-                "has_transcript": bool(tx.get("text")),
-                "audio_path": audio_key,
-            })
+            laps_data.append(
+                {
+                    "lap": int(row["lap_number"]),
+                    "text": tx.get("text", ""),
+                    "has_transcript": bool(tx.get("text")),
+                    "audio_path": audio_key,
+                }
+            )
         result.append({"driver": code, "driver_number": int(drv_num), "laps": laps_data})
 
     result.sort(key=lambda d: d["driver"])
@@ -1244,13 +1402,15 @@ def radio_transcript(gp: str, driver: str, lap: int, year: int = 2025):
     for _, row in rows.iterrows():
         audio_key = str(row.get("audio_path", "")).replace("\\", "/")
         tx = transcripts.get(audio_key, {})
-        results.append({
-            "driver": driver,
-            "lap": lap,
-            "text": tx.get("text", "[no transcript available]"),
-            "duration_s": tx.get("duration_s"),
-            "audio_path": audio_key,
-        })
+        results.append(
+            {
+                "driver": driver,
+                "lap": lap,
+                "text": tx.get("text", "[no transcript available]"),
+                "duration_s": tx.get("duration_s"),
+                "audio_path": audio_key,
+            }
+        )
 
     return {"messages": results}
 

--- a/backend/mcp_tools.py
+++ b/backend/mcp_tools.py
@@ -14,10 +14,10 @@ calls the underlying Python functions directly.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import sys
-from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
@@ -50,6 +50,22 @@ mcp = FastMCP(
 # Private helpers
 # ---------------------------------------------------------------------------
 
+
+class ToolInputError(ValueError):
+    """Raised by a `_normalize_*` helper when an LLM argument can't be resolved.
+
+    Before #442 an unparseable year/lap/driver silently substituted a wrong
+    default (2025 / lap 1 / whichever real driver code happened to share the
+    first three letters), so a garbled argument produced a confident-looking
+    WRONG prediction instead of a visible failure. Every `@mcp.tool` wrapper
+    that normalizes user input is decorated with `_catch_tool_input_error`
+    (defined below, near `_build_lap_state`), which turns this into the
+    tool's own string result -- the same plain-text refusal shape
+    `pit_strategy_agent.py::score_undercut_tool` already uses for a bad rival
+    argument -- instead of a raw traceback or a silent wrong answer.
+    """
+
+
 # Country / alias → canonical GP name mapping (matches the GP_Name column
 # in the featured parquet, which uses circuit / city names).  An LLM with
 # only the schema "Grand Prix name" defaults to the country form
@@ -58,76 +74,124 @@ mcp = FastMCP(
 # external MCP client (Claude Desktop, Cursor) — gets the same handling.
 _GP_ALIASES: dict[str, str] = {
     # Bahrain
-    "bahrain": "Sakhir", "sakhir": "Sakhir",
-    "bahrein": "Sakhir", "baréin": "Sakhir", "barein": "Sakhir",
+    "bahrain": "Sakhir",
+    "sakhir": "Sakhir",
+    "bahrein": "Sakhir",
+    "baréin": "Sakhir",
+    "barein": "Sakhir",
     # Saudi Arabia
-    "jeddah": "Jeddah", "saudi": "Jeddah",
-    "saudi arabia": "Jeddah", "arabia saudita": "Jeddah",
-    "arabia": "Jeddah", "yeda": "Jeddah",
+    "jeddah": "Jeddah",
+    "saudi": "Jeddah",
+    "saudi arabia": "Jeddah",
+    "arabia saudita": "Jeddah",
+    "arabia": "Jeddah",
+    "yeda": "Jeddah",
     # Australia
-    "australia": "Melbourne", "melbourne": "Melbourne",
+    "australia": "Melbourne",
+    "melbourne": "Melbourne",
     # Japan
-    "japan": "Suzuka", "japón": "Suzuka", "japon": "Suzuka",
+    "japan": "Suzuka",
+    "japón": "Suzuka",
+    "japon": "Suzuka",
     "suzuka": "Suzuka",
     # China
-    "china": "Shanghai", "shanghai": "Shanghai",
+    "china": "Shanghai",
+    "shanghai": "Shanghai",
     # Miami
     "miami": "Miami",
     # Imola
-    "imola": "Imola", "emilia": "Imola", "emilia romagna": "Imola",
+    "imola": "Imola",
+    "emilia": "Imola",
+    "emilia romagna": "Imola",
     # Monaco
-    "monaco": "Monaco", "mónaco": "Monaco",
+    "monaco": "Monaco",
+    "mónaco": "Monaco",
     # Canada
-    "canada": "Montréal", "canadá": "Montréal",
-    "montreal": "Montréal", "montréal": "Montréal",
+    "canada": "Montréal",
+    "canadá": "Montréal",
+    "montreal": "Montréal",
+    "montréal": "Montréal",
     # Spain
-    "spain": "Barcelona", "españa": "Barcelona", "espana": "Barcelona",
-    "barcelona": "Barcelona", "cataluña": "Barcelona", "catalunya": "Barcelona",
+    "spain": "Barcelona",
+    "españa": "Barcelona",
+    "espana": "Barcelona",
+    "barcelona": "Barcelona",
+    "cataluña": "Barcelona",
+    "catalunya": "Barcelona",
     # Austria
-    "austria": "Spielberg", "spielberg": "Spielberg",
+    "austria": "Spielberg",
+    "spielberg": "Spielberg",
     "red bull ring": "Spielberg",
     # Britain
-    "britain": "Silverstone", "great britain": "Silverstone",
-    "gran bretaña": "Silverstone", "gran bretana": "Silverstone",
-    "uk": "Silverstone", "reino unido": "Silverstone",
+    "britain": "Silverstone",
+    "great britain": "Silverstone",
+    "gran bretaña": "Silverstone",
+    "gran bretana": "Silverstone",
+    "uk": "Silverstone",
+    "reino unido": "Silverstone",
     "silverstone": "Silverstone",
     # Hungary
-    "hungary": "Budapest", "hungría": "Budapest", "hungria": "Budapest",
+    "hungary": "Budapest",
+    "hungría": "Budapest",
+    "hungria": "Budapest",
     "budapest": "Budapest",
     # Belgium
-    "belgium": "Spa-Francorchamps", "bélgica": "Spa-Francorchamps",
-    "belgica": "Spa-Francorchamps", "spa": "Spa-Francorchamps",
-    "spa-francorchamps": "Spa-Francorchamps", "francorchamps": "Spa-Francorchamps",
+    "belgium": "Spa-Francorchamps",
+    "bélgica": "Spa-Francorchamps",
+    "belgica": "Spa-Francorchamps",
+    "spa": "Spa-Francorchamps",
+    "spa-francorchamps": "Spa-Francorchamps",
+    "francorchamps": "Spa-Francorchamps",
     # Netherlands
-    "netherlands": "Zandvoort", "países bajos": "Zandvoort",
-    "paises bajos": "Zandvoort", "holanda": "Zandvoort",
+    "netherlands": "Zandvoort",
+    "países bajos": "Zandvoort",
+    "paises bajos": "Zandvoort",
+    "holanda": "Zandvoort",
     "zandvoort": "Zandvoort",
     # Italy
-    "italy": "Monza", "italia": "Monza", "monza": "Monza",
+    "italy": "Monza",
+    "italia": "Monza",
+    "monza": "Monza",
     # Azerbaijan
-    "azerbaijan": "Baku", "azerbaiyán": "Baku", "azerbaiyan": "Baku",
-    "baku": "Baku", "bakú": "Baku",
+    "azerbaijan": "Baku",
+    "azerbaiyán": "Baku",
+    "azerbaiyan": "Baku",
+    "baku": "Baku",
+    "bakú": "Baku",
     # Singapore
-    "singapore": "Marina Bay", "singapur": "Marina Bay",
+    "singapore": "Marina Bay",
+    "singapur": "Marina Bay",
     "marina bay": "Marina Bay",
     # United States
-    "united states": "Austin", "austin": "Austin",
-    "cota": "Austin", "estados unidos": "Austin", "usa": "Austin",
+    "united states": "Austin",
+    "austin": "Austin",
+    "cota": "Austin",
+    "estados unidos": "Austin",
+    "usa": "Austin",
     "us gp": "Austin",
     # Mexico
-    "mexico": "Mexico City", "méxico": "Mexico City",
-    "mexico city": "Mexico City", "ciudad de méxico": "Mexico City",
+    "mexico": "Mexico City",
+    "méxico": "Mexico City",
+    "mexico city": "Mexico City",
+    "ciudad de méxico": "Mexico City",
     # Brazil
-    "brazil": "São Paulo", "brasil": "São Paulo",
+    "brazil": "São Paulo",
+    "brasil": "São Paulo",
     "interlagos": "São Paulo",
-    "sao paulo": "São Paulo", "são paulo": "São Paulo",
+    "sao paulo": "São Paulo",
+    "são paulo": "São Paulo",
     # Las Vegas
-    "las vegas": "Las Vegas", "vegas": "Las Vegas",
+    "las vegas": "Las Vegas",
+    "vegas": "Las Vegas",
     # Qatar
-    "qatar": "Lusail", "lusail": "Lusail", "catar": "Lusail",
+    "qatar": "Lusail",
+    "lusail": "Lusail",
+    "catar": "Lusail",
     # Abu Dhabi
-    "abu dhabi": "Yas Island", "yas marina": "Yas Island",
-    "yas island": "Yas Island", "uae": "Yas Island",
+    "abu dhabi": "Yas Island",
+    "yas marina": "Yas Island",
+    "yas island": "Yas Island",
+    "uae": "Yas Island",
 }
 
 
@@ -154,22 +218,66 @@ def _normalize_gp_name(gp: str) -> str:
 # column in the featured parquet, which is the only form the agents
 # expect.
 _DRIVER_CODES: set[str] = {
-    "VER", "PER", "LEC", "SAI", "HAM", "RUS", "ANT", "NOR", "PIA",
-    "ALO", "STR", "GAS", "OCO", "DOO", "COL", "ALB", "SAR", "TSU",
-    "RIC", "LAW", "HAD", "BOT", "ZHO", "HUL", "BOR", "MAG", "BEA",
+    "VER",
+    "PER",
+    "LEC",
+    "SAI",
+    "HAM",
+    "RUS",
+    "ANT",
+    "NOR",
+    "PIA",
+    "ALO",
+    "STR",
+    "GAS",
+    "OCO",
+    "DOO",
+    "COL",
+    "ALB",
+    "SAR",
+    "TSU",
+    "RIC",
+    "LAW",
+    "HAD",
+    "BOT",
+    "ZHO",
+    "HUL",
+    "BOR",
+    "MAG",
+    "BEA",
 }
 
 # Surname (lowercase, no diacritics) → 3-letter code.  Lets an LLM that
 # defaults to natural names ("Verstappen", "Max Verstappen", "leclerc")
 # still hit the agents without us forcing it to memorise codes.
 _DRIVER_SURNAMES: dict[str, str] = {
-    "verstappen": "VER", "perez": "PER", "leclerc": "LEC", "sainz": "SAI",
-    "hamilton": "HAM", "russell": "RUS", "antonelli": "ANT", "norris": "NOR",
-    "piastri": "PIA", "alonso": "ALO", "stroll": "STR", "gasly": "GAS",
-    "ocon": "OCO", "doohan": "DOO", "colapinto": "COL", "albon": "ALB",
-    "sargeant": "SAR", "tsunoda": "TSU", "ricciardo": "RIC", "lawson": "LAW",
-    "hadjar": "HAD", "bottas": "BOT", "zhou": "ZHO", "hulkenberg": "HUL",
-    "bortoleto": "BOR", "magnussen": "MAG", "bearman": "BEA",
+    "verstappen": "VER",
+    "perez": "PER",
+    "leclerc": "LEC",
+    "sainz": "SAI",
+    "hamilton": "HAM",
+    "russell": "RUS",
+    "antonelli": "ANT",
+    "norris": "NOR",
+    "piastri": "PIA",
+    "alonso": "ALO",
+    "stroll": "STR",
+    "gasly": "GAS",
+    "ocon": "OCO",
+    "doohan": "DOO",
+    "colapinto": "COL",
+    "albon": "ALB",
+    "sargeant": "SAR",
+    "tsunoda": "TSU",
+    "ricciardo": "RIC",
+    "lawson": "LAW",
+    "hadjar": "HAD",
+    "bottas": "BOT",
+    "zhou": "ZHO",
+    "hulkenberg": "HUL",
+    "bortoleto": "BOR",
+    "magnussen": "MAG",
+    "bearman": "BEA",
 }
 
 
@@ -178,12 +286,20 @@ def _normalize_driver_code(driver: str) -> str:
 
     Accepts 3-letter codes ("VER", "ver"), surnames ("Verstappen",
     "leclerc") and full names ("Max Verstappen") — the LLM doesn't have
-    to remember the F1 abbreviation system.  Falls back to the input as
-    given so the data layer still surfaces an honest "driver not found"
-    when the user truly typed something unrecognisable.
+    to remember the F1 abbreviation system. Raises :class:`ToolInputError`
+    when nothing matches, instead of guessing.
+
+    The previous fallback took the input's first three letters and matched
+    them against `_DRIVER_CODES` (e.g. "Pereira"[:3] == "PER"), so an LLM
+    typo or an unlisted surname silently resolved to a real but unrelated
+    driver — "Pereira" (nobody on the 2023-2025 grid) became Sergio Perez's
+    code (#442). A driver code that can't be resolved must say so, not guess.
     """
     if not driver:
-        return driver
+        raise ToolInputError(
+            "Driver REFUSED — no driver was provided. "
+            f"Valid codes: {', '.join(sorted(_DRIVER_CODES))}."
+        )
     raw = str(driver).strip()
     upper = raw.upper()
     if upper in _DRIVER_CODES:
@@ -194,35 +310,46 @@ def _normalize_driver_code(driver: str) -> str:
     for token in lower.split():
         if token in _DRIVER_SURNAMES:
             return _DRIVER_SURNAMES[token]
-    if len(upper) >= 3 and upper[:3] in _DRIVER_CODES:
-        return upper[:3]
-    return raw
+    raise ToolInputError(
+        f"Driver REFUSED — {driver!r} is not a recognized 3-letter code or "
+        f"surname. Valid codes: {', '.join(sorted(_DRIVER_CODES))}."
+    )
 
 
 def _normalize_year(year: Any) -> int:
-    """Coerce year to int, defaulting to 2025 when the value is unparseable.
+    """Coerce year to int; raise :class:`ToolInputError` when unparseable.
 
-    The LLM occasionally emits ``"2024"`` (string) instead of ``2024``
-    even though the schema says integer; coercing here keeps the agents
-    from blowing up on the type mismatch.
+    The LLM sometimes emits ``"2024"`` (string) instead of ``2024`` even
+    though the schema says integer, so a simple ``int()`` coercion is still
+    attempted first. Before #442 a genuinely unparseable value (e.g.
+    ``"banana"``) silently became 2025 — a confident, WRONG season for a
+    query the LLM meant to ask about something else entirely.
     """
     try:
         return int(year)
     except (TypeError, ValueError):
-        return 2025
+        raise ToolInputError(
+            f"Year REFUSED — {year!r} is not a valid season year. "
+            "Provide an integer year, e.g. 2023, 2024, or 2025."
+        ) from None
 
 
 def _normalize_lap(lap: Any) -> int:
-    """Coerce lap to int, defaulting to 1 on garbage input.
+    """Coerce lap to int; raise :class:`ToolInputError` when unparseable.
 
-    Range validation lives in the agents (they know how many laps a
-    particular GP has); we only protect against ``"25"`` arriving as a
-    string instead of an int.
+    Range validation still lives in the agents (they know how many laps a
+    particular GP has) — this only protects the ``int()`` coercion itself.
+    Before #442 an unparseable value (e.g. ``"twenty-five"``) silently
+    became lap 1, so a garbled lap argument analysed the wrong point in the
+    race instead of surfacing a visible failure.
     """
     try:
         return int(lap)
     except (TypeError, ValueError):
-        return 1
+        raise ToolInputError(
+            f"Lap REFUSED — {lap!r} is not a valid lap number. "
+            "Provide an integer lap count, e.g. 12."
+        ) from None
 
 
 def _normalize_risk_tolerance(risk: Any) -> float:
@@ -238,6 +365,34 @@ def _normalize_risk_tolerance(risk: Any) -> float:
     return max(0.0, min(1.0, value))
 
 
+def _catch_tool_input_error(fn):
+    """Turn a :class:`ToolInputError` into the tool's own string return value.
+
+    Every tool wrapped with this decorator eventually normalizes gp/driver/
+    lap/year through the `_normalize_*` helpers above. Those helpers now
+    raise instead of silently substituting a wrong value (#442); this
+    wrapper is what turns that raise into a normal-looking tool result — the
+    LLM sees a plain "X is invalid, here are the valid options" string, the
+    same REFUSED shape `pit_strategy_agent.py::score_undercut_tool` already
+    returns for a bad rival argument, instead of a raw traceback.
+
+    Must sit BELOW ``@mcp.tool`` (closer to the function) so FastMCP wraps
+    the already-guarded callable: ``@mcp.tool`` / ``@_catch_tool_input_error``
+    / ``def foo(...)``. ``functools.wraps`` preserves the wrapped function's
+    signature via ``__wrapped__`` so FastMCP's schema introspection still
+    sees the real parameter names and types, not ``(*args, **kwargs)``.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except ToolInputError as exc:
+            return str(exc)
+
+    return wrapper
+
+
 def _build_lap_state(gp: str, driver: str, lap: int, year: int = 2025) -> dict[str, Any]:
     """Build a canonical lap_state dict from the featured parquet.
 
@@ -248,6 +403,7 @@ def _build_lap_state(gp: str, driver: str, lap: int, year: int = 2025) -> dict[s
     benefits without having to remember the conversion at the call site.
     """
     from backend.api.v1.endpoints.strategy import get_lap_state
+
     return get_lap_state(
         gp=_normalize_gp_name(gp),
         driver=_normalize_driver_code(driver),
@@ -259,12 +415,14 @@ def _build_lap_state(gp: str, driver: str, lap: int, year: int = 2025) -> dict[s
 def _get_laps_df(year: int = 2025):
     """Return the cached featured DataFrame for the given season."""
     from backend.utils.laps_cache import get_laps_df
+
     return get_laps_df(year)
 
 
 def _serialize(obj: Any) -> dict[str, Any]:
     """Convert an agent output (dataclass / dict) to a plain dict."""
     from backend.utils.serialization import agent_output_to_dict
+
     return agent_output_to_dict(obj)
 
 
@@ -277,7 +435,9 @@ def _format_result(data: dict[str, Any]) -> str:
 # MCP Tools — Agent wrappers
 # ---------------------------------------------------------------------------
 
+
 @mcp.tool
+@_catch_tool_input_error
 def predict_pace(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     """Predict lap time for a driver at a specific lap using the N25 XGBoost model.
 
@@ -292,6 +452,7 @@ def predict_pace(gp: str, driver: str, lap: int, year: int = 2025) -> str:
 
 
 @mcp.tool
+@_catch_tool_input_error
 def predict_tire(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     """Analyse tyre degradation and estimate laps to performance cliff.
 
@@ -308,6 +469,7 @@ def predict_tire(gp: str, driver: str, lap: int, year: int = 2025) -> str:
 
 
 @mcp.tool
+@_catch_tool_input_error
 def predict_situation(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     """Estimate overtake probability and safety car likelihood.
 
@@ -324,6 +486,7 @@ def predict_situation(gp: str, driver: str, lap: int, year: int = 2025) -> str:
 
 
 @mcp.tool
+@_catch_tool_input_error
 def predict_pit(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     """Recommend pit stop strategy — when to pit, which compound, undercut odds.
 
@@ -339,23 +502,47 @@ def predict_pit(gp: str, driver: str, lap: int, year: int = 2025) -> str:
 
 
 @mcp.tool
+@_catch_tool_input_error
 def analyze_radio(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     """Analyse team radio communications for a driver on a specific lap.
 
     Runs the N29 NLP pipeline (RoBERTa sentiment, SetFit intent, BERT NER)
     on available radio transcripts and returns alerts, sentiment, and entities.
     """
+    from backend.api.v1.endpoints.strategy import _get_radio_runner, _rcm_events_for_lap
     from src.agents.radio_agent import RadioMessage, RCMEvent, run_radio_agent_from_state
 
-    base_state = _build_lap_state(gp, driver, lap, year)
-    # Mirror the endpoint pattern: merge radio fields into lap_state
+    norm_gp = _normalize_gp_name(gp)
+    norm_driver = _normalize_driver_code(driver)
+    norm_lap = _normalize_lap(lap)
+    norm_year = _normalize_year(year)
+
+    base_state = _build_lap_state(norm_gp, norm_driver, norm_lap, norm_year)
+    laps_df = _get_laps_df(norm_year)
+
+    # Real radio corpus + Safety Car RCM state, mirroring what the /radio and
+    # /recommend HTTP endpoints already wire in strategy.py, instead of the
+    # empty literals this tool previously hardcoded on every call (#442).
+    # `_get_radio_runner` reads the pre-transcribed JSON cache (no live
+    # Whisper call on this request path — disable_transcription=True);
+    # `_rcm_events_for_lap` replays the stateful SC tracker from lap 1 so a
+    # neutralisation still in force reaches N29 even when this lap's own RCM
+    # window carries no fresh message. Radios are filtered to this driver's
+    # own code — the tool analyses ONE driver's communications, not the
+    # whole grid's.
+    runner = _get_radio_runner(norm_year, norm_gp, laps_df)
+    radios_raw = runner.radios_for_lap(norm_lap)[0] if runner is not None else []
+    radio_msgs = [RadioMessage(**msg) for msg in radios_raw if msg.get("driver") == norm_driver]
+    rcm_events = [
+        RCMEvent(**event) for event in _rcm_events_for_lap(norm_year, norm_gp, laps_df, norm_lap)
+    ]
+
     lap_state = {
         **base_state,
-        "lap": base_state.get("lap_number", lap),
-        "radio_msgs": [],
-        "rcm_events": [],
+        "lap": base_state.get("lap_number", norm_lap),
+        "radio_msgs": radio_msgs,
+        "rcm_events": rcm_events,
     }
-    laps_df = _get_laps_df(year)
     result = run_radio_agent_from_state(lap_state, laps_df)
     return _format_result(_serialize(result))
 
@@ -374,6 +561,7 @@ def query_regulations(question: str) -> str:
 
 
 @mcp.tool
+@_catch_tool_input_error
 def recommend_strategy(
     gp: str,
     driver: str,
@@ -394,11 +582,20 @@ def recommend_strategy(
     lap_state = _build_lap_state(gp, driver, lap, year)
     laps_df = _get_laps_df(year)
 
-    # Mirror the /recommend endpoint exactly
+    # Mirror the /recommend endpoint exactly. pace_delta_s used to be
+    # hardcoded 0.0 (#442), which told N27's overtake scoring "identical pace
+    # to last lap" on every single call regardless of what actually happened;
+    # thread it from lap_state the same way gap_ahead_s already is, using the
+    # per-row Prev_LapTime the producers now carry (#435).
+    driver_state = lap_state.get("driver", {})
+    lap_time_s = driver_state.get("lap_time_s") or 0.0
+    prev_lap_time = driver_state.get("prev_lap_time")
+    pace_delta_s = round(lap_time_s - prev_lap_time, 3) if prev_lap_time else 0.0
+
     race_state = build_race_state(
         lap_state,
-        gap_ahead_s=lap_state.get("driver", {}).get("gap_ahead_s", 2.0),
-        pace_delta_s=0.0,
+        gap_ahead_s=driver_state.get("gap_ahead_s", 2.0),
+        pace_delta_s=pace_delta_s,
         risk_tolerance=_normalize_risk_tolerance(risk_tolerance),
         radio_msgs=None,
         rcm_events=None,
@@ -416,26 +613,31 @@ def recommend_strategy(
 # MCP Tools — Helper / listing tools
 # ---------------------------------------------------------------------------
 
+
 @mcp.tool
+@_catch_tool_input_error
 def list_available_gps(year: int = 2025) -> str:
     """List all Grand Prix events available in the data for a given season."""
     from backend.api.v1.endpoints.strategy import available_gps
+
     return _format_result(available_gps(_normalize_year(year)))
 
 
 @mcp.tool
+@_catch_tool_input_error
 def list_available_drivers(gp: str, year: int = 2025) -> str:
     """List all drivers that participated in a specific Grand Prix."""
     from backend.api.v1.endpoints.strategy import available_drivers
-    return _format_result(
-        available_drivers(_normalize_gp_name(gp), _normalize_year(year))
-    )
+
+    return _format_result(available_drivers(_normalize_gp_name(gp), _normalize_year(year)))
 
 
 @mcp.tool
+@_catch_tool_input_error
 def get_lap_range(gp: str, driver: str, year: int = 2025) -> str:
     """Get the min and max lap numbers available for a driver in a GP."""
     from backend.api.v1.endpoints.strategy import lap_range
+
     return _format_result(
         lap_range(
             _normalize_gp_name(gp),
@@ -464,6 +666,7 @@ def get_lap_range(gp: str, driver: str, year: int = 2025) -> str:
 # all tools (Phase 1 manual + Phase 2 auto) are available under one server.
 
 import httpx as _httpx
+
 
 def _mount_openapi_tools(app: Any | None = None) -> None:
     """Mount auto-generated MCP tools from the FastAPI OpenAPI spec.

--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -235,10 +235,21 @@ def _compute_gap_ahead(lap_state: dict[str, Any]) -> float:
     Mirrors the CLI's derivation at ``scripts/run_simulation_cli.py`` L1354-1358
     but kept inline here because the two copies are short and intentionally
     decoupled.
+
+    ``.get("position", 99)`` used to be a dead default: when RaceStateManager
+    reports an unresolved position it still emits the ``"position"`` KEY with a
+    ``None`` VALUE, so the fallback never fired and ``our_pos - 1`` crashed with
+    a TypeError instead of degrading gracefully. An explicit None check makes
+    "unknown position" mean "no known car ahead" rather than a hidden crash
+    risk (#465). In practice this lap never reaches here anyway --
+    ``_lap_skip_reason`` below already refuses to build a RaceState when
+    position is None -- but the guard keeps this helper safe standalone too.
     """
     driver_st = lap_state.get("driver", {})
     rivals = lap_state.get("rivals", [])
-    our_pos = driver_st.get("position", 99)
+    our_pos = driver_st.get("position")
+    if our_pos is None:
+        return 0.0
     car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
     if not car_ahead:
         return 0.0
@@ -594,9 +605,17 @@ def _accumulate(
     # confidence so best/worst still track something meaningful.
     score = decision.scenario_scores.get(decision.action, decision.confidence)
     if score > state.best_decision["score"]:
-        state.best_decision = {"lap": decision.lap_number, "score": float(score), "action": decision.action}
+        state.best_decision = {
+            "lap": decision.lap_number,
+            "score": float(score),
+            "action": decision.action,
+        }
     if score < state.worst_decision["score"]:
-        state.worst_decision = {"lap": decision.lap_number, "score": float(score), "action": decision.action}
+        state.worst_decision = {
+            "lap": decision.lap_number,
+            "score": float(score),
+            "action": decision.action,
+        }
 
     if isinstance(result, dict):
         if result.get("_pit_out") is not None:
@@ -619,9 +638,35 @@ def _top_tokens(blob: list[str], top_n: int = 10) -> dict[str, int]:
     """
     from collections import Counter
 
-    stop = {"the", "a", "an", "of", "to", "in", "on", "is", "and", "for",
-            "with", "this", "that", "it", "as", "by", "at", "be", "or",
-            "are", "was", "were", "but", "not", "our", "we", "you"}
+    stop = {
+        "the",
+        "a",
+        "an",
+        "of",
+        "to",
+        "in",
+        "on",
+        "is",
+        "and",
+        "for",
+        "with",
+        "this",
+        "that",
+        "it",
+        "as",
+        "by",
+        "at",
+        "be",
+        "or",
+        "are",
+        "was",
+        "were",
+        "but",
+        "not",
+        "our",
+        "we",
+        "you",
+    }
     counter: Counter[str] = Counter()
     for line in blob:
         for tok in line.lower().split():
@@ -658,8 +703,16 @@ def _finalize_summary(
         "max": max(gaps) if gaps else 0.0,
     }
 
-    best = state.best_decision if state.best_decision["action"] else {"lap": 0, "score": 0.0, "action": ""}
-    worst = state.worst_decision if state.worst_decision["action"] else {"lap": 0, "score": 0.0, "action": ""}
+    best = (
+        state.best_decision
+        if state.best_decision["action"]
+        else {"lap": 0, "score": 0.0, "action": ""}
+    )
+    worst = (
+        state.worst_decision
+        if state.worst_decision["action"]
+        else {"lap": 0, "score": 0.0, "action": ""}
+    )
 
     return RunSummary(
         status={"ok_laps": state.ok_laps, "error_laps": state.error_laps},

--- a/backend/utils/race_state_builder.py
+++ b/backend/utils/race_state_builder.py
@@ -79,14 +79,33 @@ def build_race_state(
 
     if rival:
         gap_ahead_s, pace_delta_s = _targeting_against_rival(
-            lap_state, rival, gap_ahead_s, pace_delta_s,
+            lap_state,
+            rival,
+            gap_ahead_s,
+            pace_delta_s,
+        )
+
+    # `.get("position", 10)` was a dead default: RaceStateManager (and, since
+    # #465, this same API's own get_lap_state) report an unresolved position by
+    # keeping the "position" KEY with a None VALUE, and dict.get's default only
+    # ever fires when the key itself is MISSING -- so an incomplete/out-lap
+    # silently built a RaceState with position=None instead of the intended
+    # fallback of 10. RaceState.position is a required, non-optional int
+    # (`src/agents/strategy_orchestrator.py`, out of scope for this module), so
+    # an unresolved position is surfaced here as an explicit, readable failure
+    # instead of a None quietly reaching a field that must never hold one (#465).
+    position = drv.get("position")
+    if position is None:
+        raise ValueError(
+            "Cannot build RaceState: driver position is unknown for this lap "
+            "(likely an incomplete or out-lap). Choose a different lap."
         )
 
     return RaceState(
         driver=drv.get("driver", "UNK"),
         lap=lap_state.get("lap_number", 1),
         total_laps=meta.get("total_laps", 57),
-        position=drv.get("position", 10),
+        position=position,
         compound=drv.get("compound", "MEDIUM"),
         tyre_life=drv.get("tyre_life", 1),
         gap_ahead_s=float(gap_ahead_s),

--- a/tests/test_strategy_audit_fixes.py
+++ b/tests/test_strategy_audit_fixes.py
@@ -1,0 +1,190 @@
+"""No-LLM regression tests for the strategy-engine backend audit (#442/#465/#486/#435).
+
+Every assertion here is either a deterministic unit check or a check against
+the REAL featured parquet -- never a live LLM / orchestrator run, matching the
+verification doctrine the whole audit sprint used (see the fix commentary in
+``backend/api/v1/endpoints/strategy.py`` and ``backend/mcp_tools.py``).
+
+Tests that need the featured parquet skip (rather than fail) when it is not
+present in the current environment, since ``data/`` is fetched from Hugging
+Face Hub on first run and may be absent in a bare checkout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The lite CI installs neither pandas nor fastmcp, yet the backend modules below
+# import both at module load time. Skip the whole suite gracefully there instead of
+# erroring at collection, matching how the other dep-heavy suites behave.
+pd = pytest.importorskip("pandas")
+pytest.importorskip("fastmcp")
+
+from backend.api.v1.endpoints.strategy import (  # noqa: E402  (after importorskip)
+    _build_lap_state_from_row,
+    _safe_none,
+    get_lap_state,
+)
+from backend.mcp_tools import (  # noqa: E402
+    ToolInputError,
+    _normalize_driver_code,
+    _normalize_lap,
+    _normalize_year,
+)
+from backend.utils.laps_cache import get_laps_df  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# #442 -- MCP normalizers must refuse bad input, never silently substitute
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_year_refuses_unparseable_input():
+    """A garbled year must raise, not silently become 2025."""
+    with pytest.raises(ToolInputError):
+        _normalize_year("banana")
+
+
+def test_normalize_lap_refuses_unparseable_input():
+    """A garbled lap must raise, not silently become lap 1."""
+    with pytest.raises(ToolInputError):
+        _normalize_lap("twenty-five")
+
+
+def test_normalize_driver_code_refuses_unmatched_name():
+    """Pin for the trigram-fallback bug: "Pereira" must never become "PER".
+
+    Nobody named Pereira raced in 2023-2025; the old fallback took the first
+    three letters of any unmatched input and matched them against the real
+    code list, so "Pereira"[:3] == "PER" silently resolved to Sergio Perez.
+    """
+    with pytest.raises(ToolInputError):
+        _normalize_driver_code("Pereira")
+
+
+def test_normalize_driver_code_still_resolves_real_codes_and_surnames():
+    """The fix must not break the legitimate resolution paths."""
+    assert _normalize_driver_code("ver") == "VER"
+    assert _normalize_driver_code("Verstappen") == "VER"
+    assert _normalize_driver_code("Max Verstappen") == "VER"
+
+
+# ---------------------------------------------------------------------------
+# #465 F5 -- NaN must stay absent (None), never a searchable 0 sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_safe_none_returns_none_for_nan():
+    """The core of F5: an absent reading must come back as None, not 0."""
+    assert _safe_none(float("nan")) is None
+    assert _safe_none(pd.NA) is None
+
+
+def test_safe_none_passes_through_real_values_including_zero():
+    """0 is a real, distinct reading (e.g. a fresh tyre) and must survive."""
+    assert _safe_none(3) == 3
+    assert _safe_none(0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Shared: pull one real row (and its GP-scoped frame) from the parquet
+# ---------------------------------------------------------------------------
+
+
+def _first_row_with_prev_lap_time(year: int = 2025):
+    """One real row from the featured parquet with a resolvable Prev_LapTime.
+
+    Skips the test (rather than failing) when the featured parquet is not
+    available in this environment -- data is fetched from Hugging Face Hub
+    on first run and may be absent here.
+    """
+    df = get_laps_df(year)
+    if df is None:
+        pytest.skip(f"featured parquet for {year} not available in this environment")
+    if "Prev_LapTime" not in df.columns:
+        pytest.skip("featured parquet has no Prev_LapTime column in this environment")
+
+    candidates = df[df["Prev_LapTime"].notna()]
+    if candidates.empty:
+        pytest.skip("no row with a resolvable Prev_LapTime in the featured parquet")
+
+    row = candidates.iloc[0]
+    gp_df = df[df["GP_Name"] == row["GP_Name"]]
+    return row, gp_df
+
+
+def _to_seconds(val) -> float:
+    """Mirror the production helper: accept a raw seconds float or a timedelta."""
+    if hasattr(val, "total_seconds"):
+        return float(val.total_seconds())
+    return float(val)
+
+
+# ---------------------------------------------------------------------------
+# #486 / #435 -- track_temp_start and prev_lap_time must reach lap_state
+# ---------------------------------------------------------------------------
+
+
+def test_build_lap_state_from_row_includes_track_temp_start_and_prev_lap_time():
+    """_build_lap_state_from_row must carry both fields (#486, #435)."""
+    row, gp_df = _first_row_with_prev_lap_time()
+    total_laps = int(gp_df["LapNumber"].max())
+
+    lap_state = _build_lap_state_from_row(row, gp_df, str(row["GP_Name"]), 2025, total_laps)
+
+    assert "track_temp_start" in lap_state["session_meta"]
+    assert "prev_lap_time" in lap_state["driver"]
+
+    # track_temp_start must be the session's chronologically FIRST TrackTemp
+    # reading, not this lap's own value re-served as a constant (#486).
+    expected_start = float(gp_df.sort_values("LapNumber")["TrackTemp"].dropna().iloc[0])
+    assert lap_state["session_meta"]["track_temp_start"] == pytest.approx(expected_start)
+
+    # prev_lap_time must come from the featured parquet's own Prev_LapTime
+    # column, never this lap's own lap_time_s reused as a stand-in (#435).
+    expected_prev = _to_seconds(row["Prev_LapTime"])
+    assert lap_state["driver"]["prev_lap_time"] == pytest.approx(expected_prev)
+
+
+def test_get_lap_state_includes_track_temp_start_and_prev_lap_time():
+    """The /lap-state producer must carry both fields too (#486, #435)."""
+    row, _gp_df = _first_row_with_prev_lap_time()
+    gp, driver, lap = str(row["GP_Name"]), str(row["Driver"]), int(row["LapNumber"])
+
+    state = get_lap_state(gp=gp, driver=driver, lap=lap, year=2025)
+
+    assert "track_temp_start" in state["session_meta"]
+    assert state["session_meta"]["track_temp_start"] is not None
+    assert "prev_lap_time" in state["driver"]
+    expected_prev = _to_seconds(row["Prev_LapTime"])
+    assert state["driver"]["prev_lap_time"] == pytest.approx(expected_prev)
+
+
+# ---------------------------------------------------------------------------
+# #465 F5 (integration) -- get_lap_state must round-trip NaN as None
+# ---------------------------------------------------------------------------
+
+
+def test_get_lap_state_tyre_life_and_speed_st_never_coerced_when_nan():
+    """Cross-check get_lap_state's output against the real source row.
+
+    Whatever this dataset's TyreLife/SpeedST happens to be for the sampled
+    row, the assertion is meaningful either way: a NaN source value must come
+    back as None (the #465 fix); a real value must survive unchanged.
+    """
+    row, _gp_df = _first_row_with_prev_lap_time()
+    gp, driver, lap = str(row["GP_Name"]), str(row["Driver"]), int(row["LapNumber"])
+
+    state = get_lap_state(gp=gp, driver=driver, lap=lap, year=2025)
+    drv = state["driver"]
+
+    src_tyre_life = row.get("TyreLife")
+    if pd.isna(src_tyre_life):
+        assert drv["tyre_life"] is None
+    else:
+        assert drv["tyre_life"] == int(src_tyre_life)
+
+    src_speed_st = row.get("SpeedST")
+    if pd.isna(src_speed_st):
+        assert drv["speed_st"] is None
+    else:
+        assert drv["speed_st"] == pytest.approx(float(src_speed_st))


### PR DESCRIPTION
## What
Harden the strategy-engine backend against the adversarial Fable audit: reject unvalidated MCP tool input, stop coercing NaN positions/telemetry to searchable sentinels, and emit the missing lap-state fields.

## How
- **MCP input** — `_normalize_year`/`_normalize_lap`/`_normalize_driver_code` raise `ToolInputError` instead of silently substituting (year->2025, lap->1, surname->wrong code); a `_catch_tool_input_error` decorator surfaces it as the tool's own REFUSED-style string. `analyze_radio` wires the real radio corpus; `recommend_strategy` threads `pace_delta_s`.
- **lap-state** — `_safe_none` returns `None` on NaN for Position/TyreLife/weather/SpeedST (no more coercion to 0). `simulator`/`race_state_builder` replace dead `.get('position', N)` defaults with explicit is-None handling. Both producers now emit `track_temp_start` and the real `prev_lap_time`; `_elapsed_times_at_lap` guards on row validity.

## Checks
- New no-LLM test `tests/test_strategy_audit_fixes.py` (runs where pandas + fastmcp are present; skips on the lite CI).
- Verifies VforVitorio/F1-StratLab#442, #465, #486, #435. The parent repo bumps this submodule's pointer and closes those issues.

Note: ruff normalized formatting on the touched files (they were previously unformatted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved missing lap, driver, tyre, weather, and speed values instead of replacing them with misleading defaults.
  - Improved gap, pace, position, and race-state handling for incomplete or unresolved lap data.
  - Added previous lap time and starting track temperature to lap details.
  - Improved radio analysis with driver-specific messages and race-control events.
  - Invalid driver, year, and lap inputs now receive clear refusals rather than guessed defaults or errors.

- **Tests**
  - Added regression coverage for missing-value handling, input validation, and enriched lap-state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->