### PR TITLE
fix(dashboard): both drivers on chart hover + stop charts trapping page scroll

### DIFF
--- a/webapp/src/features/dashboard/components/ChannelChart.tsx
+++ b/webapp/src/features/dashboard/components/ChannelChart.tsx
@@ -157,21 +157,12 @@ function baseOption(
       splitLine: { show: false },
     },
     yAxis: yAxisStyled,
-    // Drag-pan + Shift+wheel zoom, inline (no visible slider). Plain wheel
-    // stays page scroll on purpose — 7-8 tall charts stacked in a column
-    // make unconditional wheel-capture a scroll trap. `filterMode: 'none'`
-    // keeps each chart's own y range stable while panning, so 8 charts
-    // synced on the same x don't rescale-jitter against each other.
-    dataZoom: [
-      {
-        type: 'inside',
-        xAxisIndex: 0,
-        filterMode: 'none',
-        zoomOnMouseWheel: 'shift',
-        moveOnMouseMove: true,
-        moveOnMouseWheel: false,
-      },
-    ],
+    // No `inside` dataZoom on purpose. It captures the mouse wheel even with
+    // wheel-zoom disabled, so a plain wheel over one of these 7-8 stacked
+    // charts gets swallowed instead of scrolling the page — a scroll trap.
+    // Zoom stays available through the toolbox box-zoom below (drag a box),
+    // which does not touch the wheel.
+    //
     // Toolbox box-zoom (x-only, via `yAxisIndex: 'none'`) is the
     // click-drag-a-box gesture that matches the Streamlit/Plotly original;
     // `restore` resets it. Both actions propagate through `CROSSHAIR_GROUP`
@@ -214,6 +205,55 @@ function buildDriverSeries(
   }))
 }
 
+/**
+ * Every loaded driver's telemetry samples distance at its own cadence (a
+ * different lap, a different FastF1 interpolation grid), so on a
+ * `type:'value'` x-axis each series' points rarely land on the same x. ECharts'
+ * axis tooltip only reports a series if it has a point at the snapped x, so
+ * with per-driver grids it silently shows just one driver instead of all of
+ * them. Resampling every driver onto ONE shared grid — the densest loaded
+ * driver's own distance array, chosen once per option build to minimise
+ * resampling error — gives every series identical x sample points, so the
+ * axis tooltip always finds a value from each driver at that distance. Same
+ * approach the Comparison tab already uses (`buildReplayModel`, both pilots
+ * resampled onto `model.distance`).
+ */
+function findDensestDistanceGrid(
+  byDriver: Record<string, LapTelemetry>,
+  drivers: string[],
+): number[] {
+  let densest: number[] = []
+  for (const driver of drivers) {
+    const distance = byDriver[driver].distance
+    if (distance.length > densest.length) densest = distance
+  }
+  return densest
+}
+
+/**
+ * Carry-forward lookup for stepped channels (gear, DRS): between two of a
+ * driver's own samples, the value doesn't blend into a fraction the way a
+ * continuous quantity would — a gear is 3 or 4, never 3.5, and DRS is open or
+ * closed. Returns the value at the largest sample distance <= x, matching the
+ * `step: 'end'` line rendering (a stepped line already holds each y until the
+ * next x, so the shared-grid lookup should agree with what's drawn).
+ */
+function stepLookup(x: number, xs: number[], ys: number[]): number {
+  const last = xs.length - 1
+  if (last < 0) return 0
+  if (x <= xs[0]) return ys[0]
+  if (x >= xs[last]) return ys[last]
+
+  let lo = 0
+  let hi = last
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1
+    if (xs[mid] <= x) lo = mid
+    else hi = mid
+  }
+  return ys[lo]
+}
+
 function buildChannelOption(
   byDriver: Record<string, LapTelemetry>,
   drivers: string[],
@@ -225,10 +265,18 @@ function buildChannelOption(
     name: driver,
     color: getDriverTextColor(driver, year),
   }))
