### PR TITLE
perf(webapp): gzip + lazy route chunks + cached compare Q-load

### DIFF
--- a/backend/api/v1/endpoints/comparison.py
+++ b/backend/api/v1/endpoints/comparison.py
@@ -17,7 +17,7 @@ from backend.services.telemetry_service import (
     get_driver_qualifying_phases
 )
 from backend.core.driver_colors import get_driver_color
-import fastf1
+from backend.services.telemetry.session_cache import get_loaded_session
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +87,12 @@ async def compare_drivers(
         if session == 'Q':
             logger.info("Qualifying session detected - using phase-specific logic")
 
-            # Load session to access phase data
-            fastf1_session = fastf1.get_session(year, gp, session)
-            fastf1_session.load()
+            # Load session to access phase data — via the shared in-process
+            # session cache (same one telemetry_service + prewarmTelemetry use),
+            # not a raw fastf1.get_session().load(): the qualifying path is the
+            # common case, and a raw load here threw away the warm cache and
+            # re-parsed from disk (~10s+), the real cause of the slow cold compare.
+            fastf1_session = get_loaded_session(year, gp, session)
 
             # Get highest common qualifying phase
             highest_phase = get_highest_common_q_phase(

--- a/webapp/nginx.conf
+++ b/webapp/nginx.conf
@@ -17,6 +17,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Compress text responses on the fly. The SPA JS bundle is ~1.9 MB raw but
+    # ~0.6 MB gzipped, and nginx:alpine ships gzip OFF by default — so prod was
+    # shipping the raw bundle. SSE (chat/voice, `text/event-stream`) is NOT in
+    # the type list, so token streaming stays unbuffered/uncompressed.
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_types application/javascript text/css application/json image/svg+xml application/wasm text/plain;
+
     # Hashed build assets can be cached hard.
     location /assets/ {
         expires 1y;

--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -1,14 +1,35 @@
-import { createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  lazyRouteComponent,
+} from '@tanstack/react-router'
 import { Header } from './Header'
 import { Shell } from './Shell'
-import { HomePage } from '@/features/home/HomePage'
-import { ThemePreview } from '@/features/dev/ThemePreview'
-import { DashboardPage } from '@/features/dashboard/DashboardPage'
 import { validateDashboardSearch } from '@/features/dashboard/search'
-import { StrategyPage } from '@/features/strategy/StrategyPage'
 import { validateStrategySearch } from '@/features/strategy/search'
-import { ComparisonPage } from '@/features/comparison/ComparisonPage'
 import { validateComparisonSearch } from '@/features/comparison/search'
+
+// Each feature page is a LAZY route component so the first paint of a light tab
+// (Home) doesn't download every other tab's code — the chart-heavy pages
+// (Dashboard/Strategy/Comparison, all pulling ECharts) split into their own
+// chunks that load on navigation (perf: the app used to ship as one ~1.9MB
+// chunk). `validateSearch` stays eager — it's a tiny sync function the route
+// tree needs at definition time, and importing it doesn't pull the page body.
+const HomePage = lazyRouteComponent(() => import('@/features/home/HomePage'), 'HomePage')
+const DashboardPage = lazyRouteComponent(
+  () => import('@/features/dashboard/DashboardPage'),
+  'DashboardPage',
+)
+const StrategyPage = lazyRouteComponent(
+  () => import('@/features/strategy/StrategyPage'),
+  'StrategyPage',
+)
+const ComparisonPage = lazyRouteComponent(
+  () => import('@/features/comparison/ComparisonPage'),
+  'ComparisonPage',
+)
+const ThemePreview = lazyRouteComponent(() => import('@/features/dev/ThemePreview'), 'ThemePreview')
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
 // content plane, see Shell.tsx); the shell's <Outlet/> renders whichever leaf
@@ -103,7 +124,17 @@ const routeTree = rootRoute.addChildren([
   devThemeRoute,
 ])
 
-export const router = createRouter({ routeTree })
+/** Shown for the brief moment a lazily-loaded page chunk is fetching. Kept
+ *  dependency-free (no heavy loader import) so it can't itself delay the split. */
+function PageFallback() {
+  return (
+    <div className="flex flex-1 items-center justify-center py-24">
+      <span className="size-6 animate-spin rounded-full border-2 border-hairline border-t-accent" />
+    </div>
+  )
+}
+
+export const router = createRouter({ routeTree, defaultPendingComponent: PageFallback })
 
 declare module '@tanstack/react-router' {
   interface Register {


### PR DESCRIPTION
Addresses the 3 highest-impact, lowest-risk items from the webapp efficiency audit (#137).

## What
- **nginx gzip** (`nginx.conf`): nginx:alpine ships gzip OFF, so prod served the raw ~1.9MB JS bundle. Enable gzip → ~0.6MB over the wire (~67% less). SSE excluded by content-type.
- **Route-level code-splitting** (`router.tsx`): every page was imported eagerly, so Home downloaded ALL tabs (one ~1.9MB chunk). Each feature page is now a `lazyRouteComponent` → per-page chunks, and **ECharts (~378KB gzip) splits into its own lazy chunk that loads only on chart pages**. Build now emits HomePage at **5.9kB**; Home's first paint drops ~611KB gzip → ~100KB. Adds a small pending fallback.
- **Backend compare cache** (`comparison.py`): the Q-session path used a raw `fastf1.get_session().load()`, discarding the shared in-process session cache (that `prewarmTelemetry` + `telemetry_service` already warm) and re-parsing from disk — the real cause of the slow cold compare. Now uses `get_loaded_session()`.

## Deferred (stays in #137)
The 4th item — migrating ECharts to `echarts/core` + explicit `use([...])` to tree-shake the lib further — is deliberately NOT in this PR. It's a delicate change across ~7 chart components where a missing component silently breaks a chart at runtime, needing a full all-charts verification pass, for a ~180KB trim on a chunk the route-split **already** made lazy. Worth a focused, separately-verified follow-up.

## Checks
typecheck · oxlint · prettier · **139 vitest** · build green; `py_compile` on the backend change. Browser-verified the Comparison tab still renders through the new lazy route (charts load, delta tooltip intact).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page load performance by loading feature pages only when visited.
  * Added a loading indicator while pages are being loaded.
  * Enabled server-side response compression to reduce transfer sizes.

* **Bug Fixes**
  * Improved qualifying-session comparison handling for more consistent telemetry results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->