### PR TITLE
fix(strategy): put track_temp_start in the weather channel the consumer reads

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -522,6 +522,10 @@ def get_lap_state(
     weather = {
         "air_temp": _safe_none(r.get("AirTemp")),
         "track_temp": _safe_none(r.get("TrackTemp")),
+        # track_temp_start belongs in weather, not session_meta: the only consumer
+        # (race_situation_agent's track_temp_delta feature) reads wx['track_temp_start'],
+        # so a session_meta-only value silently fell back to 38.0 everywhere (#486).
+        "track_temp_start": _session_track_temp_start(gp_df),
         "humidity": _safe_none(r.get("Humidity")),
         "rainfall": int(_safe(r.get("Rainfall", 0))),
     }
@@ -539,7 +543,6 @@ def get_lap_state(
             "driver": driver,
             "team": driver_dict["team"],
             "total_laps": total_laps,
-            "track_temp_start": _session_track_temp_start(gp_df),
         },
     }
 
@@ -813,6 +816,9 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
         "weather": {
             "air_temp": float(_s(row.get("AirTemp", 25))),
             "track_temp": float(_s(row.get("TrackTemp", 40))),
+            # In weather, not session_meta — the track_temp_delta consumer reads it
+            # from wx, so a session_meta-only value fell back to 38.0 (#486).
+            "track_temp_start": _session_track_temp_start(gp_df),
             "humidity": float(_s(row.get("Humidity", 50))),
             "rainfall": int(_s(row.get("Rainfall", 0))),
         },
@@ -822,7 +828,6 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
             "driver": driver_code,
             "team": str(row.get("Team", "")),
             "total_laps": total_laps,
-            "track_temp_start": _session_track_temp_start(gp_df),
         },
     }
 

--- a/tests/test_strategy_audit_fixes.py
+++ b/tests/test_strategy_audit_fixes.py
@@ -131,13 +131,15 @@ def test_build_lap_state_from_row_includes_track_temp_start_and_prev_lap_time():
 
     lap_state = _build_lap_state_from_row(row, gp_df, str(row["GP_Name"]), 2025, total_laps)
 
-    assert "track_temp_start" in lap_state["session_meta"]
+    # In weather, not session_meta: that is the channel the track_temp_delta
+    # consumer reads (wx['track_temp_start']), so the key must live there (#486).
+    assert "track_temp_start" in lap_state["weather"]
     assert "prev_lap_time" in lap_state["driver"]
 
     # track_temp_start must be the session's chronologically FIRST TrackTemp
     # reading, not this lap's own value re-served as a constant (#486).
     expected_start = float(gp_df.sort_values("LapNumber")["TrackTemp"].dropna().iloc[0])
-    assert lap_state["session_meta"]["track_temp_start"] == pytest.approx(expected_start)
+    assert lap_state["weather"]["track_temp_start"] == pytest.approx(expected_start)
 
     # prev_lap_time must come from the featured parquet's own Prev_LapTime
     # column, never this lap's own lap_time_s reused as a stand-in (#435).
@@ -152,8 +154,8 @@ def test_get_lap_state_includes_track_temp_start_and_prev_lap_time():
 
     state = get_lap_state(gp=gp, driver=driver, lap=lap, year=2025)
 
-    assert "track_temp_start" in state["session_meta"]
-    assert state["session_meta"]["track_temp_start"] is not None
+    assert "track_temp_start" in state["weather"]
+    assert state["weather"]["track_temp_start"] is not None
     assert "prev_lap_time" in state["driver"]
     expected_prev = _to_seconds(row["Prev_LapTime"])
     assert state["driver"]["prev_lap_time"] == pytest.approx(expected_prev)


### PR DESCRIPTION
The earlier audit fix emitted `track_temp_start` into `session_meta`, but the only consumer (race_situation_agent's `track_temp_delta` feature) reads `wx['track_temp_start']` from the **weather** channel — so /situation and /recommend silently kept the 38.0 fallback. Verified against the real parquet (Budapest 2025 starts at 32.3C).

Moves the key into the `weather` dict of both lap-state producers and re-points the tests to the channel the consumer reads. Fixes VforVitorio/F1-StratLab#486 (Finding 6).