### PR TITLE
fix(strategy): stop coercing NaN Position/TyreLife to sentinels in the /pace-range builder

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -791,10 +791,10 @@ def _build_lap_state_from_row(row, gp_df, gp: str, year: int, total_laps: int) -
             "lap_number": lap,
             "lap_time_s": float(_s(row.get("LapTime_s", 0))),
             "prev_lap_time": _prev_lap_time_for_row(row, gp_df, driver_code),
-            "position": int(_s(row.get("Position", 10))),
+            "position": _safe_none(row.get("Position")),
             "compound": str(row.get("Compound", "")),
             "compound_id": int(_s(row.get("CompoundID", 0))),
-            "tyre_life": int(_s(row.get("TyreLife", 0))),
+            "tyre_life": _safe_none(row.get("TyreLife")),
             "stint": int(_s(row.get("Stint", 1))),
             "stint_baseline_tyre_life": _stint_baseline_tyre_life(
                 gp_df,

--- a/tests/test_strategy_audit_fixes.py
+++ b/tests/test_strategy_audit_fixes.py
@@ -190,3 +190,33 @@ def test_get_lap_state_tyre_life_and_speed_st_never_coerced_when_nan():
         assert drv["speed_st"] is None
     else:
         assert drv["speed_st"] == pytest.approx(float(src_speed_st))
+
+
+def test_build_lap_state_from_row_nan_tyre_life_stays_none():
+    """#500: the /pace-range builder must not coerce NaN TyreLife/Position to a
+    searchable sentinel (F5).
+
+    None is safe here: run_from_state or-guards both fields before any arithmetic
+    (pace_agent.py:671/:673), and /lap-state already ships None to the SAME consumer
+    (run_pace_agent_from_state). The Fable audit confirmed None yields an identical,
+    finite prediction to the old 0 sentinel, so this is a contract-honesty fix.
+    """
+    df = get_laps_df(2025)
+    if df is None or "TyreLife" not in df.columns or "Prev_LapTime" not in df.columns:
+        pytest.skip("featured parquet with TyreLife/Prev_LapTime not available")
+
+    # The /pace-range gate (Prev_LapTime >= 60) is what lets a NaN-TyreLife row
+    # actually reach the builder; without it the row is skipped upstream.
+    nan_rows = df[
+        df["TyreLife"].isna() & df["Prev_LapTime"].notna() & (df["Prev_LapTime"] >= 60)
+    ]
+    if nan_rows.empty:
+        pytest.skip("no gate-surviving NaN-TyreLife row in this parquet")
+
+    row = nan_rows.iloc[0]
+    gp_df = df[df["GP_Name"] == row["GP_Name"]]
+    lap_state = _build_lap_state_from_row(
+        row, gp_df, str(row["GP_Name"]), 2025, int(gp_df["LapNumber"].max())
+    )
+    assert lap_state["driver"]["tyre_life"] is None  # not the old 0 sentinel
+    assert lap_state["driver"]["position"] == row["Position"]  # real value untouched


### PR DESCRIPTION
`_build_lap_state_from_row` (feeds /pace-range) coerced NaN Position->10 and NaN TyreLife->0 (class-F5 sentinels). Use `_safe_none` (None on NaN), matching `get_lap_state`'s contract.

A surgical Fable code-trace + a real-XGBoost assertion confirmed it is SAFE: the sole consumer (`run_pace_agent_from_state`) or-guards both fields before any arithmetic (pace_agent.py:671/673), /pace-range wraps each lap in try/except (never a 500), and None yields an IDENTICAL finite prediction to the old sentinel (both collapse to 1 via `or 1`). Zero prediction changes on the 66 live rows; a contract-honesty fix that also stops a NaN Position silently becoming P10. Adds a no-LLM regression test.

Fixes VforVitorio/F1-StratLab#500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing driver position and tyre-life data in strategy information.
  * Prevented unavailable values from being represented as misleading numeric defaults.

* **Tests**
  * Added regression coverage to verify missing tyre-life values remain unavailable while valid driver positions are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->