+  const sharedGrid = findDensestDistanceGrid(byDriver, loaded)
+  // Stepped channels (gear, DRS) carry-forward instead of interpolating —
+  // see `stepLookup`'s docstring for why a fractional gear would be wrong.
+  const valueAt = (distance: number, xs: number[], ys: number[]): number =>
+    channel.stepped ? stepLookup(distance, xs, ys) : interp(distance, xs, ys)
   const series = buildDriverSeries(loaded, year, channel.stepped, channel.band, (driver) => {
     const telemetry = byDriver[driver]
     const values = channel.transform(telemetry)
-    return telemetry.distance.map((distance, i): [number, number] => [distance, values[i]])
+    return sharedGrid.map((distance): [number, number] => [
+      distance,
+      valueAt(distance, telemetry.distance, values),
+    ])
   })
 
   return {
@@ -370,11 +418,13 @@ function buildDeltaOption(
     name: driver,
     color: getDriverTextColor(driver, year),
   }))
+  const sharedGrid = findDensestDistanceGrid(byDriver, loaded)
   const series = buildDriverSeries(loaded, year, false, false, (driver) => {
     const telemetry = byDriver[driver]
-    return telemetry.distance.map((distance, i): [number, number] => {
+    return sharedGrid.map((distance): [number, number] => {
+      const driverTime = interp(distance, telemetry.distance, telemetry.time)
       const refTime = interp(distance, refTelemetry.distance, refTelemetry.time)
-      return [distance, telemetry.time[i] - refTime]
+      return [distance, driverTime - refTime]
     })
   })
 

--- a/webapp/src/features/dashboard/components/LapChart.tsx
+++ b/webapp/src/features/dashboard/components/LapChart.tsx
@@ -170,18 +170,55 @@ function compoundDotHtml(compound: string): string {
   return `<span style="display:inline-block;width:8px;height:8px;border-radius:9999px;background:${hex};margin-right:4px;"></span>`
 }
 
-/** Tooltip HTML: team-coloured driver name — Lap N — M:SS.mmm — compound dot + label. */
+/** One hovered series' point, as `trigger:'axis'` hands it to the formatter —
+ *  same `seriesName`/`data` shape the tooltip already read under
+ *  `trigger:'item'`, just arriving as one entry per driver instead of one
+ *  entry total. */
+interface AxisTooltipParam {
+  seriesName?: string
+  data?: unknown
+}
+
+/** Narrows one raw axis-tooltip param down to a `LapPoint`-carrying entry, or
+ *  `null` if this driver has no lap plotted at the hovered lap number (a
+ *  driver can be short a lap, e.g. it retired, so not every series has data
+ *  at every x position). */
+function toAxisTooltipParam(raw: unknown): AxisTooltipParam | null {
+  if (!raw || typeof raw !== 'object') return null
+  const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
+  if (!isLapPoint(data)) return null
+  return { seriesName, data }
+}
+
+/** One tooltip row: team-coloured driver code — M:SS.mmm — compound dot + label. */
+function formatDriverRow(param: AxisTooltipParam, year: number | undefined): string {
+  const point = param.data as LapPoint
+  const [, lapTime] = point.value
+  const driverName = param.seriesName ?? ''
+  const driverHtml = param.seriesName
+    ? `<b style="color:${getDriverTextColor(param.seriesName, year)}">${driverName}</b>`
+    : `<b>${driverName}</b>`
+  return `${driverHtml} — ${formatLapTime(lapTime)} — ${compoundDotHtml(point.compound)}${compoundLabel(point.compound)}`
+}
+
+/** Tooltip HTML for the shared lap-number axis: a "Lap N" header followed by
+ *  one row per hovered driver. `trigger:'axis'` hands the formatter every
+ *  series at that lap number (normalized to an array here since ECharts
+ *  calls with a single object when only one series is plotted), which is
+ *  what lets every driver show up together instead of only the one under
+ *  the cursor. */
 function formatLapTooltip(year: number | undefined) {
   return (raw: unknown): string => {
-    if (!raw || typeof raw !== 'object') return ''
-    const { seriesName, data } = raw as { seriesName?: string; data?: unknown }
-    if (!isLapPoint(data)) return ''
-    const [lapNumber, lapTime] = data.value
-    const driverName = seriesName ?? ''
-    const driverHtml = seriesName
-      ? `<b style="color:${getDriverTextColor(seriesName, year)}">${driverName}</b>`
-      : `<b>${driverName}</b>`
-    return `${driverHtml} — Lap ${lapNumber} — ${formatLapTime(lapTime)} — ${compoundDotHtml(data.compound)}${compoundLabel(data.compound)}`
+    const paramsArray = Array.isArray(raw) ? raw : [raw]
+    const validParams = paramsArray
+      .map(toAxisTooltipParam)
+      .filter((param): param is AxisTooltipParam => param !== null)
+    if (validParams.length === 0) return ''
+
+    const [lapNumber] = (validParams[0].data as LapPoint).value
+    const header = `<div style="margin-bottom:4px;">Lap ${lapNumber}</div>`
+    const rows = validParams.map((param) => formatDriverRow(param, year)).join('<br/>')
+    return header + rows
   }
 }
 
@@ -195,7 +232,14 @@ function buildLapChartOption(
     // Entrance paint animation on (ECharts default). The old double-paint was
     // React StrictMode double-mounting in dev, not the animation — dropped in
     // main.tsx, so the line-draw now plays exactly once.
-    tooltip: { trigger: 'item', formatter: formatLapTooltip(year) },
+    // `trigger:'axis'` collects every driver's point at the hovered lap
+    // number (the shared x-axis) instead of only the single point under the
+    // cursor, so the formatter can render one row per driver.
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      formatter: formatLapTooltip(year),
+    },
     legend: {
       data: buildLegendData(seriesList, year),
       icon: 'roundRect',
@@ -224,23 +268,13 @@ function buildLapChartOption(
       scale: true,
     },
     series: seriesList,
-    // Drag-to-zoom (item 5): inside = click-drag pan + Shift+wheel zoom;
-    // plain wheel stays page scroll. `filterMode: 'none'` keeps zoom/pan from
-    // rescaling the y-axis. `x = lap number` here (unlike the telemetry
-    // charts' `x = distance`), so this chart is NOT joined to their
-    // `echarts.connect` crosshair group — its zoom stays independent.
-    dataZoom: [
-      {
-        type: 'inside',
-        xAxisIndex: 0,
-        filterMode: 'none',
-        zoomOnMouseWheel: 'shift',
-        moveOnMouseMove: true,
-        moveOnMouseWheel: false,
-      },
-    ],
+    // No `inside` dataZoom on purpose: ECharts' inside-roam captures the mouse
+    // wheel even with wheel-zoom disabled, which would trap the page scroll
+    // when the cursor is over this chart. Zoom stays available through the
+    // toolbox box-zoom below (drag a box), which does not touch the wheel.
+    //
     // Toolbox box-zoom (Plotly-style, x-only via `yAxisIndex: 'none'`) + a
-    // reset button — the discoverable alternative to the shift-drag gesture.
+    // reset button — the way to zoom now that the wheel is left alone.
     toolbox: {
       right: 8,
       top: 0,


### PR DESCRIPTION
Three related Dashboard chart bugs reported from the live tab. All verified in-browser against the real backend (2023 Monaco R, VER vs LEC).

## What

- **Telemetry + Delta hover showed one driver** ([#143](https://github.com/VforVitorio/F1_Telemetry_Manager/issues/143)). The tooltip was already axis-triggered and iterated all series; the real cause was each driver's line being built on its OWN distance grid, so the axis pointer only found a point in one series per snapped x. Both lines are now resampled onto one shared distance grid — linear `interp` for continuous channels, step/nearest for Gear and DRS so they never interpolate to a fractional value — so the tooltip box shows every driver at once, like the Comparison tab.
- **Lap Chart hover showed one driver** ([#144](https://github.com/VforVitorio/F1_Telemetry_Manager/issues/144)). `trigger: 'item'` → `trigger: 'axis'`; formatter rewritten to render one row per driver at the hovered lap (code, lap time, compound). Click-to-load untouched.
- **Charts trapped the mouse wheel** ([#145](https://github.com/VforVitorio/F1_Telemetry_Manager/issues/145)). ECharts' `inside` dataZoom captures the wheel even with wheel-zoom disabled (`zoomOnMouseWheel: false` is NOT enough — verified: the wheel event never reaches the page), so it's removed entirely. Zoom stays available via the toolbox box-zoom. Verified a plain wheel over Speed and the Lap Chart now scrolls the page.

## Checks

- typecheck / vitest (10/10 dashboard) / oxlint / build all green
- Browser-verified: Speed tooltip `VER 234 / LEC 242.0`, Delta `VER 0.1 / LEC 0`, Lap Chart `Lap 36 · VER 1:17.974 Medium · LEC 1:17.491 Hard`; wheel over Speed + Lap Chart scrolls the page (`defaultPrevented=false`).

## Trade-off

Removing the `inside` dataZoom drops click-drag pan and shift-wheel zoom; box-zoom (drag a box) + reset via the toolbox remain. Page-scroll-through-charts was the priority.

Closes #143, #144, #145.