### PR TITLE
fix(comparison): team-colour the delta lines + reveal-edge paint animation

### DIFF
--- a/webapp/src/features/comparison/ComparisonPage.tsx
+++ b/webapp/src/features/comparison/ComparisonPage.tsx
@@ -1,6 +1,6 @@
-// Comparison page (#36) — the flagship time-clock replay. Owns the URL search, the
+// Comparison page — the flagship time-clock replay. Owns the URL search, the
 // (explicit, cancellable) compare fetch, the pure replay model, and the ONE clock;
-// children are dumb consumers of `model`/`clock`. The state machine (spec §3):
+// children are dumb consumers of `model`/`clock`. The state machine:
 //   idle       — selection incomplete OR COMPARE not yet armed
 //   comparing  — fetch in flight (staged skeleton, cancellable via AbortController)
 //   error      — 404 (driver/lap not found) or generic, Retry keeps the selection
@@ -8,7 +8,7 @@
 //   playing / paused / finished — the replay lifecycle, driven by the clock
 //
 // The replay card is the ONE glow surface; the toolbar + banner frame it (solid,
-// no glow). Playhead time lives in the clock's ref, never React state (§4.2).
+// no glow). Playhead time lives in the clock's ref, never React state.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
@@ -44,7 +44,7 @@ import {
 
 const routeApi = getRouteApi('/comparison')
 
-/** Matches the OS "reduce motion" preference (spec §4.6: no autoplay/trails). */
+/** Matches the OS "reduce motion" preference (no autoplay/trails). */
 function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false)
   useEffect(() => {
@@ -101,7 +101,7 @@ export function ComparisonPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, comparison.dataUpdatedAt])
 
