### PR TITLE
fix(comparison): delta tooltip clarity + track-mode switch transitions

### DIFF
--- a/webapp/src/features/comparison/replay/ChannelPane.tsx
+++ b/webapp/src/features/comparison/replay/ChannelPane.tsx
@@ -100,14 +100,17 @@ export function ChannelPane({
         <h3 className="font-display text-xs font-medium uppercase tracking-wide text-fg-3">
           {label} <span className="normal-case">{unit}</span>
         </h3>
-        <div className="flex items-center gap-3">
-          {showSignKey && (
-            <span className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[10px] text-fg-3">
-              <span style={{ color: chips[1]?.color }}>▲ {pilot2.code} ahead</span>
-              <span className="text-fg-4">·</span>
-              <span style={{ color: chips[0]?.color }}>▼ {pilot1.code} ahead</span>
-            </span>
-          )}
+        {/* Delta pane: the sign key already names BOTH drivers (team-coloured,
+            with ▲/▼ for who's ahead), so it stands alone — showing the chips too
+            overflowed the ~240px header and truncated a code. The line panes
+            show the chips (their traces need a colour→driver legend). */}
+        {showSignKey ? (
+          <span className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[10px] text-fg-3">
+            <span style={{ color: chips[1]?.color }}>▲ {pilot2.code} ahead</span>
+            <span className="text-fg-4">·</span>
+            <span style={{ color: chips[0]?.color }}>▼ {pilot1.code} ahead</span>
+          </span>
+        ) : (
           <span className="flex items-center gap-2">
             {chips.map((chip) => (
               <span
@@ -123,7 +126,7 @@ export function ChannelPane({
               </span>
             ))}
           </span>
-        </div>
+        )}
       </div>
       <div className="relative" style={{ height: CHART_HEIGHT }}>
         <div style={{ pointerEvents: paused ? 'auto' : 'none' }}>

--- a/webapp/src/features/comparison/replay/ReplayTransport.tsx
+++ b/webapp/src/features/comparison/replay/ReplayTransport.tsx
@@ -251,8 +251,13 @@ export function ReplayTransport({
           </Button>
         </Tooltip>
 
-        <Tooltip content="Copy a link to this moment">
-          <Button variant="ghost" size="sm" aria-label="Share this moment" onClick={onShareMoment}>
+        <Tooltip content="Copy a link that reopens the replay paused at this exact moment (adds &t= to the URL)">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Copy a link to this paused moment"
+            onClick={onShareMoment}
+          >
             <Share2 className="size-4" aria-hidden="true" />
           </Button>
         </Tooltip>

--- a/webapp/src/features/comparison/replay/ReplayTransport.tsx
+++ b/webapp/src/features/comparison/replay/ReplayTransport.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Keyboard, Pause, Play, Repeat, RotateCcw, Share2 } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { Tooltip } from '@/components/Tooltip'
@@ -90,8 +90,21 @@ interface SegmentOption<T extends string | number> {
   label: string
 }
 
+/** Position + width of the sliding thumb, in CSS pixels — measured from the
+ *  active button's own box, so content-sized labels ("Dominance" vs "Gain")
+ *  each get an exact-fit pill rather than a fixed-width one. */
+interface ThumbStyle {
+  transform: string
+  width: string
+}
+
 /** Small pressed-state button row — the shared shape behind the speed and
- *  track-mode selectors (see the file banner for why this isn't Radix Tabs). */
+ *  track-mode selectors (see the file banner for why this isn't Radix Tabs).
+ *  T1 (Comparison #36 backlog M7): an absolutely-positioned `bg-purple-600`
+ *  pill slides/resizes under the active button via CSS `transform`+`width`
+ *  instead of the background jumping between buttons — the buttons themselves
+ *  keep only the text-colour swap, which `transition-colors` already
+ *  crossfades in sync with the slide. */
 function SegmentedControl<T extends string | number>({
   value,
   options,
@@ -103,22 +116,71 @@ function SegmentedControl<T extends string | number>({
   ariaLabel: string
   onChange: (next: T) => void
 }) {
+  const groupRef = useRef<HTMLDivElement | null>(null)
+  // Persists across renders without re-triggering the measurement effect —
+  // callback refs below keep it in sync with whichever buttons are mounted.
+  const buttonRefs = useRef(new Map<T, HTMLButtonElement>())
+  const [thumbStyle, setThumbStyle] = useState<ThumbStyle | null>(null)
+
+  // Read fresh by the (stable) measurer below without forcing it to depend on
+  // — and re-create itself whenever — `value` changes.
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  const measureThumb = useCallback(() => {
+    const activeButton = buttonRefs.current.get(valueRef.current)
+    if (!activeButton) return
+    setThumbStyle({
+      transform: `translateX(${activeButton.offsetLeft}px)`,
+      width: `${activeButton.offsetWidth}px`,
+    })
+  }, [])
+
+  // Re-measure whenever the active option (or the option set/labels) changes.
+  // The group div is `relative`, so `offsetLeft` is exactly the thumb's target
+  // translateX (it already accounts for the group's own `p-0.5` padding).
+  useLayoutEffect(() => {
+    measureThumb()
+  }, [value, options, measureThumb])
+
+  // Catches box changes the value/options deps above can't see — a webfont
+  // (JetBrains Mono) finishing its load, or the group's container resizing.
+  useEffect(() => {
+    const group = groupRef.current
+    if (!group) return
+    const observer = new ResizeObserver(measureThumb)
+    observer.observe(group)
+    return () => observer.disconnect()
+  }, [measureThumb])
+
   return (
     <div
+      ref={groupRef}
       role="group"
       aria-label={ariaLabel}
-      className="flex items-center gap-0.5 rounded-lg bg-bg-3 p-0.5"
+      className="relative flex items-center gap-0.5 rounded-lg bg-bg-3 p-0.5"
     >
+      {thumbStyle && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0.5 left-0 z-0 rounded-md bg-purple-600 transition-[transform,width] duration-200 ease-out motion-reduce:transition-none"
+          style={thumbStyle}
+        />
+      )}
       {options.map((option) => (
         <button
           key={option.value}
+          ref={(el) => {
+            if (el) buttonRefs.current.set(option.value, el)
+            else buttonRefs.current.delete(option.value)
+          }}
           type="button"
           aria-pressed={option.value === value}
           onClick={() => onChange(option.value)}
           className={cn(
-            'rounded-md px-2.5 py-1 font-mono text-xs font-medium transition-colors',
+            'relative z-10 rounded-md px-2.5 py-1 font-mono text-xs font-medium transition-colors',
             'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-0 focus-visible:outline-none',
-            option.value === value ? 'bg-purple-600 text-fg-1' : 'text-fg-3 hover:text-fg-2',
+            option.value === value ? 'text-fg-1' : 'text-fg-3 hover:text-fg-2',
           )}
         >
           {option.label}

--- a/webapp/src/features/comparison/replay/TrackCanvas.tsx
+++ b/webapp/src/features/comparison/replay/TrackCanvas.tsx
@@ -15,8 +15,31 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { fitCanvas, type CanvasFit } from '@/features/dashboard/components/circuitDraw'
 import { cn } from '@/lib/cn'
 import { useUiStore } from '@/stores/ui'
-import { computeSpeedRange, drawDynamicLayer, drawStaticLayer } from './trackDraw'
+import {
+  clamp01,
+  computeSpeedRange,
+  drawDynamicLayer,
+  drawStaticLayer,
+  type ModeTransition,
+} from './trackDraw'
 import type { ReplayClock, ReplayModel, TrackMode } from './types'
+
+/** T2 circuit-crossfade window (ms) — the plain mode-to-mode blend. */
+const MODE_TRANSITION_DURATION_MS = 220
+/** T3 dominance draw-on sweep window (ms) — longer than T2 so the feathered
+ *  distance frontier has room to read as a wipe instead of a flash. */
+const DOMINANCE_SWEEP_DURATION_MS = 400
+
+/** One armed mode-switch beat, timestamp-driven (never React state — see the
+ *  file header). `durationMs` is captured at arm time so T2 and T3 can each
+ *  run their own window without sharing one constant; `toDominance` records
+ *  which duration applies (kept alongside for clarity when debugging). */
+interface ArmedModeTransition {
+  fromMode: TrackMode
+  toDominance: boolean
+  startMs: number
+  durationMs: number
+}
 
 export interface TrackCanvasProps {
   model: ReplayModel
@@ -90,6 +113,16 @@ export function TrackCanvas({
   const themeRef = useRef(theme)
   themeRef.current = theme
 
+  // T2/T3 mode-switch beat: the in-flight transition (if any), the previous
+  // trackMode (to detect a real change vs. mount/persisted-mode reload), the
+  // previous model (to detect a fresh comparison), and the self-rAF id that
+  // drives repaints while the clock is paused. All refs — a mode-switch beat
+  // is a per-frame value like the playhead itself, never React state.
+  const modeTransitionRef = useRef<ArmedModeTransition | null>(null)
+  const prevTrackModeRef = useRef<TrackMode | null>(null)
+  const modelRef = useRef(model)
+  const transitionRafRef = useRef<number | null>(null)
+
   // Segments don't change frame-to-frame — scan their speed range once per
   // model instead of on every tick (trackDraw.ts's speed heatmap needs it).
   const speedRange = useMemo(() => computeSpeedRange(model.circuit.segments), [model])
@@ -99,6 +132,21 @@ export function TrackCanvas({
       const fit = fitRef.current
       const dynamicCtx = dynamicCtxRef.current
       if (!fit || !dynamicCtx) return
+
+      // Resolve the armed transition (if any) into this frame's blend amount
+      // purely from wall-clock timestamps — so play/pause mid-transition Just
+      // Works, and a slow/fast tab never skews the blend.
+      let modeTransition: ModeTransition | null = null
+      const transition = modeTransitionRef.current
+      if (transition) {
+        const progress = clamp01((performance.now() - transition.startMs) / transition.durationMs)
+        if (progress >= 1) {
+          modeTransitionRef.current = null
+        } else {
+          modeTransition = { fromMode: transition.fromMode, progress }
+        }
+      }
+
       drawDynamicLayer(
         dynamicCtx,
         model,
@@ -108,10 +156,29 @@ export function TrackCanvas({
         reducedMotionRef.current,
         speedRange,
         themeRef.current,
+        modeTransition,
       )
     },
     [model, speedRange],
   )
+
+  /** Drives repaints while the transition is in flight AND the clock is
+   *  paused (the clock's own subscription already repaints every frame while
+   *  playing — see the arming effect below). `isPlaying()` is checked fresh
+   *  every tick, so play/pause toggling mid-transition never leaves a gap:
+   *  whichever loop is authoritative paints, the other just no-ops. */
+  const startTransitionLoop = useCallback(() => {
+    if (transitionRafRef.current !== null) return // already running
+    const tick = () => {
+      if (modeTransitionRef.current === null) {
+        transitionRafRef.current = null
+        return // finished — stop scheduling
+      }
+      if (!clock.isPlaying()) renderFrame(clock.getTime())
+      transitionRafRef.current = requestAnimationFrame(tick)
+    }
+    transitionRafRef.current = requestAnimationFrame(tick)
+  }, [clock, renderFrame])
 
   // Sizing: measure the container, fit the track's bounds into it, resize
   // both canvases, repaint the static ribbon, and refresh the current frame
@@ -155,12 +222,48 @@ export function TrackCanvas({
   // once the clock ticks again (never, while paused). A theme change also
   // repaints the static ribbon in place (using the already-computed `fit` —
   // no need to remeasure or recreate the ResizeObserver just to swap ink).
+  //
+  // T2/T3: this is also the ONLY place a mode-switch beat gets armed. A REAL
+  // trackMode change (not the first mount, not a persisted-mode reload, not a
+  // reduced-motion session) on the SAME model starts a short crossfade —
+  // dominance-target beats get the longer T3 sweep duration, everything else
+  // gets T2's plain crossfade. A fresh comparison (new model) resets the
+  // "last seen mode" bookkeeping instead of crossfading from the old circuit.
   useEffect(() => {
     const staticCtx = staticCtxRef.current
     const fit = fitRef.current
     if (staticCtx && fit) drawStaticLayer(staticCtx, model, fit, theme)
+
+    const modelChanged = modelRef.current !== model
+    modelRef.current = model
+    if (modelChanged) prevTrackModeRef.current = null
+
+    const prevMode = prevTrackModeRef.current
+    prevTrackModeRef.current = trackMode
+    // `prevMode === null` covers first mount AND the persisted-mode reload
+    // (store.ts persists trackMode — a session that reopens in Speed must
+    // not crossfade on load).
+    if (!modelChanged && prevMode !== null && prevMode !== trackMode && !reducedMotion) {
+      const toDominance = trackMode === 'dominance'
+      modeTransitionRef.current = {
+        fromMode: prevMode,
+        toDominance,
+        startMs: performance.now(),
+        durationMs: toDominance ? DOMINANCE_SWEEP_DURATION_MS : MODE_TRANSITION_DURATION_MS,
+      }
+      startTransitionLoop()
+    }
+
     renderFrame(clock.getTime())
-  }, [trackMode, reducedMotion, theme, model, clock, renderFrame])
+
+    return () => {
+      if (transitionRafRef.current !== null) {
+        cancelAnimationFrame(transitionRafRef.current)
+        transitionRafRef.current = null
+      }
+      modeTransitionRef.current = null
+    }
+  }, [trackMode, reducedMotion, theme, model, clock, renderFrame, startTransitionLoop])
 
   // The one rAF-driven subscription: fires every frame while playing, and on
   // every seek (spec: ReplayClock.subscribe fires on seek too).

--- a/webapp/src/features/comparison/replay/channelOptions.test.ts
+++ b/webapp/src/features/comparison/replay/channelOptions.test.ts
@@ -149,12 +149,27 @@ describe('buildDeltaOption', () => {
     expect(line?.lineStyle?.color).not.toBe('#6c5ce7')
   })
 
-  it('reports the delta value at 3 decimal places in the tooltip (a 3dp verdict, not "0.8")', () => {
+  it('tooltip names the driver AHEAD (team-coloured) + gap at 3dp, ignoring the raw fill series', () => {
     const option = buildDeltaOption(model)
     const tooltip = option.tooltip as { formatter?: (params: unknown) => string }
     const formatter = tooltip.formatter as (params: unknown) => string
-    const html = formatter([{ seriesName: 'Δ', value: [0, 0.831] }])
-    expect(html).toContain('0.831')
+    // delta > 0 ⇒ pilot1 slower ⇒ pilot2 (LEC) ahead. The unnamed sign fills
+    // arrive as "series0"/"series1" on the axis trigger and must NOT leak.
+    const html = formatter([
+      { seriesName: 'series0', value: [0, 0.831] },
+      { seriesName: 'series1', value: [0, 0] },
+      { seriesName: 'Δ', value: [0, 0.831] },
+    ])
+    expect(html).toContain('LEC') // the driver ahead is named
+    expect(html).toContain('0.831') // gap at 3dp
+    expect(html).not.toContain('series0')
+    expect(html).not.toContain('series1')
+  })
+
+  it('tooltip says "Level" when the two cars are within a few thousandths', () => {
+    const option = buildDeltaOption(model)
+    const formatter = (option.tooltip as { formatter: (p: unknown) => string }).formatter
+    expect(formatter([{ seriesName: 'Δ', value: [0, 0.001] }])).toContain('Level')
   })
 })
 

--- a/webapp/src/features/comparison/replay/channelOptions.ts
+++ b/webapp/src/features/comparison/replay/channelOptions.ts
@@ -128,6 +128,45 @@ function buildTooltipFormatter(colorByName: Record<string, string>, decimals: nu
   }
 }
 
+/** Below this |delta| (s) the two cars are level — the tooltip says so instead
+ *  of attributing a lead to whoever is a thousandth ahead. */
+const DELTA_TIE_THRESHOLD = 0.005
+
+/** Delta pane's OWN tooltip: the delta chart is one cross-pilot curve plus two
+ *  zero-anchored sign fills, so the generic per-series formatter above would
+ *  print the unnamed fills as raw "series0 / series1" rows (and never name a
+ *  driver). Instead read the Δ value at the hovered point and render a single
+ *  row naming the driver AHEAD there — team-coloured dot + code + the gap — the
+ *  same convention as the header sign-key and the LiveGapReadout. */
+function buildDeltaTooltipFormatter(
+  p1Code: string,
+  p1Color: string,
+  p2Code: string,
+  p2Color: string,
+) {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
+    const deltaItem = items.find((it) => it.seriesName === 'Δ')
+    if (!deltaItem) return ''
+    const raw = Array.isArray(deltaItem.value)
+      ? deltaItem.value[deltaItem.value.length - 1]
+      : deltaItem.value
+    const delta = typeof raw === 'number' ? raw : 0
+    if (Math.abs(delta) < DELTA_TIE_THRESHOLD) {
+      return `<div style="font-family:${MONO};color:inherit">Level</div>`
+    }
+    // delta > 0 ⇒ pilot1 slower ⇒ pilot2 ahead here.
+    const aheadCode = delta > 0 ? p2Code : p1Code
+    const aheadColor = delta > 0 ? p2Color : p1Color
+    const gap = Math.abs(delta).toFixed(3)
+    return `<div style="display:flex;align-items:center;gap:7px;">
+  <span style="width:8px;height:8px;border-radius:50%;background:${aheadColor};display:inline-block"></span>
+  <span style="color:${aheadColor};font-weight:600">${aheadCode}</span>
+  <span style="font-family:${MONO}">&#9650; +${gap}s</span>
+</div>`
+  }
+}
+
 /** Shared chrome for all 4 panes: tooltip, grid, and the distance x-axis.
  *  Mirrors ChannelChart.tsx's `baseOption`. No in-plot ECharts legend — it
  *  used to sit at `top: 0` inside the grid and collide with the data itself
@@ -257,9 +296,12 @@ export function buildDeltaOption(model: ReplayModel, theme: UiTheme = 'dark'): E
   }
 
   return {
-    // Delta's own legend is hidden (see `baseChannelOption`); the tooltip
-    // colour map keeps a hover over "Δ" legible, at 3dp (see buildTooltipFormatter).
-    ...baseChannelOption(buildTooltipFormatter({ Δ: deltaLineColor }, 3)),
+    // Delta gets its OWN tooltip (names the driver ahead + gap, ignores the
+    // unnamed sign fills) — the generic per-series one would print "series0 /
+    // series1" and never a driver name/colour.
+    ...baseChannelOption(
+      buildDeltaTooltipFormatter(pilot1.code, aheadColor1, pilot2.code, aheadColor2),
+    ),
     series: [
       buildSignFill(points, true, aheadColor2),
       buildSignFill(points, false, aheadColor1),

--- a/webapp/src/features/comparison/replay/trackDraw.test.ts
+++ b/webapp/src/features/comparison/replay/trackDraw.test.ts
@@ -14,6 +14,8 @@ import {
   pickSegmentColor,
   shouldShowGapLink,
   speedHeatColor,
+  sweepFrontier,
+  sweepSegmentAlpha,
   type GainContext,
 } from './trackDraw'
 import type { TrackSegment } from './types'
@@ -167,6 +169,54 @@ describe('pickSegmentColor', () => {
     // implied a "winner" on a stretch that is actually level (Fable UI audit P2).
     const seg = segment({ color: '#abcdef' })
     expect(pickSegmentColor(seg, 'gain', speedRange, gain(0), 'dark')).toBe(NEUTRAL_GAIN_COLOR)
+  })
+})
+
+describe('sweepFrontier', () => {
+  it('starts at 0 at the beginning of the transition window', () => {
+    expect(sweepFrontier(0, 1200)).toBe(0)
+  })
+
+  it('reaches the leader distance at the end of the transition window', () => {
+    expect(sweepFrontier(1, 1200)).toBeCloseTo(1200, 9)
+  })
+
+  it('never outruns the leader distance it is chasing, mid-transition', () => {
+    expect(sweepFrontier(0.5, 1200)).toBeLessThan(1200)
+    expect(sweepFrontier(0.5, 1200)).toBeGreaterThan(0)
+  })
+
+  it('advances monotonically as progress increases', () => {
+    const samples = [0, 0.25, 0.5, 0.75, 1].map((p) => sweepFrontier(p, 1200))
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeGreaterThanOrEqual(samples[i - 1])
+    }
+  })
+})
+
+describe('sweepSegmentAlpha', () => {
+  const FRONTIER = 500
+  const FEATHER = 50
+
+  it('is 0 for a segment the sweep has not reached yet', () => {
+    expect(sweepSegmentAlpha(600, FRONTIER, FEATHER)).toBe(0)
+  })
+
+  it('is 1 for a segment a full feather-width behind the frontier', () => {
+    expect(sweepSegmentAlpha(FRONTIER - FEATHER, FRONTIER, FEATHER)).toBe(1)
+  })
+
+  it('stays clamped at 1 further behind the frontier still', () => {
+    expect(sweepSegmentAlpha(0, FRONTIER, FEATHER)).toBe(1)
+  })
+
+  it('ramps monotonically (non-increasing as distance grows) inside the feather band', () => {
+    const samples = [450, 460, 475, 490, 500].map((endDistance) =>
+      sweepSegmentAlpha(endDistance, FRONTIER, FEATHER),
+    )
+    for (let i = 1; i < samples.length; i++) {
+      expect(samples[i]).toBeLessThanOrEqual(samples[i - 1])
+    }
   })
 })
 

--- a/webapp/src/features/comparison/replay/trackDraw.ts
+++ b/webapp/src/features/comparison/replay/trackDraw.ts
@@ -64,6 +64,16 @@ const GAIN_NEUTRAL_THRESHOLD_S = 1e-3
  *  a genuinely neutral grey, not tuned toward either pilot. */
 export const NEUTRAL_GAIN_COLOR = '#7c8798'
 
+// ── Mode-transition sweep (T3 — dominance draw-on) ──────────────────────────
+
+/** Minimum feather width in metres — floors the soft leading edge so a switch
+ *  right after the start line (small leaderDistance) doesn't collapse the
+ *  sweep into a hard, steppy cut. ~2-3 segment lengths of softness. */
+const SWEEP_FEATHER_MIN_M = 30
+/** Feather as a fraction of the leader's current distance, floored by
+ *  SWEEP_FEATHER_MIN_M above. */
+const SWEEP_FEATHER_RATIO = 0.04
+
 // ── Trails ───────────────────────────────────────────────────────────────────
 
 /** How far back each pilot's racing-line trail extends, in seconds. */
@@ -107,12 +117,19 @@ const MONO_FONT_STACK =
 
 // ── Small numeric helpers ────────────────────────────────────────────────────
 
-function clamp01(value: number): number {
+export function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value))
 }
 
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t
+}
+
+/** `p*p*(3−2p)` — eases 0→1 with a soft entry/exit. Used for the T2 mode-
+ *  switch alpha crossfade: a raw linear alpha ramp reads as a flash at the
+ *  start/end, smoothstep reads as a smooth blend instead. */
+function smoothstep(p: number): number {
+  return p * p * (3 - 2 * p)
 }
 
 function toHexByte(value: number): string {
@@ -163,6 +180,35 @@ export function speedHeatColor(speed: number, min: number, max: number): string 
  *  the COLOUR differs by mode; visibility is the same everywhere). */
 export function isSegmentRevealed(segment: TrackSegment, leaderDistance: number): boolean {
   return segment.endDistance < leaderDistance
+}
+
+/** `1 − (1−p)³` — a fast launch off the start line that settles into the
+ *  target distance. Private to `sweepFrontier` below (T3's dominance
+ *  draw-on) — never used or exported on its own. */
+function easeOutCubic(p: number): number {
+  return 1 - (1 - p) ** 3
+}
+
+/**
+ * Where the T3 "dominance draw-on" sweep has reached along the track, in
+ * metres — an eased fraction of the leader's OWN (growing) distance, so the
+ * frontier can never outrun the leader it's chasing (monotone, no pop, even
+ * while playing). `progress` is the raw (un-eased) 0→1 fraction of the
+ * transition window; the easing lives here rather than in the caller so it
+ * travels with the metre-space math it shapes.
+ */
+export function sweepFrontier(progress: number, leaderDistance: number): number {
+  return easeOutCubic(progress) * leaderDistance
+}
+
+/**
+ * A segment's alpha during the T3 sweep: 0 once fully ahead of the frontier,
+ * 1 once fully behind it (already swept), ramping linearly across `feather`
+ * metres in between — the soft leading edge that reads as a wipe rather than
+ * a hard cut.
+ */
+export function sweepSegmentAlpha(endDistance: number, frontier: number, feather: number): number {
+  return clamp01((frontier - endDistance) / feather)
 }
 
 /**
@@ -282,6 +328,63 @@ export function drawStaticLayer(
   strokeBaseRibbon(ctx, model, fit, theme)
 }
 
+/** A short (T2 ~220ms / T3 ~400ms) mode-switch beat, threaded optionally
+ *  through `drawDynamicLayer` → `drawRevealedSegments`. Pass 1 repaints the
+ *  OUTGOING mode (`fromMode`) at full alpha; pass 2 blends the LIVE mode on
+ *  top. `progress` is the raw 0→1 fraction of the transition window — each
+ *  branch inside `drawRevealedSegments` applies its own easing (`smoothstep`
+ *  for a plain crossfade, `sweepFrontier`'s `easeOutCubic` for the dominance
+ *  sweep), so easing stays a drawing decision rather than something the
+ *  caller has to get right per target mode. */
+export interface ModeTransition {
+  fromMode: TrackMode
+  /** 0→1, raw (un-eased) — see the type-level note above. */
+  progress: number
+}
+
+/** Strokes one revealed segment in the given mode's colour — the shared body
+ *  behind today's single pass AND both T2/T3 transition passes, so a colour
+ *  decision never has to be written (or drift) three times. Caller owns
+ *  `ctx.globalAlpha` before calling this (a uniform crossfade alpha or a
+ *  per-segment sweep alpha, depending on the pass). */
+function strokeSegment(
+  ctx: CanvasRenderingContext2D,
+  model: ReplayModel,
+  segment: TrackSegment,
+  index: number,
+  fit: CanvasFit,
+  mode: TrackMode,
+  speedRange: SpeedRange,
+  theme: CanvasTheme,
+): void {
+  const [pilot1, pilot2] = model.pilots
+  const gain: GainContext = {
+    localGain: localDeltaGain(model.delta, index),
+    pilot1Color: pilot1.color,
+    pilot2Color: pilot2.color,
+  }
+  ctx.strokeStyle = pickSegmentColor(segment, mode, speedRange, gain, theme)
+  ctx.beginPath()
+  const [x1, y1] = fit.toPx(segment.x1, segment.y1)
+  const [x2, y2] = fit.toPx(segment.x2, segment.y2)
+  ctx.moveTo(x1, y1)
+  ctx.lineTo(x2, y2)
+  ctx.stroke()
+}
+
+/**
+ * Draws the progressive dominance/speed/gain reveal. With no `modeTransition`
+ * this is a single pass in the live `trackMode` (today's behaviour, unchanged
+ * — every existing caller keeps working since the param is optional). With
+ * one, it's a two-pass crossfade (T2): pass 1 repaints `fromMode` at full
+ * alpha, pass 2 blends the live `trackMode` on top — identical geometry means
+ * pass 2 progressively COVERS pass 1, reading as a per-segment colour
+ * crossfade with zero hex-string interpolation (both passes reuse
+ * `pickSegmentColor` as-is). When the live mode is `dominance`, pass 2
+ * becomes T3's feathered distance-frontier sweep instead of a uniform alpha —
+ * switching AWAY from dominance stays a plain crossfade (a reverse-wipe would
+ * read as the track emptying, the wrong metaphor).
+ */
 function drawRevealedSegments(
   ctx: CanvasRenderingContext2D,
   model: ReplayModel,
@@ -290,28 +393,53 @@ function drawRevealedSegments(
   trackMode: TrackMode,
   speedRange: SpeedRange,
   theme: CanvasTheme,
+  modeTransition?: ModeTransition | null,
 ): void {
   const segments = model.circuit.segments
-  const [pilot1, pilot2] = model.pilots
   ctx.save()
   ctx.lineWidth = SEGMENT_STROKE_WIDTH_PX
   ctx.lineCap = 'round'
+
+  if (!modeTransition) {
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]
+      if (!isSegmentRevealed(segment, leaderDistance)) continue
+      strokeSegment(ctx, model, segment, i, fit, trackMode, speedRange, theme)
+    }
+    ctx.restore()
+    return
+  }
+
+  // Pass 1 — the outgoing mode, full alpha (exactly today's single-pass draw,
+  // just with `fromMode` instead of the live mode).
+  ctx.globalAlpha = 1
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i]
     if (!isSegmentRevealed(segment, leaderDistance)) continue
-    const gain: GainContext = {
-      localGain: localDeltaGain(model.delta, i),
-      pilot1Color: pilot1.color,
-      pilot2Color: pilot2.color,
-    }
-    ctx.strokeStyle = pickSegmentColor(segment, trackMode, speedRange, gain, theme)
-    ctx.beginPath()
-    const [x1, y1] = fit.toPx(segment.x1, segment.y1)
-    const [x2, y2] = fit.toPx(segment.x2, segment.y2)
-    ctx.moveTo(x1, y1)
-    ctx.lineTo(x2, y2)
-    ctx.stroke()
+    strokeSegment(ctx, model, segment, i, fit, modeTransition.fromMode, speedRange, theme)
   }
+
+  // Pass 2 — the incoming (live) mode, blended on top.
+  if (trackMode === 'dominance') {
+    const frontier = sweepFrontier(modeTransition.progress, leaderDistance)
+    const feather = Math.max(SWEEP_FEATHER_RATIO * leaderDistance, SWEEP_FEATHER_MIN_M)
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]
+      if (!isSegmentRevealed(segment, leaderDistance)) continue
+      const alpha = sweepSegmentAlpha(segment.endDistance, frontier, feather)
+      if (alpha <= 0) continue // not reached by the sweep yet
+      ctx.globalAlpha = alpha
+      strokeSegment(ctx, model, segment, i, fit, trackMode, speedRange, theme)
+    }
+  } else {
+    ctx.globalAlpha = smoothstep(modeTransition.progress)
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]
+      if (!isSegmentRevealed(segment, leaderDistance)) continue
+      strokeSegment(ctx, model, segment, i, fit, trackMode, speedRange, theme)
+    }
+  }
+
   ctx.restore()
 }
 
@@ -445,6 +573,10 @@ function resolvePilotColors(model: ReplayModel, theme: CanvasTheme): [string, st
  * `reducedMotion`), their dots, and the gap-link when they're racing close.
  * `model.frameAt(t)` is resolved exactly once and threaded through every
  * layer below — cheap, but no reason to pay it twice in one frame.
+ *
+ * `modeTransition` (optional, T2/T3) blends `drawRevealedSegments`'s reveal
+ * between two track-colour modes over a short window — see `ModeTransition`.
+ * Every existing caller that omits it keeps today's single-pass draw.
  */
 export function drawDynamicLayer(
   ctx: CanvasRenderingContext2D,
@@ -455,11 +587,21 @@ export function drawDynamicLayer(
   reducedMotion: boolean,
   speedRange: SpeedRange,
   theme: CanvasTheme,
+  modeTransition?: ModeTransition | null,
 ): void {
   clearCanvas(ctx, fit)
   const frame = model.frameAt(t)
   const pilotColors = resolvePilotColors(model, theme)
-  drawRevealedSegments(ctx, model, frame.leaderDistance, fit, trackMode, speedRange, theme)
+  drawRevealedSegments(
+    ctx,
+    model,
+    frame.leaderDistance,
+    fit,
+    trackMode,
+    speedRange,
+    theme,
+    modeTransition,
+  )
   if (!reducedMotion) drawTrails(ctx, model, t, fit, pilotColors)
   drawDots(ctx, model, t, fit, reducedMotion, pilotColors)
   drawGapLink(ctx, model, frame, fit, theme, pilotColors)


### PR DESCRIPTION
Follow-ups to the #36 Comparison tab, from Víctor's review.

## Delta chart clarity (his main ask)
- The delta tooltip used the generic per-series formatter, so it printed the two unnamed sign-fill series as raw **`series0 / series1`** rows and never named a driver. Now it has its OWN tooltip: a single row naming the driver **ahead** at that point — team-coloured dot + code + gap (e.g. `● VER ▲ +0.007s`).
- The delta pane header crammed the sign key **and** the chips into ~240px and truncated a code. Now the delta pane shows only the sign key (which already names both drivers with ▲/▼ + team colour); the line panes keep the chips.
- Share button: clearer tooltip + aria-label — it copies a link that reopens the replay paused at this exact moment (adds `&t=`).

## Track-mode switch transitions (partially addresses #138)
Per a Fable motion design (no new deps, `prefers-reduced-motion` honoured):
- **T1** — the Dominance/Speed/Gain (and speed) segmented control gets a sliding pill (CSS transform+width, 200ms ease-out).
- **T2** — switching modes crossfades the circuit ribbon (220ms two-pass canvas draw, old under new at `globalAlpha=smoothstep(p)`, timestamp-driven; a paused-only rAF drives repaints so it never double-draws vs the one clock).
- **T3** — switching **to** dominance sweeps the microsectors on along the track (feathered distance frontier 0→leaderDistance, 400ms easeOutCubic; never paints ahead of the leader). `sweepFrontier`/`sweepSegmentAlpha` unit-tested.

## Checks
typecheck · oxlint · prettier · **139 vitest** · build — all green. Browser-verified on the real 2025 Japanese GP Q (NOR vs VER), both delta tooltip + all three transitions, 0 console errors.