-  // Keyboard transport, scoped to the focused replay card (dossier #33).
+  // Keyboard transport, scoped to the focused replay card.
   const cardRef = useRef<HTMLDivElement>(null)
   useReplayKeyboard(cardRef, {
     clock,
@@ -116,8 +116,8 @@ export function ComparisonPage() {
   const apiError = comparison.error instanceof ComparisonApiError ? comparison.error : null
   const showError = shouldFetch(search) && comparison.isError
 
-  // Screen-reader announcement of the replay lifecycle (spec §4.4): a keyboard/SR
-  // user pressing Space gets silence otherwise. aria-live fires only on change.
+  // Screen-reader announcement of the replay lifecycle: a keyboard/SR user
+  // pressing Space gets silence otherwise. aria-live fires only on change.
   const replayAnnouncement =
     !model || status === 'ready'
       ? ''

--- a/webapp/src/features/comparison/components/AskAiButton.tsx
+++ b/webapp/src/features/comparison/components/AskAiButton.tsx
@@ -1,6 +1,6 @@
-// "Ask AI about this comparison" entry point (design spec §2 row 15). The
-// chat surface (#39) hasn't landed yet, so this ships disabled with an
-// explanatory tooltip — but the real `/chat` deep-link target is already
+// "Ask AI about this comparison" entry point. The chat surface hasn't landed
+// yet, so this ships disabled with an explanatory tooltip — but the real
+// `/chat` deep-link target is already
 // computed from the current selection, so wiring it up later is a one-line
 // change (drop `disabled`, point the trigger at the router) rather than a
 // redesign.

--- a/webapp/src/features/comparison/components/ComparisonToolbar.tsx
+++ b/webapp/src/features/comparison/components/ComparisonToolbar.tsx
@@ -1,6 +1,6 @@
-// Sticky context bar for the Comparison tab (design spec §3, row 1: "[2024▾]
-// [Monaco GP▾][Q▾][VER✕ LEC✕ ▾(max 2)]  [⚑ fastest laps]  [COMPARE▸]"). Same
-// cascading Year → GP → Session → Drivers grammar as the Dashboard's
+// Sticky context bar for the Comparison tab: "[2024▾][Monaco GP▾][Q▾][VER✕
+// LEC✕ ▾(max 2)]  [⚑ fastest laps]  [COMPARE▸]". Same cascading Year → GP →
+// Session → Drivers grammar as the Dashboard's
 // `SelectorsToolbar`, capped at MAX_DRIVERS=2, plus the "fastest laps only"
 // info chip and the explicit COMPARE action that gates the (expensive) fetch.
 //

--- a/webapp/src/features/comparison/components/ResultBanner.tsx
+++ b/webapp/src/features/comparison/components/ResultBanner.tsx
@@ -1,12 +1,10 @@
-// Calm result banner (design spec §3, row "RESULT BANNER"): the one-glance
-// verdict shown before the replay card even plays. Fable P1 fix (2026-07-19):
-// the original banner typeset the verdict at the same 14px as the lap times
-// ("three identical boxes, no focal point") — now the winner code + gap is
-// the HERO (mono, 24px, semibold, team-coloured), "first by" is demoted to a
-// tracked eyebrow, and both lap times + the microsector tally step down to
-// secondary/tertiary. Hierarchy comes from type, not glow — this stays a
-// resting `Card` (glow is reserved for the single replay card, spec §1/§3).
-// The hero gap also counts up on mount (M2), a tiny rAF loop with no new deps.
+// Calm result banner: the one-glance verdict shown before the replay card even
+// plays. The winner code + gap is the HERO (mono, 24px, semibold,
+// team-coloured), "first by" is a tracked eyebrow, and both lap times + the
+// microsector tally step down to secondary/tertiary — hierarchy comes from
+// type, not glow, so this stays a resting `Card` (glow is reserved for the
+// single replay card). The hero gap also counts up on mount, a tiny rAF loop
+// with no new deps.
 
 import { useEffect, useState } from 'react'
 import { Card } from '@/components/Card'
@@ -34,8 +32,8 @@ function prefersReducedMotion(): boolean {
 
 /**
  * Animates a display value from 0 up to `target` over `durationMs` via
- * requestAnimationFrame (M2 "banner count-up" — the gap number *arrives*
- * instead of popping in flat). Tabular-nums on the caller keeps the digits
+ * requestAnimationFrame — the gap number *arrives* instead of popping in flat.
+ * Tabular-nums on the caller keeps the digits
  * from shifting width mid-count. Resolves straight to `target` under
  * `prefersReducedMotion()`, both for accessibility and so the value is
  * assertable synchronously in tests.

--- a/webapp/src/features/comparison/replay/ChannelGrid.tsx
+++ b/webapp/src/features/comparison/replay/ChannelGrid.tsx
@@ -1,8 +1,8 @@
-// The Comparison replay's 4-channel grid (spec §4.5): Delta, Speed, Brake,
-// Throttle, each a fully static ECharts pane (ChannelPane) with a DOM-overlay
-// playhead. Every chart's option is rebuilt via `useMemo` only on (model,
-// theme) — never on a clock tick; the moving cursor lives entirely in
-// ChannelPane's CursorOverlay/FutureDimmer.
+// The Comparison replay's 4-channel grid: Delta, Speed, Brake, Throttle, each
+// a fully static ECharts pane (ChannelPane) with a DOM-overlay playhead. Every
+// chart's option is rebuilt via `useMemo` only on (model, theme) — never on a
+// clock tick; the moving cursor lives entirely in ChannelPane's
+// CursorOverlay/FutureDimmer.
 
 import { useMemo } from 'react'
 import type { EChartsOption } from 'echarts'
@@ -34,11 +34,10 @@ export interface ChannelGridProps {
 /** 2x2 grid of the 4 channel panes: Delta first (the cross-pilot summary),
  *  then Speed/Brake/Throttle in `LINE_CHANNEL_KEYS` order. */
 export function ChannelGrid({ model, clock, status, className }: ChannelGridProps) {
-  // The app's light/dark mode (not the ECharts theme name) — both the delta
-  // markLine/curve ink and every series' `resolvePilotColor` identity colour
-  // key off this one value (channelOptions.ts stays a pure builder; see its
-  // module docstring). ChannelPane re-applies the registered ECharts theme
-  // separately, via its own theme-keyed remount.
+  // The app's light/dark mode (not the ECharts theme name) — every series'
+  // `resolvePilotColor` identity colour keys off this one value, while
+  // channelOptions.ts stays a pure builder. ChannelPane re-applies the
+  // registered ECharts theme separately, via its own theme-keyed remount.
   const uiTheme = useUiStore((state) => state.theme)
 
   const deltaOption = useMemo(() => buildDeltaOption(model, uiTheme), [model, uiTheme])
@@ -70,7 +69,6 @@ export function ChannelGrid({ model, clock, status, className }: ChannelGridProp
         model={model}
         clock={clock}
         status={status}
-        showSignKey
       />
       {LINE_CHANNEL_KEYS.map((channel) => (
         <ChannelPane

--- a/webapp/src/features/comparison/replay/ChannelPane.tsx
+++ b/webapp/src/features/comparison/replay/ChannelPane.tsx
@@ -1,7 +1,7 @@
 // One channel's chart card: a titled shell hosting a fully static ECharts
-// option (spec §4.5 — `setOption` runs once, at mount, and never again) plus
-// its two DOM-overlay layers, FutureDimmer (painted first, so it sits under)
-// and CursorOverlay (painted after, so its 1px line sits on top).
+// option (`setOption` runs once, at mount, and never again) plus its two
+// DOM-overlay layers, FutureDimmer (painted first, so it sits under) and
+// CursorOverlay (painted after, so its 1px line sits on top).
 //
 // Joins the shared `echarts.connect` crosshair group, mirroring
 // ChannelChart.tsx's CROSSHAIR_GROUP, so once the replay is paused, hovering
@@ -37,8 +37,8 @@ const CROSSHAIR_GROUP = 'comparison-replay-crosshair'
 export interface ChannelPaneProps {
   /** Uppercase-styled channel name, e.g. "Speed", "Delta" — kept separate
    *  from `unit` so the unit's own casing (lowercase "s", "km/h") survives
-   *  the label's `uppercase` styling (P3: "Delta (s)" was rendering as
-   *  "DELTA (S)" because `uppercase` applied to the whole combined title). */
+   *  the label's `uppercase` styling. A combined "Delta (s)" title would
+   *  render as "DELTA (S)" because `uppercase` applies to the whole string. */
   label: string
   /** Parenthesised unit, e.g. "(km/h)", "(s)" — rendered `normal-case`. */
   unit: string
@@ -48,24 +48,12 @@ export interface ChannelPaneProps {
   model: ReplayModel
   clock: ReplayClock
   status: ReplayStatus
-  /** Only the Delta pane sets this: renders a team-coloured sign key
-   *  ("▲ LEC ahead · ▼ VER ahead") in the header so the fill's +/− tinting
-   *  is decodable at a glance (P1 — previously there was no key anywhere). */
-  showSignKey?: boolean
 }
 
 /** One channel of the 4-chart grid: a static ECharts pane inside a titled
  *  card, with its two DOM-overlay layers mounted only once the chart
  *  instance exists (so they can assume a non-null `getChart()`). */
-export function ChannelPane({
-  label,
-  unit,
-  option,
-  model,
-  clock,
-  status,
-  showSignKey,
-}: ChannelPaneProps) {
+export function ChannelPane({ label, unit, option, model, clock, status }: ChannelPaneProps) {
   const chartTheme = useChartTheme()
   const uiTheme = useUiStore((state) => state.theme)
   const chartRef = useRef<ECharts | null>(null)
@@ -100,33 +88,25 @@ export function ChannelPane({
         <h3 className="font-display text-xs font-medium uppercase tracking-wide text-fg-3">
           {label} <span className="normal-case">{unit}</span>
         </h3>
-        {/* Delta pane: the sign key already names BOTH drivers (team-coloured,
-            with ▲/▼ for who's ahead), so it stands alone — showing the chips too
-            overflowed the ~240px header and truncated a code. The line panes
-            show the chips (their traces need a colour→driver legend). */}
-        {showSignKey ? (
-          <span className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[10px] text-fg-3">
-            <span style={{ color: chips[1]?.color }}>▲ {pilot2.code} ahead</span>
-            <span className="text-fg-4">·</span>
-            <span style={{ color: chips[0]?.color }}>▼ {pilot1.code} ahead</span>
-          </span>
-        ) : (
-          <span className="flex items-center gap-2">
-            {chips.map((chip) => (
+        {/* Team-coloured driver chips — the same identity legend on all four
+            panes. The delta pane earns them too now that it draws two
+            team-coloured lines (faster's flat baseline + slower's deficit
+            curve), so identity lives in the data like Speed/Brake/Throttle. */}
+        <span className="flex items-center gap-2">
+          {chips.map((chip) => (
+            <span
+              key={chip.code}
+              className="flex items-center gap-1 font-mono text-[10px] text-fg-3"
+            >
               <span
-                key={chip.code}
-                className="flex items-center gap-1 font-mono text-[10px] text-fg-3"
-              >
-                <span
-                  aria-hidden="true"
-                  className="size-1.5 rounded-full"
-                  style={{ backgroundColor: chip.color }}
-                />
-                {chip.code}
-              </span>
-            ))}
-          </span>
-        )}
+                aria-hidden="true"
+                className="size-1.5 rounded-full"
+                style={{ backgroundColor: chip.color }}
+              />
+              {chip.code}
+            </span>
+          ))}
+        </span>
       </div>
       <div className="relative" style={{ height: CHART_HEIGHT }}>
         <div style={{ pointerEvents: paused ? 'auto' : 'none' }}>

--- a/webapp/src/features/comparison/replay/CursorOverlay.tsx
+++ b/webapp/src/features/comparison/replay/CursorOverlay.tsx
@@ -1,7 +1,7 @@
 // The moving playhead for the channel grid, drawn OUTSIDE ECharts entirely.
-// The 4 charts are fully static (spec §4.5 — `setOption` runs once, at mount,
-// and never again while the clock ticks); the cursor instead lives as a 1px
-// DOM line whose position is a compositor-only `transform: translateX(px)`.
+// The 4 charts are fully static (`setOption` runs once, at mount, and never
+// again while the clock ticks); the cursor instead lives as a 1px DOM line
+// whose position is a compositor-only `transform: translateX(px)`.
 //
 // The distance -> pixel mapping is expensive to recompute (it goes through
 // ECharts' own axis conversion), so it's cached as a plain linear function

--- a/webapp/src/features/comparison/replay/FutureDimmer.tsx
+++ b/webapp/src/features/comparison/replay/FutureDimmer.tsx
@@ -2,8 +2,8 @@
 // and whose right edge sits at the end of the plot — everything to the right
 // of the cursor (what hasn't happened yet on track) reads as dimmed, without
 // touching the chart itself. Same DOM-overlay + cached-mapping strategy as
-// CursorOverlay (spec §4.5): recomputed on chart-ready/resize, moved and
-// resized per frame via `transform`/`width`, never a `setOption`.
+// CursorOverlay: recomputed on chart-ready/resize, moved and resized per frame
+// via `transform`/`width`, never a `setOption`.
 
 import { useEffect, useRef } from 'react'
 import type { ECharts } from 'echarts'
@@ -13,8 +13,8 @@ import type { ReplayClock, ReplayModel, ReplayStatus } from './types'
 // Vertical inset approximating the plot's own reserved chrome (mirrors
 // channelOptions.ts's `GRID.top`, and the axis-label band ECharts'
 // `containLabel: true` reserves at the bottom) so the veil covers the DATA
-// only — the original `inset-y-0` also dimmed the x-axis label row into
-// unreadability (Fable UI audit, P1).
+// only — a plain `inset-y-0` also dims the x-axis label row into
+// unreadability.
 const PLOT_TOP_INSET = 16
 const PLOT_BOTTOM_INSET = 28
 
@@ -22,10 +22,9 @@ export interface FutureDimmerProps {
   model: ReplayModel
   clock: ReplayClock
   /** At `ready` (t=0, nothing has played yet) the veil is invisible — the
-   *  spec's own framing is "a complete static analysis screen", not a dimmed
-   *  one. It fades in over `~250ms` the moment the replay leaves `ready`,
-   *  turning the fix into a designed beat: "the future veils itself when the
-   *  clock starts" (Fable UI audit, P1 / motion idea M4). */
+   *  first frame is a complete static analysis screen, not a dimmed one. It
+   *  fades in over `~250ms` the moment the replay leaves `ready`, so the future
+   *  veils itself when the clock starts. */
   status: ReplayStatus
   /** Resolves the live ECharts instance. The caller (ChannelPane) only mounts
    *  this component once the chart has fired `onChartReady`, so this always

--- a/webapp/src/features/comparison/replay/LiveGapReadout.tsx
+++ b/webapp/src/features/comparison/replay/LiveGapReadout.tsx
@@ -2,18 +2,18 @@ import { useMemo } from 'react'
 import { useReplayTime } from './useReplayClock'
 import type { ReplayClock, ReplayModel, ReplayStatus } from './types'
 
-// Compact "who's ahead, by how much" readout (spec §4.6). While the replay is
-// running or paused mid-lap, this tracks the live on-track leader and gap
-// (`frameAt`); once it finishes, `frameAt`'s live gap has decayed to 0 (both
-// cars share the finish distance), so the frozen `WinnerMeta` — the real
-// lap-time delta — is the number worth showing instead.
+// Compact "who's ahead, by how much" readout. While the replay is running or
+// paused mid-lap, this tracks the live on-track leader and gap (`frameAt`);
+// once it finishes, `frameAt`'s live gap has decayed to 0 (both cars share the
+// finish distance), so the frozen `WinnerMeta` — the real lap-time delta — is
+// the number worth showing instead.
 
 const READOUT_HZ = 10
 
-// Below this on-track separation, calling either car "leader" is a coin-flip
-// tie-break dressed up as a claim (P3: at t=0 the gap is exactly 0, so the
-// old code always named pilot 0 the "leader" of a race that hadn't started).
-const GAP_TIE_THRESHOLD_SECONDS = 0.05
+// Below this on-track separation the cars are genuinely level (mainly t=0, where
+// the gap is exactly 0). A 0.05s gap is a real lead in F1, not a tie; 0.01s is
+// the true "too close to call" floor.
+const GAP_TIE_THRESHOLD_SECONDS = 0.01
 
 export interface LiveGapReadoutProps {
   model: ReplayModel
@@ -59,17 +59,28 @@ export function LiveGapReadout({ model, clock, status }: LiveGapReadoutProps) {
   )
   const isTie = code === null
 
+  // Fixed width + right-justified so the text swapping (leader code ↔ "Level",
+  // gap value ticking) never reflows the transport row — the scrubber sits on
+  // the same flex line and was jittering a pixel as this readout changed size.
   return (
-    <div className="flex items-center gap-2 font-mono text-sm" title="Leader and on-track gap">
+    <div
+      className="flex w-32 shrink-0 items-center justify-end gap-2 font-mono text-sm whitespace-nowrap"
+      title="Leader and on-track gap"
+    >
       <span
         aria-hidden="true"
         className="size-1.5 shrink-0 rounded-full ring-1 ring-inset ring-hairline"
         style={{ backgroundColor: color }}
       />
       <span className="font-medium text-fg-1">{isTie ? 'Level' : code}</span>
-      <span className="tabular-nums text-fg-2">
-        <span aria-hidden="true">{isTie ? '=' : '▲'}</span> {gapText}
-      </span>
+      {/* When level there is no meaningful gap to show — a "Level" with a value
+          next to it reads as a contradiction. Only render the gap when a leader
+          is named. */}
+      {!isTie && (
+        <span className="tabular-nums text-fg-2">
+          <span aria-hidden="true">▲</span> {gapText}
+        </span>
+      )}
     </div>
   )
 }

--- a/webapp/src/features/comparison/replay/ReplayScrubber.tsx
+++ b/webapp/src/features/comparison/replay/ReplayScrubber.tsx
@@ -4,17 +4,17 @@ import { cn } from '@/lib/cn'
 import { useReplayTime } from './useReplayClock'
 import type { ReplayClock } from './types'
 
-// Time-domain scrubber for the replay clock (spec §4.6, dossier #33). Built
-// directly on `@radix-ui/react-slider` rather than the shared `Slider` — the
-// scrubber needs `aria-valuetext` and S1/S2/S3 sector ticks that `Slider`
-// deliberately doesn't support (see Slider.tsx's own comment).
+// Time-domain scrubber for the replay clock. Built directly on
+// `@radix-ui/react-slider` rather than the shared `Slider` — the scrubber needs
+// `aria-valuetext` and S1/S2/S3 sector ticks that `Slider` deliberately doesn't
+// support (see Slider.tsx's own comment).
 //
-// While the user is NOT dragging, the thumb mirrors `useReplayTime` (Worker
-// E's throttled clock mirror, bumped to 30Hz here — smooth enough for a
-// single visual element without re-rendering the whole tree). While
-// dragging, a local `dragTime` state takes over: `onValueChange` seeks the
-// clock live so the redraw is O(1), and playback pauses for the drag,
-// resuming on release only if it was actually playing.
+// While the user is NOT dragging, the thumb mirrors `useReplayTime` (the
+// throttled clock mirror, bumped to 30Hz here — smooth enough for a single
+// visual element without re-rendering the whole tree). While dragging, a local
+// `dragTime` state takes over: `onValueChange` seeks the clock live so the
+// redraw is O(1), and playback pauses for the drag, resuming on release only if
+// it was actually playing.
 
 const SCRUBBER_HZ = 30
 const STEP_SECONDS = 0.05
@@ -31,7 +31,7 @@ export interface ReplayScrubberProps {
   duration: number
   clock: ReplayClock
   /** Sector boundary times (s), for the S1/S2/S3 ticks — placeholder 25/50/75%
-   *  of duration when the model has no official splits (spec §4.6). */
+   *  of duration when the model has no official splits. */
   sectorTimes: number[]
   /** Builds the thumb's `aria-valuetext` for a given elapsed time. */
   ariaValueText: (t: number) => string
@@ -53,7 +53,7 @@ function sectorPercent(sectorTime: number, duration: number): string {
 
 /** Shared hover title for a sector tick/label — honestly discloses that the
  *  split is the 25/50/75%-of-duration placeholder (`buildReplayModel`'s
- *  `sectorTimes`), not an official S1/S2/S3 boundary (P3, spec §4.6). */
+ *  `sectorTimes`), not an official S1/S2/S3 boundary. */
 function sectorTitle(index: number): string {
   return `S${index + 1} split (est.)`
 }

--- a/webapp/src/features/comparison/replay/ReplayTransport.a11y.test.tsx
+++ b/webapp/src/features/comparison/replay/ReplayTransport.a11y.test.tsx
@@ -1,8 +1,8 @@
-// Regression test named after migration dossier #33: in Streamlit the replay's
-// Play control was a canvas element Playwright/axe could not click. The migrated
-// transport must expose Play as a REAL, accessible, enabled HTML button wired to
-// the clock — this asserts that contract at the unit level (the live Playwright
-// run proves it end-to-end; this keeps it from regressing in CI).
+// Regression test for the transport's accessibility contract: in Streamlit the
+// replay's Play control was a canvas element Playwright/axe could not click. The
+// migrated transport must expose Play as a REAL, accessible, enabled HTML button
+// wired to the clock — this asserts that contract at the unit level (the live
+// Playwright run proves it end-to-end; this keeps it from regressing in CI).
 
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
@@ -81,7 +81,7 @@ function renderTransport(clock: ReplayClock) {
   )
 }
 
-describe('dossier #33 — Play is a real, clickable HTML button', () => {
+describe('Play is a real, clickable HTML button', () => {
   it('exposes an enabled Play button with an accessible name', () => {
     renderTransport(fakeClock())
     const play = screen.getByRole('button', { name: /play/i })

--- a/webapp/src/features/comparison/replay/ReplayTransport.tsx
+++ b/webapp/src/features/comparison/replay/ReplayTransport.tsx
@@ -8,11 +8,11 @@ import { ReplayScrubber } from './ReplayScrubber'
 import { LiveGapReadout } from './LiveGapReadout'
 import type { ReplayClock, ReplayModel, ReplayStatus, TrackMode } from './types'
 
-// The "ready" pulse (M3, spec §3: name the primary action without a redesign)
-// follows the same hand-rolled-`@keyframes` + `.f1-anim` convention as
-// Modal/Toast/Tooltip (see Tooltip.tsx's file banner) — `.f1-anim` collapses
-// the animation to ~0 under reduced motion instead of skipping it outright,
-// so `onAnimationEnd` still fires and clears the one-shot state.
+// The "ready" pulse (a one-shot glow that names the primary action) follows the
+// same hand-rolled-`@keyframes` + `.f1-anim` convention as Modal/Toast/Tooltip
+// (see Tooltip.tsx's file banner) — `.f1-anim` collapses the animation to ~0
+// under reduced motion instead of skipping it outright, so `onAnimationEnd`
+// still fires and clears the one-shot state.
 const PLAY_PULSE_KEYFRAMES = `
 @keyframes f1-play-ready-pulse {
   0% { box-shadow: 0 0 0 0 rgba(108, 92, 231, 0.55); }
@@ -24,8 +24,8 @@ const PLAY_PULSE_KEYFRAMES = `
 }
 `
 
-/** Groups controls with intent (P2 "parking lot" fix): tight `gap-1` inside a
- *  cluster, a hairline divider between clusters. */
+/** Groups controls with intent: tight `gap-1` inside a cluster, a hairline
+ *  divider between clusters. */
 const GROUP_CLASSNAME = 'flex items-center gap-1'
 const DIVIDER_CLASSNAME = 'hidden h-6 w-px shrink-0 bg-hairline sm:inline-block'
 
@@ -53,10 +53,10 @@ function KeyboardShortcutsHint() {
   )
 }
 
-// Real HTML transport controls for the replay (spec §4.6, fixes dossier #33 —
-// Playwright/axe must be able to click Play and drive the scrubber directly).
-// Speed and track-mode selectors are hand-rolled button rows rather than
-// Radix `Tabs`: Tabs' roving-tabindex arrow-key navigation would fight
+// Real HTML transport controls for the replay — Playwright/axe must be able to
+// click Play and drive the scrubber directly, so these are real buttons, not
+// clickable divs. Speed and track-mode selectors are hand-rolled button rows
+// rather than Radix `Tabs`: Tabs' roving-tabindex arrow-key navigation would fight
 // `useReplayKeyboard`'s own ←/→ seek shortcut the instant focus lands inside
 // one (both would fire on the same keypress). Plain buttons have no built-in
 // arrow-key behaviour, so there is nothing to collide with.
@@ -100,11 +100,10 @@ interface ThumbStyle {
 
 /** Small pressed-state button row — the shared shape behind the speed and
  *  track-mode selectors (see the file banner for why this isn't Radix Tabs).
- *  T1 (Comparison #36 backlog M7): an absolutely-positioned `bg-purple-600`
- *  pill slides/resizes under the active button via CSS `transform`+`width`
- *  instead of the background jumping between buttons — the buttons themselves
- *  keep only the text-colour swap, which `transition-colors` already
- *  crossfades in sync with the slide. */
+ *  An absolutely-positioned `bg-purple-600` pill slides/resizes under the
+ *  active button via CSS `transform`+`width` instead of the background jumping
+ *  between buttons — the buttons themselves keep only the text-colour swap,
+ *  which `transition-colors` already crossfades in sync with the slide. */
 function SegmentedControl<T extends string | number>({
   value,
   options,
@@ -202,14 +201,13 @@ function buildAriaValueText(model: ReplayModel) {
 
 /**
  * Transport bar for the replay card, grouped with intent rather than one flat
- * row (P2 "parking lot" fix): `[restart · play]` · scrubber · speed · a
- * hairline divider · track-mode · a hairline divider · `[loop · share ·
- * keyboard-hint]` · the live gap readout. Play is the one filled/primary
- * control — everything else is `ghost` — and pulses once the instant the
- * replay first reaches `ready` (M3). Every control is a real HTML `<button>`
- * so Playwright and axe can drive and inspect it directly. Tab order still
- * follows visual (left-to-right) order: restart → play → scrubber → speed →
- * track-mode → loop → share → keyboard-hint (spec §4.6).
+ * row: `[restart · play]` · scrubber · speed · a hairline divider · track-mode
+ * · a hairline divider · `[loop · share · keyboard-hint]` · the live gap
+ * readout. Play is the one filled/primary control — everything else is `ghost`
+ * — and pulses once the instant the replay first reaches `ready`. Every control
+ * is a real HTML `<button>` so Playwright and axe can drive and inspect it
+ * directly. Tab order follows visual (left-to-right) order: restart → play →
+ * scrubber → speed → track-mode → loop → share → keyboard-hint.
  */
 export function ReplayTransport({
   model,
@@ -229,8 +227,8 @@ export function ReplayTransport({
     label: `${s}×`,
   }))
 
-  // One-shot pulse the instant the replay first becomes `ready` (spec §3, M3)
-  // — fires on the ready TRANSITION, not on every render, and self-clears via
+  // One-shot pulse the instant the replay first becomes `ready` — fires on the
+  // ready TRANSITION, not on every render, and self-clears via
   // `onAnimationEnd` so it never replays on a later ready (e.g. a fresh
   // compare remounts this component, so `prevStatusRef` starts `null` again).
   const prevStatusRef = useRef<ReplayStatus | null>(null)

--- a/webapp/src/features/comparison/replay/TrackCanvas.tsx
+++ b/webapp/src/features/comparison/replay/TrackCanvas.tsx
@@ -1,5 +1,5 @@
-// The 60fps track map for the Comparison replay (spec §4.4, issue #36). Two
-// stacked canvases split the work by how often it changes: a STATIC layer
+// The 60fps track map for the Comparison replay. Two stacked canvases split
+// the work by how often it changes: a STATIC layer
 // (the faint grey ribbon) repaints only on resize/model change, and a DYNAMIC
 // layer (dominance reveal, trails, dots, gap-link) repaints every clock tick.
 // Splitting them means the expensive-relative-to-nothing static ribbon never
@@ -24,16 +24,16 @@ import {
 } from './trackDraw'
 import type { ReplayClock, ReplayModel, TrackMode } from './types'
 
-/** T2 circuit-crossfade window (ms) — the plain mode-to-mode blend. */
+/** Circuit-crossfade window (ms) — the plain mode-to-mode blend. */
 const MODE_TRANSITION_DURATION_MS = 220
-/** T3 dominance draw-on sweep window (ms) — longer than T2 so the feathered
- *  distance frontier has room to read as a wipe instead of a flash. */
+/** Dominance draw-on sweep window (ms) — longer than the plain crossfade so the
+ *  feathered distance frontier has room to read as a wipe instead of a flash. */
 const DOMINANCE_SWEEP_DURATION_MS = 400
 
 /** One armed mode-switch beat, timestamp-driven (never React state — see the
- *  file header). `durationMs` is captured at arm time so T2 and T3 can each
- *  run their own window without sharing one constant; `toDominance` records
- *  which duration applies (kept alongside for clarity when debugging). */
+ *  file header). `durationMs` is captured at arm time so the plain crossfade
+ *  and the dominance sweep can each run their own window without sharing one
+ *  constant; `toDominance` records which duration applies. */
 interface ArmedModeTransition {
   fromMode: TrackMode
   toDominance: boolean
@@ -99,9 +99,9 @@ export function TrackCanvas({
   const dynamicCtxRef = useRef<CanvasRenderingContext2D | null>(null)
   const fitRef = useRef<CanvasFit | null>(null)
 
-  // Read internally rather than via a prop (spec: keep TrackCanvasProps
-  // unchanged) — the canvas is the one surface that used to hardcode dark-
-  // theme ink regardless of `data-theme` (Fable UI audit P1).
+  // Read internally rather than via a prop, so TrackCanvasProps stays unchanged
+  // — the canvas is the one surface that used to hardcode dark-theme ink
+  // regardless of light/dark mode.
   const theme = useUiStore((state) => state.theme)
 
   // Latest trackMode/reducedMotion/theme, read fresh inside the rAF-driven
@@ -113,7 +113,7 @@ export function TrackCanvas({
   const themeRef = useRef(theme)
   themeRef.current = theme
 
-  // T2/T3 mode-switch beat: the in-flight transition (if any), the previous
+  // Mode-switch beat: the in-flight transition (if any), the previous
   // trackMode (to detect a real change vs. mount/persisted-mode reload), the
   // previous model (to detect a fresh comparison), and the self-rAF id that
   // drives repaints while the clock is paused. All refs — a mode-switch beat
@@ -223,12 +223,12 @@ export function TrackCanvas({
   // repaints the static ribbon in place (using the already-computed `fit` —
   // no need to remeasure or recreate the ResizeObserver just to swap ink).
   //
-  // T2/T3: this is also the ONLY place a mode-switch beat gets armed. A REAL
+  // This is also the ONLY place a mode-switch beat gets armed. A REAL
   // trackMode change (not the first mount, not a persisted-mode reload, not a
   // reduced-motion session) on the SAME model starts a short crossfade —
-  // dominance-target beats get the longer T3 sweep duration, everything else
-  // gets T2's plain crossfade. A fresh comparison (new model) resets the
-  // "last seen mode" bookkeeping instead of crossfading from the old circuit.
+  // dominance-target beats get the longer sweep duration, everything else gets
+  // the plain crossfade. A fresh comparison (new model) resets the "last seen
+  // mode" bookkeeping instead of crossfading from the old circuit.
   useEffect(() => {
     const staticCtx = staticCtxRef.current
     const fit = fitRef.current

--- a/webapp/src/features/comparison/replay/buildReplayModel.test.ts
+++ b/webapp/src/features/comparison/replay/buildReplayModel.test.ts
@@ -1,12 +1,11 @@
-// Golden-fixture test for the replay math port (spec §6 / #36 acceptance).
+// Golden-fixture test for the replay math port.
 //
 // The fixture is the REAL output of the production Python
 // (comparison_service.prepare_comparison_data) on the only fully-cached offline
 // session: 2023 Monaco GP, Race, VER vs LEC. It carries the exact API `payload`
 // plus a NumPy `reference` for the per-driver time-domain synthesis. We build the
 // TS model from the payload and assert the port reproduces both to 1e-6, pinning
-// buildReplayModel to the thesis-validated maths. Loaded via node:fs so `tsc`
-// never has to infer a 500-element JSON literal type.
+// buildReplayModel to the thesis-validated maths.
 
 import { describe, expect, it } from 'vitest'
 // Vite `?raw` import: the fixture arrives as a plain string (typed by vite/client),
@@ -42,7 +41,7 @@ describe('buildReplayModel — golden fixture (2023 Monaco R, VER vs LEC)', () =
     expect(maxErr).toBeLessThan(TOL)
   })
 
-  it('reproduces both per-driver time syntheses to 1e-6 (spec §4.1)', () => {
+  it('reproduces both per-driver time syntheses to 1e-6', () => {
     const check = (got: Float64Array, want: number[]) => {
       let maxErr = 0
       for (let i = 0; i < want.length; i++) maxErr = Math.max(maxErr, Math.abs(got[i] - want[i]))
@@ -147,11 +146,10 @@ describe('buildReplayModel — synthetic edge cases', () => {
 })
 
 // Adversarial cross-check: the REAL Python (comparison_service.calculate_delta_time
-// + the §4.1 time synthesis) was run on hand-built synthetic telemetry that
-// exercises what the single Monaco fixture cannot — both delta signs, a sign
-// crossing, equal lap times (the scale-to-zero branch), and a near-stopped
-// segment (the epsilon guard). The TS port must reproduce every case to 1e-6.
-// (This is the check the Fable bugs-audit pass was running; completed here.)
+// + the time synthesis) was run on hand-built synthetic telemetry that exercises
+// what the single Monaco fixture cannot — both delta signs, a sign crossing,
+// equal lap times (the scale-to-zero branch), and a near-stopped segment (the
+// epsilon guard). The TS port must reproduce every case to 1e-6.
 interface SyntheticCase {
   name: string
   distance: number[]

--- a/webapp/src/features/comparison/replay/buildReplayModel.ts
+++ b/webapp/src/features/comparison/replay/buildReplayModel.ts
@@ -2,16 +2,16 @@
 // compare payload into the ReplayModel (baked Float32 channels, per-driver
 // time-domain samplers, delta, track geometry, winner) the whole replay renders
 // from. No React, no DOM, no allocation in the per-frame samplers → unit-testable
-// against a Python golden fixture (buildReplayModel.test.ts, spec §6).
+// against a Python golden fixture (buildReplayModel.test.ts).
 //
 // The two ported bits of thesis-validated maths (both from
 // comparison_service.py) and their SIGN/UNIT contracts:
-//   1. Per-driver time synthesis (spec §4.1): tᵢ[k] = Σ Δd/(vᵢ/3.6), then scale
-//      so tᵢ[last] == real lap_time. Units: v is km/h → ÷3.6 = m/s; Δd in m.
+//   1. Per-driver time synthesis: tᵢ[k] = Σ Δd/(vᵢ/3.6), then scale so
+//      tᵢ[last] == real lap_time. Units: v is km/h → ÷3.6 = m/s; Δd in m.
 //   2. Delta (calculate_delta_time): cumsum(t1−t2) scaled by (lap_time1−lap_time2).
-//      POSITIVE = pilot1 SLOWER (the backend docstring is wrong; the math and
-//      spec §6 agree on this sign). We recompute it here so the golden test pins
-//      the port to the backend output to 1e-6 — the app then uses this value.
+//      POSITIVE = pilot1 SLOWER — the backend docstring is wrong; the math is
+//      the source of truth. We recompute it here so the golden test pins the
+//      port to the backend output to 1e-6 — the app then uses this value.
 
 import { interp } from '@/lib/interp'
 import { flipY } from '@/features/dashboard/components/circuitDraw'
@@ -41,7 +41,7 @@ function toF64(a: number[]): Float64Array {
 
 /**
  * Per-driver cumulative elapsed time on the distance grid, scaled to the real
- * lap time (spec §4.1). Strictly increasing for a monotone distance grid with
+ * lap time. Strictly increasing for a monotone distance grid with
  * positive speeds. Returns a length-N array (t[0] = 0, t[last] = lapTime).
  * Float64 — cumulative + lap-scale, so Float32 rounding (~1e-5 s) would show up.
  */

--- a/webapp/src/features/comparison/replay/channelOptions.test.ts
+++ b/webapp/src/features/comparison/replay/channelOptions.test.ts
@@ -1,7 +1,7 @@
 // Pure-function tests for the channel grid's ECharts option builders. No
 // ECharts instance, no React, no canvas — just asserting the shape of the
-// plain objects channelOptions.ts returns (spec §4.5's whole point: these
-// options are built once and never touched imperatively again).
+// plain objects channelOptions.ts returns. These options are built once and
+// never touched imperatively again, which the final test pins.
 
 import type { LineSeriesOption } from 'echarts'
 import { describe, expect, it } from 'vitest'
@@ -52,7 +52,10 @@ function fakeModel(): ReplayModel {
     duration: 90,
     distance: DISTANCE,
     pilots,
-    delta: Float64Array.from([0, 0.2, -0.1, 0.3]),
+    // VER (pilot1/index0) is the winner, so delta (= pilot1 − pilot2) nets
+    // negative and ends at −gapSeconds (VER 1s faster). The oriented delta curve
+    // must therefore end at +gapSeconds.
+    delta: Float64Array.from([0, -0.2, 0.1, -1]),
     circuit: {
       bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
       outline: new Float32Array(),
@@ -105,76 +108,73 @@ describe('buildLineOption', () => {
 
 describe('buildDeltaOption', () => {
   const model = fakeModel()
+  const FASTER = resolvePilotColor(PILOT_1_COLOR, 'dark') // VER (winner)
+  const SLOWER = resolvePilotColor(PILOT_2_COLOR, 'dark') // LEC
 
-  it('has one named delta line (with a dashed y=0 markLine) + two sign fills', () => {
-    const series = buildDeltaOption(model).series as LineSeriesOption[]
-    expect(series).toHaveLength(3)
-    const line = series.find((s) => s.name === 'Δ')
-    expect(line?.markLine?.data).toEqual([{ yAxis: 0 }])
-    // The line carries an explicit colour so it never depends on a visualMap
-    // (which silently dropped the whole series in the browser).
-    expect(line?.lineStyle?.color).toBeTruthy()
+  it('draws two team-coloured lines (faster flat baseline + slower deficit curve), no markLine', () => {
+    const series = buildDeltaOption(model, 'dark').series as LineSeriesOption[]
+    expect(series).toHaveLength(4) // 2 sign fills + faster line + slower line
+    for (const s of series) expect(s.markLine).toBeUndefined()
+
+    const fasterLine = series.find((s) => s.name === 'VER')
+    const slowerLine = series.find((s) => s.name === 'LEC')
+    // Faster = a flat baseline at y=0 in their colour.
+    expect(fasterLine?.lineStyle?.color).toBe(FASTER)
+    const baseline = fasterLine?.data as Array<[number, number]>
+    expect(baseline.every(([, v]) => v === 0)).toBe(true)
+    // Slower = the oriented deficit curve in their colour, ending at +gapSeconds.
+    expect(slowerLine?.lineStyle?.color).toBe(SLOWER)
+    const curve = slowerLine?.data as Array<[number, number]>
+    expect(curve[curve.length - 1][1]).toBeCloseTo(model.winner.gapSeconds, 6)
   })
 
-  it('tints each sign region by the driver AHEAD there, not the one falling behind', () => {
-    // delta[i] > 0 means pilot1 is SLOWER, i.e. pilot2 is ahead — so the
-    // positive fill must carry pilot2's colour and the negative fill
-    // pilot1's (the original build had this inverted: it tinted the
-    // positive/pilot1-slower region in pilot1's OWN colour, glowing the
-    // losing driver's hue — Fable UI audit, P1).
+  it('flips the orientation sign when the winner is pilot2 (curve = raw delta)', () => {
+    const flipped = fakeModel()
+    flipped.delta = Float64Array.from([0, 0.2, -0.1, 1]) // LEC now wins by 1s (pilot1 slower)
+    flipped.winner = { ...flipped.winner, winnerIndex: 1, winnerCode: 'LEC', loserCode: 'VER' }
+    const series = buildDeltaOption(flipped, 'dark').series as LineSeriesOption[]
+    const slowerLine = series.find((s) => s.name === 'VER') // VER is now the slower
+    const curve = slowerLine?.data as Array<[number, number]>
+    // winnerIndex===1 -> sign +1 -> oriented === raw delta.
+    expect(curve[curve.length - 1][1]).toBeCloseTo(1, 6)
+  })
+
+  it('tints the two zero-anchored fills by the driver ahead (above 0 = faster, below = slower), no animation', () => {
     const fills = (buildDeltaOption(model, 'dark').series as LineSeriesOption[]).filter(
       (s) => !s.name,
     )
     expect(fills).toHaveLength(2)
     const [positiveFill, negativeFill] = fills as [LineSeriesOption, LineSeriesOption]
-
-    // Fills clamp to one sign each: positive fill never dips below 0, negative
-    // fill never rises above 0.
-    const positiveData = positiveFill.data as Array<[number, number]>
-    const negativeData = negativeFill.data as Array<[number, number]>
-    expect(positiveData.every(([, v]) => v >= 0)).toBe(true)
-    expect(negativeData.every(([, v]) => v <= 0)).toBe(true)
-
-    expect(positiveFill.areaStyle?.color).toBe(resolvePilotColor(PILOT_2_COLOR, 'dark'))
-    expect(negativeFill.areaStyle?.color).toBe(resolvePilotColor(PILOT_1_COLOR, 'dark'))
-  })
-
-  it('paints the sign fills without an entrance animation, so they never look truncated mid-sweep', () => {
-    const fills = (buildDeltaOption(model).series as LineSeriesOption[]).filter((s) => !s.name)
+    expect((positiveFill.data as Array<[number, number]>).every(([, v]) => v >= 0)).toBe(true)
+    expect((negativeFill.data as Array<[number, number]>).every(([, v]) => v <= 0)).toBe(true)
+    expect(positiveFill.areaStyle?.color).toBe(FASTER)
+    expect(negativeFill.areaStyle?.color).toBe(SLOWER)
     for (const fill of fills) expect(fill.animation).toBe(false)
   })
 
-  it('uses a neutral (non-accent-purple) colour for the delta curve itself', () => {
-    const line = (buildDeltaOption(model).series as LineSeriesOption[]).find((s) => s.name === 'Δ')
-    expect(line?.lineStyle?.color).not.toBe('#6c5ce7')
+  it('tooltip names the driver ahead (faster when curve>0, slower when <0), keyed off the slower series', () => {
+    const formatter = (
+      buildDeltaOption(model, 'dark').tooltip as { formatter: (p: unknown) => string }
+    ).formatter
+    // curve read off the SLOWER's (LEC) series: +0.3 = slower behind -> VER (faster) ahead.
+    const ahead = formatter([{ seriesName: 'LEC', value: [0, 0.3] }])
+    expect(ahead).toContain('VER')
+    expect(ahead).toContain('0.300')
+    // negative -> the slower (LEC) is ahead here.
+    expect(formatter([{ seriesName: 'LEC', value: [0, -0.3] }])).toContain('LEC')
   })
 
-  it('tooltip names the driver AHEAD (team-coloured) + gap at 3dp, ignoring the raw fill series', () => {
-    const option = buildDeltaOption(model)
-    const tooltip = option.tooltip as { formatter?: (params: unknown) => string }
-    const formatter = tooltip.formatter as (params: unknown) => string
-    // delta > 0 ⇒ pilot1 slower ⇒ pilot2 (LEC) ahead. The unnamed sign fills
-    // arrive as "series0"/"series1" on the axis trigger and must NOT leak.
-    const html = formatter([
-      { seriesName: 'series0', value: [0, 0.831] },
-      { seriesName: 'series1', value: [0, 0] },
-      { seriesName: 'Δ', value: [0, 0.831] },
-    ])
-    expect(html).toContain('LEC') // the driver ahead is named
-    expect(html).toContain('0.831') // gap at 3dp
-    expect(html).not.toContain('series0')
-    expect(html).not.toContain('series1')
-  })
-
-  it('tooltip says "Level" when the two cars are within a few thousandths', () => {
-    const option = buildDeltaOption(model)
-    const formatter = (option.tooltip as { formatter: (p: unknown) => string }).formatter
-    expect(formatter([{ seriesName: 'Δ', value: [0, 0.001] }])).toContain('Level')
+  it('tooltip says "Level" only within a thousandth (0.0004), not at a real 0.004 lead', () => {
+    const formatter = (
+      buildDeltaOption(model, 'dark').tooltip as { formatter: (p: unknown) => string }
+    ).formatter
+    expect(formatter([{ seriesName: 'LEC', value: [0, 0.0004] }])).toContain('Level')
+    expect(formatter([{ seriesName: 'LEC', value: [0, 0.004] }])).not.toContain('Level')
   })
 })
 
 describe('channelOptions.ts never calls ECharts imperatively', () => {
-  it('makes no `.setOption(`/`.dispatchAction(` CALL in the source (spec §4.5)', () => {
+  it('makes no `.setOption(`/`.dispatchAction(` CALL in the source', () => {
     // Match method CALLS, not the words in prose — the module's own docstring
     // explains that it never calls setOption, so a bare word match self-trips.
     expect(channelOptionsSource).not.toMatch(/\.(setOption|dispatchAction)\s*\(/)

--- a/webapp/src/features/comparison/replay/channelOptions.ts
+++ b/webapp/src/features/comparison/replay/channelOptions.ts
@@ -2,9 +2,9 @@
 // (Delta, Speed, Brake, Throttle). Each option is built ONCE per (model,
 // theme) — see ChannelGrid's `useMemo` — and never touched again: the moving
 // playhead is a DOM overlay (CursorOverlay/FutureDimmer), never a per-frame
-// `setOption`/`dispatchAction` (spec §4.5). Kept framework- and ECharts-
-// instance-free (plain option objects only) so the shape is unit-testable
-// without mounting a chart — see channelOptions.test.ts.
+// `setOption`/`dispatchAction`. Kept framework- and ECharts-instance-free
+// (plain option objects only) so the shape is unit-testable without mounting
+// a chart — see channelOptions.test.ts.
 //
 // Visual language mirrors the dashboard telemetry grid (ChannelChart.tsx):
 // no symbols, 2px lines, axis-triggered tooltip in team colour, hairline
@@ -31,23 +31,10 @@ const LINE_WIDTH = 2
 const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 const GRID = { top: 16, left: 8, right: 20, bottom: 8, containLabel: true } as const
 
-// Delta's y=0 markLine isn't governed by the registered ECharts theme (same
-// reasoning as ChannelChart.tsx's own MARK_LINE_COLOR_DARK/LIGHT), so its
-// colour is threaded in per the app's current light/dark mode.
-const MARK_LINE_COLOR_DARK = 'rgba(255,255,255,0.35)'
-const MARK_LINE_COLOR_LIGHT = 'rgba(20,18,31,0.35)'
-
-/** The delta CURVE itself — a neutral fg-2 tone (mirrors echartsTheme.ts's own
- *  DARK/LIGHT_PALETTE.fg2), not the brand accent purple: the accent already
- *  means "the moving cursor" (CursorOverlay's `bg-accent` playhead line), and
- *  two unrelated meanings on one hue collide (Fable UI audit, finding P1). The
- *  sign-split fills below carry the driver-identity colour instead. */
-const DELTA_LINE_COLOR_DARK = 'rgba(255,255,255,0.72)'
-const DELTA_LINE_COLOR_LIGHT = 'rgba(20,18,31,0.75)'
-
-/** Area fill under the split-sign delta line — faint enough that the y=0
- *  markLine and the line itself stay the primary read (spec §4.5: "who
- *  gains where" is a background cue, not the headline). */
+/** Area fill under each sign of the delta — faint enough that the two
+ *  team-coloured lines (the faster's flat baseline + the slower's deficit curve)
+ *  stay the primary read. Tinted by the driver AHEAD in that region, so "who
+ *  gains where" reads as a background cue, not the headline. */
 const DELTA_AREA_ALPHA = 0.15
 
 /** One of the 3 plain telemetry channels rendered as a static two-pilot line
@@ -73,7 +60,7 @@ export const LINE_CHANNEL_KEYS: readonly LineChannel[] = ['speed', 'brake', 'thr
 /** "Speed" — the uppercase-styled part of the pane header. Split from the
  *  unit (below) so ChannelPane can render the label `uppercase` while the
  *  unit stays as-typed: CSS `uppercase` on a combined "Speed (km/h)" string
- *  smashed "(s)" into "(S)" (Fable UI audit, P3). */
+ *  would smash "(s)" into "(S)". */
 export function lineChannelLabel(channel: LineChannel): string {
   return LINE_CHANNELS[channel].title
 }
@@ -95,11 +82,10 @@ function toPoints(distance: Float64Array, values: ArrayLike<number>): Array<[num
 }
 
 /** Team colour for a pilot: the payload's own `color` first, `getDriverColor`
- *  only as a fallback for a missing/empty value ("team colours come from the
- *  payload; getDriverColor/getDriverTextColor are fallbacks only"). Exported
- *  so ChannelPane's header chips (P1: team-coloured chips replacing the
- *  in-plot legend) resolve identity colour the same way as the series do,
- *  rather than duplicating the fallback. */
+ *  only as a fallback for a missing/empty value (team colours come from the
+ *  payload; getDriverColor is a fallback only). Exported so ChannelPane's
+ *  team-coloured header chips resolve identity colour the same way as the
+ *  series do, rather than duplicating the fallback. */
 export function pilotColor(pilot: PilotModel, year: number | undefined): string {
   return pilot.color || getDriverColor(pilot.code, year)
 }
@@ -108,8 +94,8 @@ export function pilotColor(pilot: PilotModel, year: number | undefined): string 
  *  the value right-aligned in mono — clones ChannelChart.tsx's
  *  `buildTooltipFormatter`, keyed here by an explicit colour map since this
  *  grid's series names are pilot codes, not arbitrary driver strings.
- *  `decimals` is per-channel (P3): delta reads to 3dp (the verdict itself is
- *  a sub-second gap, e.g. 0.831s — 1dp rounded it to a misleading "0.8"),
+ *  `decimals` is per-channel: delta reads to 3dp (the verdict itself is a
+ *  sub-second gap, e.g. 0.831s — 1dp would round it to a misleading "0.8"),
  *  the plain telemetry channels round to whole units. */
 function buildTooltipFormatter(colorByName: Record<string, string>, decimals: number) {
   return (params: TooltipComponentFormatterCallbackParams): string => {
@@ -128,37 +114,35 @@ function buildTooltipFormatter(colorByName: Record<string, string>, decimals: nu
   }
 }
 
-/** Below this |delta| (s) the two cars are level — the tooltip says so instead
- *  of attributing a lead to whoever is a thousandth ahead. */
-const DELTA_TIE_THRESHOLD = 0.005
+/** "Level" only when the gap, shown to 3dp, would read +0.000. F1 timing
+ *  resolves to a thousandth: a +0.004 lead is a real lead in qualifying, never a
+ *  tie — 0.005 was swallowing gaps the tooltip itself would then display. */
+const DELTA_TIE_THRESHOLD = 0.0005
 
-/** Delta pane's OWN tooltip: the delta chart is one cross-pilot curve plus two
- *  zero-anchored sign fills, so the generic per-series formatter above would
- *  print the unnamed fills as raw "series0 / series1" rows (and never name a
- *  driver). Instead read the Δ value at the hovered point and render a single
- *  row naming the driver AHEAD there — team-coloured dot + code + the gap — the
- *  same convention as the header sign-key and the LiveGapReadout. */
+/** Delta pane's OWN tooltip: the chart is the slower driver's oriented deficit
+ *  curve (positive = slower behind) plus the faster's flat baseline and two sign
+ *  fills, so the generic per-series formatter would print anonymous rows. Read
+ *  the SLOWER's curve value at the hovered point and render a single row naming
+ *  the driver AHEAD there — team-coloured dot + code + gap. */
 function buildDeltaTooltipFormatter(
-  p1Code: string,
-  p1Color: string,
-  p2Code: string,
-  p2Color: string,
+  fasterCode: string,
+  fasterColor: string,
+  slowerCode: string,
+  slowerColor: string,
 ) {
   return (params: TooltipComponentFormatterCallbackParams): string => {
     const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
-    const deltaItem = items.find((it) => it.seriesName === 'Δ')
-    if (!deltaItem) return ''
-    const raw = Array.isArray(deltaItem.value)
-      ? deltaItem.value[deltaItem.value.length - 1]
-      : deltaItem.value
-    const delta = typeof raw === 'number' ? raw : 0
-    if (Math.abs(delta) < DELTA_TIE_THRESHOLD) {
+    const curve = items.find((it) => it.seriesName === slowerCode)
+    if (!curve) return ''
+    const raw = Array.isArray(curve.value) ? curve.value[curve.value.length - 1] : curve.value
+    const v = typeof raw === 'number' ? raw : 0
+    if (Math.abs(v) < DELTA_TIE_THRESHOLD) {
       return `<div style="font-family:${MONO};color:inherit">Level</div>`
     }
-    // delta > 0 ⇒ pilot1 slower ⇒ pilot2 ahead here.
-    const aheadCode = delta > 0 ? p2Code : p1Code
-    const aheadColor = delta > 0 ? p2Color : p1Color
-    const gap = Math.abs(delta).toFixed(3)
+    // oriented curve: positive = the slower is behind here, so the FASTER is ahead.
+    const aheadCode = v > 0 ? fasterCode : slowerCode
+    const aheadColor = v > 0 ? fasterColor : slowerColor
+    const gap = Math.abs(v).toFixed(3)
     return `<div style="display:flex;align-items:center;gap:7px;">
   <span style="width:8px;height:8px;border-radius:50%;background:${aheadColor};display:inline-block"></span>
   <span style="color:${aheadColor};font-weight:600">${aheadCode}</span>
@@ -169,10 +153,9 @@ function buildDeltaTooltipFormatter(
 
 /** Shared chrome for all 4 panes: tooltip, grid, and the distance x-axis.
  *  Mirrors ChannelChart.tsx's `baseOption`. No in-plot ECharts legend — it
- *  used to sit at `top: 0` inside the grid and collide with the data itself
- *  (P1 Fable finding: "VER — LEC" drawn on top of 100% brake/throttle
- *  lines); driver identity now lives in ChannelPane's header chips instead,
- *  one pattern for all 4 panes. */
+ *  would sit at `top: 0` inside the grid and collide with the data itself
+ *  ("VER — LEC" drawn on top of 100% brake/throttle lines); driver identity
+ *  lives in ChannelPane's header chips instead, one pattern for all 4 panes. */
 function baseChannelOption(
   tooltipFormatter: (params: TooltipComponentFormatterCallbackParams) => string,
 ): EChartsOption {
@@ -207,9 +190,9 @@ function baseChannelOption(
 /** One line series per pilot, x = distance, y = the given channel's baked
  *  values, coloured by team. Static — a fresh option per (model, channel,
  *  theme); the caller never calls `setOption` again once it's mounted.
- *  Colours pass through `resolvePilotColor` (P2: a team colour that's too
- *  dark for the dark cards, e.g. Red Bull's navy, otherwise recedes to
- *  near-invisible next to a saturated rival like Ferrari red). */
+ *  Colours pass through `resolvePilotColor` so a team colour that's too dark
+ *  for the dark cards (e.g. Red Bull's navy) is lifted, rather than receding
+ *  to near-invisible next to a saturated rival like Ferrari red. */
 export function buildLineOption(
   model: ReplayModel,
   channel: LineChannel,
@@ -237,14 +220,13 @@ export function buildLineOption(
  *  baseline, not the axis floor. Silent + unnamed so it adds no tooltip row.
  *  `animation: false` — this is a decorative background cue (not the
  *  headline read), so it paints at its full extent immediately rather than
- *  playing ECharts' default left-to-right entrance sweep; that sweep is what
- *  made the fill look like it "terminated early" when captured mid-animation
- *  (Fable UI audit, P2 — the underlying delta data already spans the full
- *  distance grid, see buildReplayModel's `computeDelta`).
+ *  playing ECharts' default left-to-right entrance sweep; that sweep made the
+ *  fill look like it "terminated early" when captured mid-animation, even
+ *  though the delta data already spans the full distance grid.
  *
- *  This replaces a piecewise `visualMap` (spec §4.5's original suggestion),
- *  which in filter mode silently drops the whole line — verified in the browser.
- *  Two explicit fills + a solid line render reliably in both themes. */
+ *  Two explicit sign fills, rather than one line under a piecewise `visualMap`
+ *  — the visualMap in filter mode silently drops the whole line. Two fills + a
+ *  solid line render reliably in both themes. */
 function buildSignFill(
   points: Array<[number, number]>,
   keepPositive: boolean,
@@ -262,50 +244,58 @@ function buildSignFill(
   }
 }
 
-/** The delta chart: a solid delta CURVE (`model.delta`, already scaled to the
- *  real lap-time gap — positive = pilot1 slower, i.e. pilot2 AHEAD there), a
- *  dashed y=0 reference line, and two sign-tinted area fills that show "who
- *  gains where" while stopped. Each fill is tinted by the driver GAINING /
- *  AHEAD in that region, not the one falling behind — the original build
- *  tinted the positive (pilot1-slower) region in pilot1's own colour, i.e.
- *  the pane glowed the LOSING driver's hue with no way to decode + vs −
- *  (Fable UI audit, P1: "the chart contradicts the banner at first glance").
- *  ChannelPane's header sign-key spells out the same convention in words. */
+/** The delta chart, Streamlit-faithful: TWO team-coloured lines — the
+ *  FASTER driver as a flat line at y=0 in their
+ *  colour (the reference baseline), the SLOWER driver as their cumulative
+ *  DEFICIT curve in their colour (positive = behind, negative dips = stretches
+ *  they were actually ahead on cumulative time). Plus the two sign-tinted fills
+ *  (above 0 = faster's colour, below = slower's) as a background "who gains
+ *  where" cue. No neutral curve, no dashed grey markLine — the faster's flat
+ *  team line IS the zero baseline. `model.delta` = pilot1 − pilot2, so the
+ *  slower's curve is `-delta` when the faster is pilot1, `+delta` otherwise; it
+ *  lands exactly on `winner.gapSeconds` at the flag. */
 export function buildDeltaOption(model: ReplayModel, theme: UiTheme = 'dark'): EChartsOption {
-  const [pilot1, pilot2] = model.pilots
-  const markLineColor = theme === 'light' ? MARK_LINE_COLOR_LIGHT : MARK_LINE_COLOR_DARK
-  const deltaLineColor = theme === 'light' ? DELTA_LINE_COLOR_LIGHT : DELTA_LINE_COLOR_DARK
-  const aheadColor1 = resolvePilotColor(pilotColor(pilot1, undefined), theme) // pilot1 AHEAD (delta < 0)
-  const aheadColor2 = resolvePilotColor(pilotColor(pilot2, undefined), theme) // pilot2 AHEAD (delta > 0)
-  const points = toPoints(model.distance, model.delta)
+  const fasterIdx = model.winner.winnerIndex
+  const faster = model.pilots[fasterIdx]
+  const slower = model.pilots[1 - fasterIdx]
+  const fasterColor = resolvePilotColor(pilotColor(faster, undefined), theme)
+  const slowerColor = resolvePilotColor(pilotColor(slower, undefined), theme)
 
-  const line: LineSeriesOption = {
-    name: 'Δ',
+  const sign = fasterIdx === 0 ? -1 : 1
+  const oriented: Array<[number, number]> = Array.from(model.distance, (d, i) => [
+    d,
+    sign * model.delta[i],
+  ])
+  const baseline: Array<[number, number]> = Array.from(model.distance, (d) => [d, 0])
+
+  const fasterLine: LineSeriesOption = {
+    name: faster.code,
     type: 'line',
     showSymbol: false,
-    lineStyle: { width: LINE_WIDTH, color: deltaLineColor },
-    data: points,
-    markLine: {
-      symbol: 'none',
-      silent: true,
-      label: { show: false }, // no stray "0" tag at the line's end
-      lineStyle: { type: 'dashed', color: markLineColor },
-      data: [{ yAxis: 0 }],
-    },
+    lineStyle: { width: LINE_WIDTH, color: fasterColor },
+    itemStyle: { color: fasterColor },
+    data: baseline,
+    z: 2,
+  }
+  const slowerLine: LineSeriesOption = {
+    name: slower.code,
+    type: 'line',
+    showSymbol: false,
+    lineStyle: { width: LINE_WIDTH, color: slowerColor },
+    itemStyle: { color: slowerColor },
+    data: oriented,
     z: 3,
   }
 
   return {
-    // Delta gets its OWN tooltip (names the driver ahead + gap, ignores the
-    // unnamed sign fills) — the generic per-series one would print "series0 /
-    // series1" and never a driver name/colour.
     ...baseChannelOption(
-      buildDeltaTooltipFormatter(pilot1.code, aheadColor1, pilot2.code, aheadColor2),
+      buildDeltaTooltipFormatter(faster.code, fasterColor, slower.code, slowerColor),
     ),
     series: [
-      buildSignFill(points, true, aheadColor2),
-      buildSignFill(points, false, aheadColor1),
-      line,
+      buildSignFill(oriented, true, fasterColor), // above 0: faster ahead
+      buildSignFill(oriented, false, slowerColor), // below 0: slower ahead (their purple stretch)
+      fasterLine,
+      slowerLine,
     ],
   }
 }

--- a/webapp/src/features/comparison/replay/trackDraw.test.ts
+++ b/webapp/src/features/comparison/replay/trackDraw.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for trackDraw.ts's pure helpers only — the predicates and colour
 // mappers that decide WHAT to draw. The actual canvas painting (drawStaticLayer/
 // drawDynamicLayer) is DOM/canvas behaviour with no meaningful jsdom 2D context;
-// it's verified visually instead (screenshot pass), per the worker brief.
+// it's verified visually instead (screenshot pass).
 
 import { describe, expect, it } from 'vitest'
 import { resolvePilotColor } from '@/lib/drivers'
@@ -12,6 +12,7 @@ import {
   localDeltaGain,
   NEUTRAL_GAIN_COLOR,
   pickSegmentColor,
+  revealEdgeIntensity,
   shouldShowGapLink,
   speedHeatColor,
   sweepFrontier,
@@ -137,9 +138,7 @@ describe('pickSegmentColor', () => {
 
   it('dominance mode darkens an over-bright segment colour on the light theme', () => {
     // Same #abcdef is ABOVE the light-theme ceiling, so it needs darkening —
-    // delegated to resolvePilotColor rather than duplicated here (P1 fix +
-    // the audit's nice-to-have: the revealed dominance ribbon was never
-    // theme-checked at all).
+    // delegated to resolvePilotColor rather than duplicated here.
     const seg = segment({ color: '#abcdef' })
     expect(pickSegmentColor(seg, 'dominance', speedRange, gain(0), 'light')).toBe(
       resolvePilotColor('#abcdef', 'light'),
@@ -165,8 +164,8 @@ describe('pickSegmentColor', () => {
   })
 
   it('gain mode falls back to a neutral grey near a dead heat, not the dominance colour', () => {
-    // Previously fell back to the segment's dominance colour, which silently
-    // implied a "winner" on a stretch that is actually level (Fable UI audit P2).
+    // A dominance-colour fallback here would silently imply a "winner" on a
+    // stretch that is actually level.
     const seg = segment({ color: '#abcdef' })
     expect(pickSegmentColor(seg, 'gain', speedRange, gain(0), 'dark')).toBe(NEUTRAL_GAIN_COLOR)
   })
@@ -217,6 +216,27 @@ describe('sweepSegmentAlpha', () => {
     for (let i = 1; i < samples.length; i++) {
       expect(samples[i]).toBeLessThanOrEqual(samples[i - 1])
     }
+  })
+})
+
+describe('revealEdgeIntensity', () => {
+  const WINDOW = 40
+
+  it('peaks at 1 the instant the leader crosses a segment end', () => {
+    expect(revealEdgeIntensity(500, 500, WINDOW)).toBe(1)
+  })
+
+  it('fades to 0 once the leader is a full window ahead', () => {
+    expect(revealEdgeIntensity(500, 540, WINDOW)).toBe(0)
+  })
+
+  it('decays quadratically, so it concentrates at the frontier', () => {
+    // Halfway through the window the linear term is 0.5, squared → 0.25.
+    expect(revealEdgeIntensity(520, 540, WINDOW)).toBeCloseTo(0.25, 9)
+  })
+
+  it('is disabled (0) for a non-positive window, e.g. reduced motion', () => {
+    expect(revealEdgeIntensity(500, 500, 0)).toBe(0)
   })
 })
 

--- a/webapp/src/features/comparison/replay/trackDraw.ts
+++ b/webapp/src/features/comparison/replay/trackDraw.ts
@@ -1,23 +1,22 @@
-// Pure canvas-drawing layer for the Comparison TrackCanvas (spec §4.4). No
-// React here — every function either (a) is a plain, unit-testable predicate/
-// mapper over model data, or (b) paints one layer onto a 2D context the caller
-// already sized and transformed (see TrackCanvas.tsx). Keeping the two apart
-// means the interesting logic (what gets revealed, what colour a segment is,
-// when the gap-link shows) is testable without ever touching a canvas.
+// Pure canvas-drawing layer for the Comparison TrackCanvas. No React here —
+// every function either (a) is a plain, unit-testable predicate/mapper over
+// model data, or (b) paints one layer onto a 2D context the caller already
+// sized and transformed (see TrackCanvas.tsx). Keeping the two apart means the
+// interesting logic (what gets revealed, what colour a segment is, when the
+// gap-link shows) is testable without ever touching a canvas.
 //
 // Coordinate frame: the whole ReplayModel is y-flipped (down = positive, canvas
 // convention) — buildReplayModel flips both TrackGeometry (outline/segments) AND
 // PilotModel.x/y at build time, so dots/trails and the ribbon share one frame.
 // `toPilotPx` is therefore a straight `fit.toPx`, no per-point flip.
 //
-// Theme: `drawStaticLayer`/`drawDynamicLayer` take a `CanvasTheme` so the ONE
-// canvas surface in the app stops being theme-blind (Fable UI audit, Comparison
-// #36, finding P1) — the base ribbon, gap-link and gap label were hardcoded
-// dark-theme ink and became a near-invisible ghost in light mode. Pilot identity
-// colours (dots, trails, gain-mode segment tints, the gap label) are additionally
-// passed through `resolvePilotColor` (P2: a too-dark team colour recedes on the
-// dark cards) — same helper `channelOptions.ts` already uses, so a driver reads
-// with equal visual weight whether they're a chart line or a canvas dot.
+// Theme: `drawStaticLayer`/`drawDynamicLayer` take a `CanvasTheme` so the base
+// ribbon, gap-link and gap label follow light/dark ink instead of a hardcoded
+// dark tone that became a near-invisible ghost in light mode. Pilot identity
+// colours (dots, trails, gain-mode segment tints, the gap label) additionally
+// pass through `resolvePilotColor` so a too-dark team colour is lifted on the
+// dark cards — the same helper `channelOptions.ts` uses, so a driver reads with
+// equal visual weight whether they're a chart line or a canvas dot.
 
 import type { CanvasFit } from '@/features/dashboard/components/circuitDraw'
 import { resolvePilotColor } from '@/lib/drivers'
@@ -31,9 +30,9 @@ export type CanvasTheme = 'dark' | 'light'
 
 // ── Static ribbon ────────────────────────────────────────────────────────────
 
-/** The faint un-revealed course preview, per theme. Dark keeps the original
- *  slate tone; light swaps to ink at a lower alpha — the dark value sat at
- *  ~1.15:1 against a white card (Fable UI audit P1). */
+/** The faint un-revealed course preview, per theme. Dark keeps the slate tone;
+ *  light swaps to ink at a lower alpha, since the dark value sat at ~1.15:1
+ *  against a white card. */
 const BASE_RIBBON_PALETTE: Record<CanvasTheme, { color: string; alpha: number }> = {
   dark: { color: '#94a3b8', alpha: 0.28 },
   light: { color: '#14121f', alpha: 0.25 },
@@ -45,18 +44,17 @@ const BASE_RIBBON_WIDTH_PX = 9
 const SEGMENT_STROKE_WIDTH_PX = 5
 
 /** Slow end of the speed heatmap — a desaturated blue-grey, deliberately NOT a
- *  saturated identity blue: the previous blue(slow)->red(fast) ramp collided
- *  with VER's Red Bull blue and LEC's Ferrari red, so "speed mode" and
- *  "dominance mode" read as the same thing at a glance (Fable UI audit P2). */
+ *  saturated identity blue: a blue(slow)->red(fast) ramp would collide with
+ *  VER's Red Bull blue and LEC's Ferrari red, so "speed mode" and "dominance
+ *  mode" would read as the same thing at a glance. */
 const SPEED_COLOR_SLOW = { r: 100, g: 116, b: 139 } // slate-500
 /** Fast end of the speed heatmap — amber, clear of both team colours above. */
 const SPEED_COLOR_FAST = { r: 245, g: 158, b: 11 } // amber-500
 
 /** Below this local delta-derivative (seconds) a stretch reads as a dead heat.
  *  `gain` mode tints it with `NEUTRAL_GAIN_COLOR` rather than either pilot's
- *  colour, or — as it did before — the segment's dominance colour, which
- *  silently implied a "winner" on ground that is actually level (Fable UI
- *  audit P2). */
+ *  colour — tinting a level stretch with a dominance colour would silently
+ *  imply a "winner" on ground that is actually level. */
 const GAIN_NEUTRAL_THRESHOLD_S = 1e-3
 
 /** Dead-heat tint for `gain` mode. Deliberately mid-luminance (~0.24) so it
@@ -64,7 +62,7 @@ const GAIN_NEUTRAL_THRESHOLD_S = 1e-3
  *  a genuinely neutral grey, not tuned toward either pilot. */
 export const NEUTRAL_GAIN_COLOR = '#7c8798'
 
-// ── Mode-transition sweep (T3 — dominance draw-on) ──────────────────────────
+// ── Mode-transition sweep (dominance draw-on) ───────────────────────────────
 
 /** Minimum feather width in metres — floors the soft leading edge so a switch
  *  right after the start line (small leaderDistance) doesn't collapse the
@@ -73,6 +71,23 @@ const SWEEP_FEATHER_MIN_M = 30
 /** Feather as a fraction of the leader's current distance, floored by
  *  SWEEP_FEATHER_MIN_M above. */
 const SWEEP_FEATHER_RATIO = 0.04
+
+// ── Reveal edge (wet-paint highlight) ────────────────────────────────────────
+
+/** A soft white highlight riding the reveal frontier during play: the moment
+ *  the leader crosses a segment's end it lights up, then fades back to its
+ *  settled colour over the next `windowMeters` of the leader's travel. Reads as
+ *  the dominance/speed/gain colour being "painted on" segment by segment.
+ *  Window = this fraction of the lap, floored by REVEAL_EDGE_MIN_M. */
+const REVEAL_EDGE_RATIO = 0.015
+const REVEAL_EDGE_MIN_M = 40
+/** Peak highlight opacity right at the frontier, per theme — kept low so it
+ *  brightens the fresh segment without washing out its colour. */
+const REVEAL_EDGE_MAX_ALPHA: Record<CanvasTheme, number> = { dark: 0.4, light: 0.25 }
+/** Extra stroke width at the frontier, tapering to 0 with the highlight — a
+ *  touch of swell so the painting edge catches the eye. */
+const REVEAL_EDGE_WIDTH_BOOST_PX = 2
+const REVEAL_EDGE_COLOR = '#ffffff'
 
 // ── Trails ───────────────────────────────────────────────────────────────────
 
@@ -88,7 +103,7 @@ const DOT_RADIUS_PX = 7
 const DOT_RING_WIDTH_PX = 2
 /** Stays white in BOTH themes — the ring frames the fill, which already
  *  carries the (theme-resolved) team colour + glow; the ring itself never
- *  needs to compete for legibility (Fable UI audit P1). */
+ *  needs to compete for legibility. */
 const DOT_RING_COLOR = '#ffffff'
 const DOT_GLOW_BLUR_PX = 14
 /** Breathing amplitude around DOT_GLOW_BLUR_PX (±35%), not an on/off flicker. */
@@ -103,9 +118,9 @@ const DOT_GLOW_PULSE_HZ = 0.8
 const GAP_LINK_THRESHOLD_RATIO = 0.08
 const GAP_LINK_DASH: [number, number] = [5, 4]
 const GAP_LINK_WIDTH_PX = 1.5
-/** Dashed line between the two cars, per theme — the dark value was already
- *  fine; light swaps to an ink-based tone at the same alpha (Fable UI audit
- *  P1: it was invisible-ish on a white card). */
+/** Dashed line between the two cars, per theme — the dark value stays; light
+ *  swaps to an ink-based tone at the same alpha, since the dark one was
+ *  invisible-ish on a white card. */
 const GAP_LINK_COLOR: Record<CanvasTheme, string> = {
   dark: 'rgba(226,232,240,0.7)',
   light: 'rgba(20,18,31,0.7)',
@@ -125,9 +140,9 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t
 }
 
-/** `p*p*(3−2p)` — eases 0→1 with a soft entry/exit. Used for the T2 mode-
- *  switch alpha crossfade: a raw linear alpha ramp reads as a flash at the
- *  start/end, smoothstep reads as a smooth blend instead. */
+/** `p*p*(3−2p)` — eases 0→1 with a soft entry/exit. Used for the mode-switch
+ *  alpha crossfade: a raw linear alpha ramp reads as a flash at the start/end,
+ *  smoothstep reads as a smooth blend instead. */
 function smoothstep(p: number): number {
   return p * p * (3 - 2 * p)
 }
@@ -183,32 +198,49 @@ export function isSegmentRevealed(segment: TrackSegment, leaderDistance: number)
 }
 
 /** `1 − (1−p)³` — a fast launch off the start line that settles into the
- *  target distance. Private to `sweepFrontier` below (T3's dominance
- *  draw-on) — never used or exported on its own. */
+ *  target distance. Private to `sweepFrontier` below (the dominance draw-on) —
+ *  never used or exported on its own. */
 function easeOutCubic(p: number): number {
   return 1 - (1 - p) ** 3
 }
 
 /**
- * Where the T3 "dominance draw-on" sweep has reached along the track, in
- * metres — an eased fraction of the leader's OWN (growing) distance, so the
- * frontier can never outrun the leader it's chasing (monotone, no pop, even
- * while playing). `progress` is the raw (un-eased) 0→1 fraction of the
- * transition window; the easing lives here rather than in the caller so it
- * travels with the metre-space math it shapes.
+ * Where the "dominance draw-on" sweep has reached along the track, in metres —
+ * an eased fraction of the leader's OWN (growing) distance, so the frontier can
+ * never outrun the leader it's chasing (monotone, no pop, even while playing).
+ * `progress` is the raw (un-eased) 0→1 fraction of the transition window; the
+ * easing lives here rather than in the caller so it travels with the
+ * metre-space math it shapes.
  */
 export function sweepFrontier(progress: number, leaderDistance: number): number {
   return easeOutCubic(progress) * leaderDistance
 }
 
 /**
- * A segment's alpha during the T3 sweep: 0 once fully ahead of the frontier,
- * 1 once fully behind it (already swept), ramping linearly across `feather`
- * metres in between — the soft leading edge that reads as a wipe rather than
- * a hard cut.
+ * A segment's alpha during the mode-switch sweep: 0 once fully ahead of the
+ * frontier, 1 once fully behind it (already swept), ramping linearly across
+ * `feather` metres in between — the soft leading edge that reads as a wipe
+ * rather than a hard cut.
  */
 export function sweepSegmentAlpha(endDistance: number, frontier: number, feather: number): number {
   return clamp01((frontier - endDistance) / feather)
+}
+
+/**
+ * How brightly the reveal-edge highlight sits on a segment: 1 the instant the
+ * leader crosses its end, fading to 0 over `windowMeters` of leader travel.
+ * Squared so the glow concentrates right at the frontier and tapers gently
+ * behind it. Returns 0 for a non-positive window (reduced motion, or a
+ * degenerate track) so callers can gate the whole highlight on one value.
+ */
+export function revealEdgeIntensity(
+  segmentEndDistance: number,
+  leaderDistance: number,
+  windowMeters: number,
+): number {
+  if (windowMeters <= 0) return 0
+  const linear = clamp01(1 - (leaderDistance - segmentEndDistance) / windowMeters)
+  return linear * linear
 }
 
 /**
@@ -231,8 +263,7 @@ export function shouldShowGapLink(separationMeters: number, trackLengthMeters: n
 
 /** On-track gap-link label: the leader's code + the on-track time gap — e.g.
  *  "LEC ▲ +0.15s" — so the canvas agrees with the transport's own readout
- *  ("● LEC ▲ 0.15s") instead of showing an unattributed "▲ +0.15s" (Fable UI
- *  audit P3). */
+ *  ("● LEC ▲ 0.15s") instead of showing an unattributed "▲ +0.15s". */
 export function buildGapLabel(leaderCode: string, gapSeconds: number): string {
   return `${leaderCode} ▲ +${gapSeconds.toFixed(2)}s`
 }
@@ -328,22 +359,39 @@ export function drawStaticLayer(
   strokeBaseRibbon(ctx, model, fit, theme)
 }
 
-/** A short (T2 ~220ms / T3 ~400ms) mode-switch beat, threaded optionally
- *  through `drawDynamicLayer` → `drawRevealedSegments`. Pass 1 repaints the
- *  OUTGOING mode (`fromMode`) at full alpha; pass 2 blends the LIVE mode on
- *  top. `progress` is the raw 0→1 fraction of the transition window — each
- *  branch inside `drawRevealedSegments` applies its own easing (`smoothstep`
- *  for a plain crossfade, `sweepFrontier`'s `easeOutCubic` for the dominance
- *  sweep), so easing stays a drawing decision rather than something the
- *  caller has to get right per target mode. */
+/** A short (~220ms plain crossfade / ~400ms dominance sweep) mode-switch beat,
+ *  threaded optionally through `drawDynamicLayer` → `drawRevealedSegments`.
+ *  Pass 1 repaints the OUTGOING mode (`fromMode`) at full alpha; pass 2 blends
+ *  the LIVE mode on top. `progress` is the raw 0→1 fraction of the transition
+ *  window — each branch inside `drawRevealedSegments` applies its own easing
+ *  (`smoothstep` for a plain crossfade, `sweepFrontier`'s `easeOutCubic` for
+ *  the dominance sweep), so easing stays a drawing decision rather than
+ *  something the caller has to get right per target mode. */
 export interface ModeTransition {
   fromMode: TrackMode
   /** 0→1, raw (un-eased) — see the type-level note above. */
   progress: number
 }
 
+/** The raw path stroke for one segment — moveTo/lineTo/stroke in the current
+ *  `ctx.strokeStyle`/`lineWidth`. Shared by `strokeSegment` (which sets the
+ *  colour first) and the reveal-edge highlight (which re-strokes an
+ *  already-coloured segment in white). */
+function strokeSegmentPath(
+  ctx: CanvasRenderingContext2D,
+  segment: TrackSegment,
+  fit: CanvasFit,
+): void {
+  ctx.beginPath()
+  const [x1, y1] = fit.toPx(segment.x1, segment.y1)
+  const [x2, y2] = fit.toPx(segment.x2, segment.y2)
+  ctx.moveTo(x1, y1)
+  ctx.lineTo(x2, y2)
+  ctx.stroke()
+}
+
 /** Strokes one revealed segment in the given mode's colour — the shared body
- *  behind today's single pass AND both T2/T3 transition passes, so a colour
+ *  behind the single live pass AND both transition passes, so a colour
  *  decision never has to be written (or drift) three times. Caller owns
  *  `ctx.globalAlpha` before calling this (a uniform crossfade alpha or a
  *  per-segment sweep alpha, depending on the pass). */
@@ -364,26 +412,54 @@ function strokeSegment(
     pilot2Color: pilot2.color,
   }
   ctx.strokeStyle = pickSegmentColor(segment, mode, speedRange, gain, theme)
-  ctx.beginPath()
-  const [x1, y1] = fit.toPx(segment.x1, segment.y1)
-  const [x2, y2] = fit.toPx(segment.x2, segment.y2)
-  ctx.moveTo(x1, y1)
-  ctx.lineTo(x2, y2)
-  ctx.stroke()
+  strokeSegmentPath(ctx, segment, fit)
+}
+
+/**
+ * The wet-paint highlight: re-strokes the segments just behind the reveal
+ * frontier in translucent white, brightest at the leader and fading over
+ * `windowMeters`. Walks back from the last revealed segment and stops at the
+ * first one the window no longer reaches (segments are distance-ordered, so
+ * everything earlier is fainter still). A no-op when `windowMeters <= 0` or
+ * nothing is revealed yet. Caller has already painted the settled colours.
+ */
+function drawRevealEdge(
+  ctx: CanvasRenderingContext2D,
+  segments: TrackSegment[],
+  lastRevealed: number,
+  leaderDistance: number,
+  windowMeters: number,
+  fit: CanvasFit,
+  theme: CanvasTheme,
+): void {
+  if (windowMeters <= 0 || lastRevealed < 0) return
+  ctx.save()
+  ctx.strokeStyle = REVEAL_EDGE_COLOR
+  ctx.lineCap = 'round'
+  const maxAlpha = REVEAL_EDGE_MAX_ALPHA[theme]
+  for (let i = lastRevealed; i >= 0; i--) {
+    const intensity = revealEdgeIntensity(segments[i].endDistance, leaderDistance, windowMeters)
+    if (intensity <= 0) break
+    ctx.globalAlpha = maxAlpha * intensity
+    ctx.lineWidth = SEGMENT_STROKE_WIDTH_PX + REVEAL_EDGE_WIDTH_BOOST_PX * intensity
+    strokeSegmentPath(ctx, segments[i], fit)
+  }
+  ctx.restore()
 }
 
 /**
  * Draws the progressive dominance/speed/gain reveal. With no `modeTransition`
- * this is a single pass in the live `trackMode` (today's behaviour, unchanged
- * — every existing caller keeps working since the param is optional). With
- * one, it's a two-pass crossfade (T2): pass 1 repaints `fromMode` at full
- * alpha, pass 2 blends the live `trackMode` on top — identical geometry means
- * pass 2 progressively COVERS pass 1, reading as a per-segment colour
- * crossfade with zero hex-string interpolation (both passes reuse
- * `pickSegmentColor` as-is). When the live mode is `dominance`, pass 2
- * becomes T3's feathered distance-frontier sweep instead of a uniform alpha —
+ * this is a single pass in the live `trackMode`, followed by the reveal-edge
+ * highlight riding the frontier (skipped when `edgeWindowMeters <= 0`, e.g.
+ * reduced motion). With a transition it's a two-pass crossfade: pass 1 repaints
+ * `fromMode` at full alpha, pass 2 blends the live `trackMode` on top —
+ * identical geometry means pass 2 progressively COVERS pass 1, reading as a
+ * per-segment colour crossfade with zero hex-string interpolation (both passes
+ * reuse `pickSegmentColor` as-is). When the live mode is `dominance`, pass 2
+ * becomes the feathered distance-frontier sweep instead of a uniform alpha —
  * switching AWAY from dominance stays a plain crossfade (a reverse-wipe would
- * read as the track emptying, the wrong metaphor).
+ * read as the track emptying, the wrong metaphor). The reveal-edge highlight is
+ * skipped mid-transition so the two effects never fight.
  */
 function drawRevealedSegments(
   ctx: CanvasRenderingContext2D,
@@ -394,6 +470,7 @@ function drawRevealedSegments(
   speedRange: SpeedRange,
   theme: CanvasTheme,
   modeTransition?: ModeTransition | null,
+  edgeWindowMeters = 0,
 ): void {
   const segments = model.circuit.segments
   ctx.save()
@@ -401,11 +478,14 @@ function drawRevealedSegments(
   ctx.lineCap = 'round'
 
   if (!modeTransition) {
+    let lastRevealed = -1
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i]
       if (!isSegmentRevealed(segment, leaderDistance)) continue
       strokeSegment(ctx, model, segment, i, fit, trackMode, speedRange, theme)
+      lastRevealed = i
     }
+    drawRevealEdge(ctx, segments, lastRevealed, leaderDistance, edgeWindowMeters, fit, theme)
     ctx.restore()
     return
   }
@@ -552,7 +632,7 @@ function drawGapLink(
   const label = buildGapLabel(leaderCode, frame.gapSeconds)
   ctx.save()
   ctx.font = `${GAP_LABEL_FONT_SIZE_PX}px ${MONO_FONT_STACK}`
-  ctx.fillStyle = pilotColors[frame.leaderIndex] // attributes the label to the leader (P3)
+  ctx.fillStyle = pilotColors[frame.leaderIndex] // attributes the label to the leader
   ctx.textAlign = 'center'
   ctx.textBaseline = 'bottom'
   ctx.fillText(label, midX, midY - GAP_LABEL_OFFSET_PX)
@@ -561,7 +641,7 @@ function drawGapLink(
 
 /** Both pilots' identity colour, resolved once per frame for the given theme —
  *  shared by the dots, the trails, and the gap label so a driver's colour
- *  never drifts between the three (Fable UI audit P2). */
+ *  never drifts between the three. */
 function resolvePilotColors(model: ReplayModel, theme: CanvasTheme): [string, string] {
   const [pilot1, pilot2] = model.pilots
   return [resolvePilotColor(pilot1.color, theme), resolvePilotColor(pilot2.color, theme)]
@@ -574,9 +654,11 @@ function resolvePilotColors(model: ReplayModel, theme: CanvasTheme): [string, st
  * `model.frameAt(t)` is resolved exactly once and threaded through every
  * layer below — cheap, but no reason to pay it twice in one frame.
  *
- * `modeTransition` (optional, T2/T3) blends `drawRevealedSegments`'s reveal
- * between two track-colour modes over a short window — see `ModeTransition`.
- * Every existing caller that omits it keeps today's single-pass draw.
+ * `modeTransition` (optional) blends `drawRevealedSegments`'s reveal between
+ * two track-colour modes over a short window — see `ModeTransition`. Callers
+ * that omit it get the single-pass draw plus the reveal-edge highlight, whose
+ * window scales with the lap length (and collapses to nothing under
+ * `reducedMotion`, disabling the highlight).
  */
 export function drawDynamicLayer(
   ctx: CanvasRenderingContext2D,
@@ -592,6 +674,10 @@ export function drawDynamicLayer(
   clearCanvas(ctx, fit)
   const frame = model.frameAt(t)
   const pilotColors = resolvePilotColors(model, theme)
+  const trackLength = model.distance[model.distance.length - 1]
+  const edgeWindowMeters = reducedMotion
+    ? 0
+    : Math.max(REVEAL_EDGE_RATIO * trackLength, REVEAL_EDGE_MIN_M)
   drawRevealedSegments(
     ctx,
     model,
@@ -601,6 +687,7 @@ export function drawDynamicLayer(
     speedRange,
     theme,
     modeTransition,
+    edgeWindowMeters,
   )
   if (!reducedMotion) drawTrails(ctx, model, t, fit, pilotColors)
   drawDots(ctx, model, t, fit, reducedMotion, pilotColors)

--- a/webapp/src/features/comparison/replay/types.ts
+++ b/webapp/src/features/comparison/replay/types.ts
@@ -1,12 +1,12 @@
-// Frozen cross-worker contracts for the Comparison replay engine. buildReplayModel
+// Frozen cross-module contracts for the Comparison replay engine. buildReplayModel
 // produces the ReplayModel (pure, unit-tested); the clock, canvas, channel grid,
 // transport and readouts all consume THESE types — nothing imports another
-// worker's component. Keep this file free of React and of comparison-specific UI
-// so `useReplayClock` + `ReplayTransport` stay reusable seams (spec §5).
+// module's component. Keep this file free of React and of comparison-specific UI
+// so `useReplayClock` + `ReplayTransport` stay reusable seams.
 
 import type { ComparisonMetadata } from '@/lib/api/comparison'
 
-/** Track colour mode (spec §7 rank 2). `dominance` = microsector parity. */
+/** Track colour mode. `dominance` = microsector parity. */
 export type TrackMode = 'dominance' | 'speed' | 'gain'
 
 /** Replay lifecycle inside a loaded comparison (page adds idle/comparing/error). */
@@ -14,7 +14,7 @@ export type ReplayStatus = 'ready' | 'playing' | 'paused' | 'finished'
 
 /** One driver, baked to Float32Arrays with time-domain samplers. All arrays share
  *  the common 500-pt distance grid; `timeAtDistance` is strictly increasing and
- *  scaled to the real lap time (spec §4.1). */
+ *  scaled to the real lap time. */
 export interface PilotModel {
   code: string
   name: string
@@ -102,7 +102,7 @@ export interface ReplayModel {
   /** Shared distance grid (m). */
   distance: Float64Array
   pilots: [PilotModel, PilotModel]
-  /** Speed-integrated, lap-time-scaled delta; + = pilot1 slower (spec §6). */
+  /** Speed-integrated, lap-time-scaled delta; + = pilot1 slower. */
   delta: Float64Array
   circuit: TrackGeometry
   /** Microsectors won: [pilot1, pilot2]. Sums to nMicrosectors. */
@@ -111,7 +111,7 @@ export interface ReplayModel {
   winner: WinnerMeta
   metadata: ComparisonMetadata
   /** Times (s) of sector boundaries for scrubber ticks. Placeholder 25/50/75% of
-   *  duration when official splits are absent (spec §4.6). */
+   *  duration when official splits are absent. */
   sectorTimes: number[]
   /** Resolve the render frame at elapsed time `t`. */
   frameAt(t: number): ReplayFrame

--- a/webapp/src/features/comparison/replay/useReplayClock.ts
+++ b/webapp/src/features/comparison/replay/useReplayClock.ts
@@ -1,4 +1,4 @@
-// The ONE rAF clock for the Comparison replay (spec §4.2/§4.3, #36). Every
+// The ONE rAF clock for the Comparison replay. Every
 // other replay piece — TrackCanvas, the channel-chart playhead overlay, the
 // transport bar, the scrubber — reads time through THIS clock; nothing else
 // runs its own requestAnimationFrame loop. The playhead lives in a ref, never
@@ -216,7 +216,7 @@ export function useReplayClock(opts: UseReplayClockOptions): ReplayClock {
  * (elapsed/remaining labels, tooltips). This is the ONLY place the clock's
  * ref-based time is lifted into React state — canvas and DOM-overlay consumers
  * must keep reading `clock.getTime()` inside their own `subscribe` callback so
- * a 60fps tick never re-renders the tree (spec §4.2).
+ * a 60fps tick never re-renders the tree.
  */
 export function useReplayTime(clock: ReplayClock, hz = 10): number {
   const [time, setTime] = useState(clock.getTime())

--- a/webapp/src/features/comparison/replay/useReplayKeyboard.ts
+++ b/webapp/src/features/comparison/replay/useReplayKeyboard.ts
@@ -2,13 +2,13 @@ import { useEffect } from 'react'
 import type { RefObject } from 'react'
 import type { ReplayClock } from './types'
 
-// Global keyboard transport for the replay card (spec §4.6, fixes dossier
-// #33). The page attaches this to the focused replay `Card`'s ref; it covers
-// the shortcut surface — play/pause, scrub, speed, restart — from anywhere
-// inside the card. Generic over the speed type `S` so this stays a reusable
-// transport primitive (spec §5's "keep the seams free of comparison-specific
-// types"): TypeScript infers `S` as `ReplaySpeed` from the caller's actual
-// `speed`/`speeds`/`onSpeedChange` without this file importing that type.
+// Global keyboard transport for the replay card. The page attaches this to the
+// focused replay `Card`'s ref; it covers the shortcut surface — play/pause,
+// scrub, speed, restart — from anywhere inside the card. Generic over the speed
+// type `S` so this stays a reusable transport primitive that keeps the seams
+// free of comparison-specific types: TypeScript infers `S` as `ReplaySpeed`
+// from the caller's actual `speed`/`speeds`/`onSpeedChange` without this file
+// importing that type.
 
 const NUDGE_SMALL_SECONDS = 0.5
 const NUDGE_LARGE_SECONDS = 5

--- a/webapp/src/features/comparison/search.ts
+++ b/webapp/src/features/comparison/search.ts
@@ -2,7 +2,7 @@
 // session / drivers) lives in the URL — same shape as the Dashboard so the
 // cross-link "Go to comparison" carries context — but capped at TWO drivers, plus
 // an optional `t` moment-link that reproduces a paused instant of the replay
-// (`?…&drivers=VER,LEC&t=34.2`, spec §6). Same raw↔component boundary as
+// (`?…&drivers=VER,LEC&t=34.2`). Same raw↔component boundary as
 // dashboard/search.ts; the cap-2 + `t` are the only differences.
 
 export const MAX_DRIVERS = 2
@@ -13,9 +13,9 @@ export interface ComparisonSearch {
   gp?: string
   session?: string
   drivers: string[]
-  /** The explicit COMPARE gate (spec §4.2): the (expensive) fetch runs only when
-   *  this is set. The button sets it; changing any selector clears it. A deep
-   *  link with `compare=1` reproduces a loaded comparison. */
+  /** The explicit COMPARE gate: the (expensive) fetch runs only when this is
+   *  set. The button sets it; changing any selector clears it. A deep link with
+   *  `compare=1` reproduces a loaded comparison. */
   compare?: boolean
   /** Optional replay moment (seconds), applied once on load then owned by the
    *  share button. Clamped to [0, duration] at apply time (duration isn't known

--- a/webapp/src/features/comparison/store.ts
+++ b/webapp/src/features/comparison/store.ts
@@ -4,8 +4,8 @@ import type { ReplayStatus, TrackMode } from './replay/types'
 
 // Comparison replay UI state (Zustand). Holds ONLY view/transport preferences and
 // the coarse replay lifecycle — NOT the playhead time (that lives in a ref inside
-// useReplayClock; 60 setState/s would re-render the whole tree, spec §4.2) and
-// NOT the comparison DATA (that's TanStack Query, immutable). The clock drives
+// useReplayClock; 60 setState/s would re-render the whole tree) and NOT the
+// comparison DATA (that's TanStack Query, immutable). The clock drives
 // `status`; the transport drives speed/loop/trackMode.
 //
 // speed/loop/trackMode persist as preferences (like the Dashboard's chartLayout);


### PR DESCRIPTION
Round-3 polish on the #36 Comparison time-clock replay, from user feedback on the live tab. All four asks verified in-browser against the real backend (2025 Japanese GP Q, NOR vs VER — VER by 0.012s, the near-tie that triggered the bug).

## What

- **Delta chart → two team-coloured lines** (matching the Streamlit/Arcade reference): the faster driver is a flat baseline at y=0 in their colour, the slower driver is their cumulative deficit curve in theirs, plus two faint sign-tinted fills as a background who-gains-where cue. Replaces the neutral curve + grey markLine. The custom tooltip reads the slower series so the two unnamed fills never leak anonymous `series0/series1` rows.
- **Reveal-edge wet-paint highlight** on the track: as the leader crosses each microsector end it lights up in translucent white and fades over ~40m of travel, so dominance/speed/gain paints on segment by segment. Cheap — re-strokes only the handful of segments behind the frontier — skipped under reduced motion and during mode-switch transitions.
- **LiveGapReadout**: no more contradictory `Level = 0.05s`. The tie floor drops 0.05s → 0.01s and the gap value is hidden entirely when level. Fixed-width + right-justified so text swaps (leader code ↔ Level, gap ticking) no longer reflow the scrubber row — the microsecond jitter.
- **Comment hygiene**: drop internal audit/spec/dossier references across the feature; rename the transport a11y regression test off its dossier codename.

## Checks

- typecheck (`tsc -b`) green
- `vitest` 79/79 green (new `revealEdgeIntensity` + rewritten `buildDeltaOption` tests)
- `oxlint` clean on the replay dir
- production build green
- Browser-verified: delta two-colour lines (dark + light), reveal-edge painting live, LiveGapReadout naming the leader mid-play, mode-switch repaints (Speed heatmap / Gain).

## Out of scope

- echarts core tree-shake (#137).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Improvements**
  * Updated comparison gap charts with team-colored lines and shaded ahead/behind areas.
  * Added a subtle highlight that follows newly revealed track segments during replay.
  * Improved chart tooltips and gap indicators for clearer leader and deficit information.

* **Bug Fixes**
  * Refined tie detection so near-level results are identified more accurately.
  * Prevented layout shifting in the live gap readout and removed the gap value when competitors are level.

* **Documentation**
  * Clarified comparison replay and accessibility behavior across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->