### PR TITLE
refactor(webapp): refine Race Analysis tab UI

### DIFF
--- a/webapp/src/components/DataTable.tsx
+++ b/webapp/src/components/DataTable.tsx
@@ -93,6 +93,12 @@ export interface DataTableProps<T> {
   height?: number
   /** Filename used by the CSV export button. Defaults to 'export.csv'. */
   csvFilename?: string
+  /** When true, the table hugs the sum of its column widths instead of
+   *  stretching to fill its container. Use it for narrow tables (a handful of
+   *  columns) so values stay packed together rather than scattered across the
+   *  viewport with wide empty gaps. Defaults to false, so existing full-width
+   *  tables keep their current layout. */
+  fitContent?: boolean
 }
 
 /** Virtualized data table with a sticky header and a CSV export button.
@@ -103,6 +109,7 @@ export function DataTable<T>({
   data,
   height = DEFAULT_HEIGHT_PX,
   csvFilename = 'export.csv',
+  fitContent = false,
 }: DataTableProps<T>) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const table = useReactTable({ columns, data, getCoreRowModel: getCoreRowModel() })
@@ -138,10 +145,16 @@ export function DataTable<T>({
       </div>
       <div
         ref={scrollRef}
-        className="overflow-auto rounded-xl border border-hairline"
+        className={cn(
+          'overflow-auto rounded-xl border border-hairline',
+          fitContent && 'w-fit max-w-full',
+        )}
         style={{ height }}
       >
-        <table className="w-full table-fixed border-collapse text-sm">
+        <table
+          className={cn('table-fixed border-collapse text-sm', !fitContent && 'w-full')}
+          style={fitContent ? { width: table.getTotalSize() } : undefined}
+        >
           <thead className="sticky top-0 bg-bg-2">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>

--- a/webapp/src/features/race/RacePage.tsx
+++ b/webapp/src/features/race/RacePage.tsx
@@ -18,7 +18,7 @@ import type { RaceRecord } from '@/lib/api/race'
 import { useRaceData } from './queries'
 import { useRaceStore } from './store'
 import { applyRacePatch, fromRaw, toRaw, type RaceSearch, type RaceTab } from './search'
-import { RaceContextBar, type RaceLoadedInfo } from './components/RaceContextBar'
+import { RaceContextBar, RaceContextExtras, type RaceLoadedInfo } from './components/RaceContextBar'
 import { TyresPanel } from './components/TyresPanel'
 import { GapsPanel } from './components/GapsPanel'
 import { DatasetPanel } from './components/DatasetPanel'
@@ -117,6 +117,11 @@ export function RacePage() {
     : null
 
   const hasData = frame.length > 0
+  // At true idle (no GP loaded yet) every data tab is disabled. Showing one
+  // of them as the active-yet-dead trigger reads as broken, so default the
+  // visible tab to Regulations (the only tab that never needs a loaded race)
+  // without touching the URL's own `tab` value.
+  const activeTab = !hasData && search.tab !== 'regs' ? 'regs' : search.tab
 
   /** Wrap a data-tab body in the idle / loading / error states. */
   const dataBody = (panel: React.ReactNode): React.ReactNode => {
@@ -163,12 +168,13 @@ export function RacePage() {
             value={search}
             onChange={patch}
             driverOptions={driverOptions}
-            loaded={loaded}
             loading={loading}
           />
         </div>
 
-        <Tabs value={search.tab} onValueChange={(tab) => patch({ tab: tab as RaceTab })}>
+        <RaceContextExtras loaded={loaded} />
+
+        <Tabs value={activeTab} onValueChange={(tab) => patch({ tab: tab as RaceTab })}>
           <TabsList variant="underline">
             <TabsTrigger value="tyres" disabled={!hasData}>
               Tyres

--- a/webapp/src/features/race/components/DatasetPanel.tsx
+++ b/webapp/src/features/race/components/DatasetPanel.tsx
@@ -3,17 +3,17 @@
 // All/Selected scope toggle and CSV export. `DataTable` already renders
 // numeric cells in tabular mono figures; this panel is only responsible for
 // choosing which columns show per preset and dressing up cell content
-// (compound branding, boolean pills, null formatting, right-aligned numbers)
-// on top of that.
+// (compound identity dot, boolean text, null formatting, right-aligned
+// numbers) on top of that.
 
 import { useMemo, type ReactNode } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
-import { CompoundPill } from '@/components/CompoundPill'
+import { tireColors } from '@/charts/echartsTheme'
 import { DataTable } from '@/components/DataTable'
 import { EmptyState } from '@/components/EmptyState'
-import { Pill } from '@/components/Pill'
 import { Tabs, TabsList, TabsTrigger } from '@/components/Tabs'
 import type { RaceRecord } from '@/lib/api/race'
+import { compoundLabel, compoundVariant } from '@/lib/compounds'
 import { DATASET_PRESETS, useRaceStore, type DatasetPreset, type DatasetScope } from '../store'
 
 export interface DatasetPanelProps {
@@ -26,6 +26,13 @@ export interface DatasetPanelProps {
 const DASH = '—'
 const TABLE_HEIGHT_PX = 560
 
+// Presets at or under this many columns hug their own width instead of
+// stretching across the card (see the `DataTable` wrapper below); the `all`
+// preset sits far above it and keeps the full-width, scrollable layout.
+const COMPACT_COLUMN_LIMIT = 9
+
+const EYEBROW_CLASSNAME = 'mr-2 text-xs font-medium uppercase tracking-widest text-fg-3'
+
 // ── Column catalogue ─────────────────────────────────────────────────────────
 // One entry per RaceRecord field the Dataset tab can show: its display label
 // and how its cell renders. Presets below just pick which keys to show, in
@@ -37,6 +44,11 @@ type ColumnKey = keyof RaceRecord
 interface ColumnSpec {
   label: string
   kind: ColumnKind
+  /** Decimal places to show for a `number` column. Omitted columns fall back
+   *  to `DEFAULT_NUMBER_PRECISION` (3dp); coarse physical readings such as
+   *  temperatures and fuel load look fake-precise at that default, so they
+   *  override it to match the sensor's real resolution. */
+  precision?: number
 }
 
 const COLUMN_SPECS: Record<ColumnKey, ColumnSpec> = {
@@ -56,13 +68,13 @@ const COLUMN_SPECS: Record<ColumnKey, ColumnSpec> = {
   Position: { label: 'Pos', kind: 'number' },
   CompoundID: { label: 'Compound ID', kind: 'number' },
   LapTime_s: { label: 'Lap Time (s)', kind: 'number' },
-  FuelLoad: { label: 'Fuel Load (kg)', kind: 'number' },
+  FuelLoad: { label: 'Fuel Load (kg)', kind: 'number', precision: 2 },
   FuelAdjustedLapTime: { label: 'Fuel-Adj. Lap Time (s)', kind: 'number' },
   FuelAdjustedDegAbsolute: { label: 'Fuel-Adj. Deg (abs)', kind: 'number' },
   FuelAdjustedDegPercent: { label: 'Fuel-Adj. Deg (%)', kind: 'number' },
   DegradationRate: { label: 'Deg. Rate (s/lap)', kind: 'number' },
-  AirTemp: { label: 'Air Temp (°C)', kind: 'number' },
-  TrackTemp: { label: 'Track Temp (°C)', kind: 'number' },
+  AirTemp: { label: 'Air Temp (°C)', kind: 'number', precision: 1 },
+  TrackTemp: { label: 'Track Temp (°C)', kind: 'number', precision: 1 },
   GP_Name: { label: 'Grand Prix', kind: 'text' },
   GapToCarAhead: { label: 'Gap Ahead (s)', kind: 'number' },
   GapToCarBehind: { label: 'Gap Behind (s)', kind: 'number' },
@@ -112,31 +124,56 @@ const PRESET_COLUMNS: Record<DatasetPreset, ColumnKey[]> = {
     'consistent_gap_behind_laps',
   ],
   weather: ['Driver', 'LapNumber', 'AirTemp', 'TrackTemp'],
-  all: Object.keys(COLUMN_SPECS) as ColumnKey[],
+  // `GP_Name` is dropped here: a loaded frame is always a single Grand Prix,
+  // so the column would repeat one value for every row, and the context bar
+  // above the table already names the GP.
+  all: (Object.keys(COLUMN_SPECS) as ColumnKey[]).filter((key) => key !== 'GP_Name'),
 }
 
-/** Round a display number to 3dp; whole numbers (lap counts, positions) stay
- *  bare so "Lap 12" doesn't read as "Lap 12.000". */
-function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(3)
+const DEFAULT_NUMBER_PRECISION = 3
+
+/** Round a display number to its column's precision (default 3dp); whole
+ *  numbers (lap counts, positions) stay bare so "Lap 12" doesn't read as
+ *  "Lap 12.000". */
+function formatNumber(value: number, precision: number = DEFAULT_NUMBER_PRECISION): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(precision)
+}
+
+/** Render a compound value as a small identity dot plus its label, rather
+ *  than a saturated pill — a table with hundreds of rows reads better quiet,
+ *  and the driver's compound colour is already carried by the stint gantt and
+ *  the compound legend above the table. An unrecognised compound string falls
+ *  back to plain text with no dot, matching how `CompoundPill` treats it. */
+function renderCompoundCell(value: string): ReactNode {
+  const variant = compoundVariant(value)
+  if (!variant) return compoundLabel(value)
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="size-2 rounded-full" style={{ background: tireColors[variant] }} />
+      {compoundLabel(value)}
+    </span>
+  )
 }
 
 /** Render one cell's content per its column kind. Null/blank always collapses
  *  to an em dash rather than a raw "null"/empty cell — the guard runs first
  *  so it applies uniformly across every kind, including `false` booleans
  *  which must NOT be caught by it (`false == null` is false, so they aren't). */
-function renderCell(kind: ColumnKind, value: unknown): ReactNode {
+function renderCell(spec: ColumnSpec, value: unknown): ReactNode {
   if (value == null || value === '') return <span className="text-fg-3">{DASH}</span>
-  switch (kind) {
+  switch (spec.kind) {
     case 'compound':
-      return typeof value === 'string' ? <CompoundPill compound={value} /> : DASH
+      return typeof value === 'string' ? renderCompoundCell(value) : DASH
     case 'boolean':
-      return <Pill tone={value ? 'success' : 'neutral'}>{value ? 'Fresh' : 'Used'}</Pill>
+      // Plain text keeps this an information surface rather than a rail of
+      // status pills; "Used" is dimmed since "Fresh" is the state worth
+      // noticing at a glance.
+      return value ? 'Fresh' : <span className="text-fg-3">Used</span>
     case 'number':
       // Alignment and mono/tabular-nums figures both come from the cell's
       // `<td>` in DataTable (via `meta.align` and its numeric-value check) —
       // this case only needs to return the formatted text.
-      return typeof value === 'number' ? formatNumber(value) : DASH
+      return typeof value === 'number' ? formatNumber(value, spec.precision) : DASH
     default:
       return String(value)
   }
@@ -155,7 +192,7 @@ function buildColumns(preset: DatasetPreset): ColumnDef<RaceRecord, unknown>[] {
       header: spec.label,
       size: COLUMN_WIDTH[spec.kind],
       meta: spec.kind === 'number' ? { align: 'right' } : undefined,
-      cell: (info) => renderCell(spec.kind, info.getValue()),
+      cell: (info) => renderCell(spec, info.getValue()),
     }
   })
 }
@@ -182,6 +219,7 @@ export function DatasetPanel({ rows, selectedDrivers }: DatasetPanelProps) {
   const displayedScope: DatasetScope = scope === 'selected' && noDriversSelected ? 'all' : scope
 
   const columns = useMemo(() => buildColumns(preset), [preset])
+  const isCompactPreset = columns.length <= COMPACT_COLUMN_LIMIT
 
   if (rows.length === 0) {
     return (
@@ -195,15 +233,18 @@ export function DatasetPanel({ rows, selectedDrivers }: DatasetPanelProps) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <Tabs value={preset} onValueChange={(value) => setPreset(value as DatasetPreset)}>
-          <TabsList variant="segmented">
-            {DATASET_PRESETS.map((key) => (
-              <TabsTrigger key={key} value={key}>
-                {PRESET_LABELS[key]}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+        <div className="flex flex-wrap items-center">
+          <span className={EYEBROW_CLASSNAME}>Columns</span>
+          <Tabs value={preset} onValueChange={(value) => setPreset(value as DatasetPreset)}>
+            <TabsList variant="segmented">
+              {DATASET_PRESETS.map((key) => (
+                <TabsTrigger key={key} value={key}>
+                  {PRESET_LABELS[key]}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
 
         <Tabs value={displayedScope} onValueChange={(value) => setScope(value as DatasetScope)}>
           <TabsList variant="segmented">
@@ -223,11 +264,15 @@ export function DatasetPanel({ rows, selectedDrivers }: DatasetPanelProps) {
         {scopedRows.length.toLocaleString()} rows · {columns.length} columns
       </p>
 
+      {/* A compact preset (a handful of columns) hugs its own width so values
+          stay packed together; the wide `all` preset keeps the normal
+          full-width, horizontally-scrollable layout. */}
       <DataTable
         columns={columns}
         data={scopedRows}
         height={TABLE_HEIGHT_PX}
         csvFilename="race-dataset.csv"
+        fitContent={isCompactPreset}
       />
     </div>
   )

--- a/webapp/src/features/race/components/GapCharts.tsx
+++ b/webapp/src/features/race/components/GapCharts.tsx
@@ -7,9 +7,11 @@
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
 import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { ChartCard } from '@/components/ChartCard'
 import type { RaceRecord } from '@/lib/api/race'
+import type { Theme } from '@/stores/ui'
 import { RACE_YEAR } from '../search'
 import {
   buildGapConsistencyOption,
@@ -24,6 +26,18 @@ registerF1Theme()
 
 const CHART_HEIGHT = 360
 
+/** The gap-evolution y-axis clips at 12s so the strategic band (0-3.5s) stays
+ *  readable even when a lapped car's gap runs to 25+ seconds (see
+ *  `Y_MAX_CEILING` in gapSeries.ts). Without a hint, a line just vanishing at
+ *  the top edge reads like a render bug rather than an intentional cap. */
+const GAP_CLIP_FOOTER = 'Gaps above 12s are clipped. Drag the box-zoom to inspect them.'
+
+/** The consistency bars cap at 15 laps (`CONSISTENCY_Y_MAX` in gapSeries.ts)
+ *  so one driver's very long streak can't flatten the 3-lap strategic
+ *  threshold into an unreadable sliver near the x-axis. */
+const CONSISTENCY_CAP_FOOTER =
+  'Streaks are capped at 15 laps so the 3-lap strategic threshold stays readable. Longer streaks are clipped at the top.'
+
 export interface GapChartsProps {
   /** Frame filtered to the selected drivers (or the whole field if none). */
   rows: RaceRecord[]
@@ -37,10 +51,14 @@ export interface GapChartsProps {
  *  supporting detail: how long have they held). */
 export function GapCharts({ rows, highlight }: GapChartsProps) {
   const chartTheme = useChartTheme()
+  // Same theme-name comparison TyreChartSwitcher.tsx uses, so the zone bands
+  // (buildZonesSeries in gapSeries.ts) get the right alpha for the mode
+  // that's actually on screen.
+  const theme: Theme = chartTheme === F1_LIGHT_THEME ? 'light' : 'dark'
 
   const evolutionOption = useMemo(
-    () => buildGapEvolutionOption(rows, RACE_YEAR, highlight),
-    [rows, highlight],
+    () => buildGapEvolutionOption(rows, RACE_YEAR, theme, highlight),
+    [rows, theme, highlight],
   )
   const consistencyOption = useMemo(() => buildGapConsistencyOption(rows, RACE_YEAR), [rows])
 
@@ -55,7 +73,10 @@ export function GapCharts({ rows, highlight }: GapChartsProps) {
 
   return (
     <div className="flex flex-col gap-4">
-      <ChartCard title="Gap evolution">
+      <ChartCard
+        title="Gap evolution (s)"
+        footer={<p className="text-xs text-fg-4">{GAP_CLIP_FOOTER}</p>}
+      >
         <div
           role="img"
           aria-label="Gap to the car ahead and behind, per lap, with undercut and overcut zones"
@@ -69,7 +90,10 @@ export function GapCharts({ rows, highlight }: GapChartsProps) {
           />
         </div>
       </ChartCard>
-      <ChartCard title="Gap consistency">
+      <ChartCard
+        title="Gap consistency (laps)"
+        footer={<p className="text-xs text-fg-4">{CONSISTENCY_CAP_FOOTER}</p>}
+      >
         <div
           role="img"
           aria-label="Consecutive laps each driver stayed in the same gap-ahead window"

--- a/webapp/src/features/race/components/PodiumQuickPick.tsx
+++ b/webapp/src/features/race/components/PodiumQuickPick.tsx
@@ -21,7 +21,7 @@ export function PodiumQuickPick({ podium, onPick }: PodiumQuickPickProps) {
     <EmptyState
       icon={<Users className="size-6" />}
       title="Pick drivers to chart"
-      description="The whole field is 20 cars — too many lines to read at once. Choose up to 3 (the gantt and strategy cards already cover the full field)."
+      description="The whole field is 20 cars, too many lines to read at once. Choose up to 3 (the gantt and strategy cards already cover the full field)."
       action={
         podium.length > 0 ? (
           <div className="flex flex-wrap items-center justify-center gap-2">

--- a/webapp/src/features/race/components/RaceContextBar.tsx
+++ b/webapp/src/features/race/components/RaceContextBar.tsx
@@ -1,29 +1,26 @@
-// Sticky context bar for Race Analysis: the GP selector + a driver multiselect
-// (cap 3, options come from the loaded frame) + a "what's loaded" strip. No
-// year/session (Race is always the 2025 featured parquet) and no explicit load
-// gate — picking a GP auto-fetches. A dot on a GP option flags radio availability.
+// Context row for Race Analysis: the GP selector + a driver multiselect (cap
+// 3, options come from the loaded frame). No year/session (Race is always the
+// 2025 featured parquet), and no explicit load gate: picking a GP auto-fetches.
+// A dot on a GP option flags radio availability.
 //
-// A collapsed "Local data" disclosure at the bottom lets an offline CSV/parquet
-// stand in for the backend fetch entirely (see RacePage: an active upload takes
-// precedence over `search.gp`'s query). It's a plain native <details> so it
-// costs nothing when collapsed and never competes visually with the GP/driver
-// controls above it.
+// This is the only part meant to stay pinned under the page header. The
+// loaded-frame summary and the local-data drop zone live in the separate
+// `RaceContextExtras` below, rendered in normal (non-sticky) flow so scrolling
+// a chart never pins a quarter of the viewport as chrome.
 
 import { useState } from 'react'
 import { ChevronRight, CircleDot, Database, X } from 'lucide-react'
 import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
-import { CompoundPill } from '@/components/CompoundPill'
 import { FileDrop } from '@/components/FileDrop'
 import { Pill } from '@/components/Pill'
 import { useToast } from '@/components/Toast'
 import { getDriverColor } from '@/lib/drivers'
-import { cn } from '@/lib/cn'
 import { parseUploadedFile } from '../lib/uploadParse'
 import { useRaceGps, useRadioAvailableGps } from '../queries'
 import { RACE_YEAR, type RaceSearch } from '../search'
 import { useRaceStore } from '../store'
 
-/** Summary of the loaded frame for the strip. */
+/** Summary of the loaded frame for `RaceContextExtras`. */
 export interface RaceLoadedInfo {
   rows: number
   drivers: number
@@ -34,22 +31,14 @@ export interface RaceLoadedInfo {
 export interface RaceContextBarProps {
   value: RaceSearch
   onChange: (patch: Partial<RaceSearch>) => void
-  /** Driver codes present in the loaded frame — the multiselect options. */
+  /** Driver codes present in the loaded frame, the multiselect options. */
   driverOptions: string[]
-  /** The loaded-frame summary, or null before a race is loaded. */
-  loaded: RaceLoadedInfo | null
   loading: boolean
 }
 
 const EYEBROW = 'text-xs font-medium uppercase tracking-widest text-fg-3'
 
-export function RaceContextBar({
-  value,
-  onChange,
-  driverOptions,
-  loaded,
-  loading,
-}: RaceContextBarProps) {
+export function RaceContextBar({ value, onChange, driverOptions, loading }: RaceContextBarProps) {
   const gpsQuery = useRaceGps()
   const radioGpsQuery = useRadioAvailableGps()
   const radioGps = new Set(radioGpsQuery.data ?? [])
@@ -64,14 +53,86 @@ export function RaceContextBar({
   }))
 
   const upload = useRaceStore((s) => s.upload)
-  const setUpload = useRaceStore((s) => s.setUpload)
   const clearUpload = useRaceStore((s) => s.clearUpload)
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <span className="hidden shrink-0 items-center rounded-full border border-hairline bg-bg-4 px-2 py-1 font-mono text-xs text-fg-3 sm:inline-flex">
+        {RACE_YEAR} season
+      </span>
+
+      <div className="flex flex-col gap-1.5 sm:w-64">
+        <span className={EYEBROW}>Grand Prix</span>
+        <Combobox
+          ariaLabel="Grand Prix"
+          options={gpOptions}
+          value={value.gp}
+          onChange={(gp) => onChange({ gp })}
+          placeholder="Select a Grand Prix"
+          loading={gpsQuery.isLoading}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5 sm:w-72">
+        <span className={EYEBROW}>Drivers</span>
+        <MultiCombobox
+          ariaLabel="Drivers (max 3)"
+          options={driverComboOptions}
+          value={value.drivers}
+          onChange={(drivers) => onChange({ drivers })}
+          placeholder={
+            !value.gp ? 'Load a race first' : loading ? 'Loading race…' : 'Filter drivers (max 3)'
+          }
+          disabled={!value.gp || loading || driverOptions.length === 0}
+          max={3}
+          getOptionAccent={(code) => getDriverColor(code, RACE_YEAR)}
+        />
+      </div>
+
+      {radioGps.has(value.gp ?? '') ? (
+        <span className="flex items-center gap-1 text-xs text-fg-3">
+          <CircleDot className="size-3 text-success" aria-hidden="true" />
+          radio available
+        </span>
+      ) : null}
+
+      {upload ? (
+        <Pill tone="purple" className="gap-1.5">
+          <Database className="size-3" aria-hidden="true" />
+          Local dataset
+          <button
+            type="button"
+            onClick={clearUpload}
+            aria-label="Clear local dataset"
+            className="rounded-full hover:text-fg-1"
+          >
+            <X className="size-3" aria-hidden="true" />
+          </button>
+        </Pill>
+      ) : null}
+    </div>
+  )
+}
+
+export interface RaceContextExtrasProps {
+  /** The loaded-frame summary, or null before a race is loaded. */
+  loaded: RaceLoadedInfo | null
+}
+
+/** Below-the-fold row: the loaded-frame summary on the left, a compact
+ *  "Local data" disclosure on the right so an offline CSV/parquet can stand in
+ *  for the backend fetch entirely (see RacePage: an active upload takes
+ *  precedence over `search.gp`'s query). Rendered in normal page flow, never
+ *  inside the sticky context bar. */
+export function RaceContextExtras({ loaded }: RaceContextExtrasProps) {
+  const upload = useRaceStore((s) => s.upload)
+  const setUpload = useRaceStore((s) => s.setUpload)
   const { toast } = useToast()
   const [isParsing, setIsParsing] = useState(false)
 
   /** Parse a dropped file client-side and stash it as the active upload. A
    *  parse failure (malformed CSV, non-parquet binary, …) never touches the
-   *  store — the previous upload (if any) stays active. */
+   *  store, so the previous upload (if any) stays active. */
   async function handleFile(file: File) {
     setIsParsing(true)
     try {
@@ -94,87 +155,30 @@ export function RaceContextBar({
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-        <span className="hidden shrink-0 items-center rounded-full border border-hairline bg-bg-4 px-2 py-1 font-mono text-xs text-fg-3 sm:inline-flex">
-          {RACE_YEAR} season
-        </span>
-
-        <div className="flex flex-col gap-1.5 sm:w-64">
-          <span className={EYEBROW}>Grand Prix</span>
-          <Combobox
-            ariaLabel="Grand Prix"
-            options={gpOptions}
-            value={value.gp}
-            onChange={(gp) => onChange({ gp })}
-            placeholder="Select a Grand Prix"
-            loading={gpsQuery.isLoading}
-          />
-        </div>
-
-        <div className="flex flex-col gap-1.5 sm:w-72">
-          <span className={EYEBROW}>Drivers</span>
-          <MultiCombobox
-            ariaLabel="Drivers (max 3)"
-            options={driverComboOptions}
-            value={value.drivers}
-            onChange={(drivers) => onChange({ drivers })}
-            placeholder={
-              !value.gp ? 'Load a race first' : loading ? 'Loading race…' : 'Filter drivers (max 3)'
-            }
-            disabled={!value.gp || loading || driverOptions.length === 0}
-            max={3}
-            getOptionAccent={(code) => getDriverColor(code, RACE_YEAR)}
-          />
-        </div>
-
-        {radioGps.has(value.gp ?? '') ? (
-          <span className="flex items-center gap-1 text-xs text-fg-3">
-            <CircleDot className="size-3 text-success" aria-hidden="true" />
-            radio available
-          </span>
-        ) : null}
-
-        {upload ? (
-          <Pill tone="purple" className="gap-1.5">
-            <Database className="size-3" aria-hidden="true" />
-            Local dataset
-            <button
-              type="button"
-              onClick={clearUpload}
-              aria-label="Clear local dataset"
-              className="rounded-full hover:text-fg-1"
-            >
-              <X className="size-3" aria-hidden="true" />
-            </button>
-          </Pill>
-        ) : null}
-      </div>
-
+    <div className="flex flex-wrap items-center gap-3">
       {loaded ? (
-        <div className={cn('flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-fg-3')}>
-          <span className="font-mono text-fg-2">{loaded.rows.toLocaleString()} rows</span>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-fg-3">
+          <span className="font-mono text-fg-2">{loaded.laps} laps</span>
           <span className="font-mono">{loaded.drivers} drivers</span>
-          <span className="font-mono">{loaded.laps} laps</span>
+          <span className="font-mono">{loaded.rows.toLocaleString()} rows</span>
           {loaded.compounds.length > 0 ? (
-            <span className="flex items-center gap-1">
-              {loaded.compounds.map((c) => (
-                <CompoundPill key={c} compound={c} />
-              ))}
+            <span className="font-mono">
+              {loaded.compounds.map((c) => c.charAt(0)).join(' · ')}
             </span>
           ) : null}
         </div>
       ) : null}
 
-      <details className="group rounded-lg border border-hairline open:bg-bg-4/60">
-        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-medium text-fg-2 [&::-webkit-details-marker]:hidden">
+      <details className="group ml-auto w-fit rounded-lg border border-hairline open:bg-bg-4/60">
+        <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-fg-3 transition-colors hover:text-fg-2 [&::-webkit-details-marker]:hidden">
+          <Database className="size-3.5 shrink-0" aria-hidden="true" />
+          Local data
           <ChevronRight
             aria-hidden="true"
-            className="size-4 shrink-0 text-fg-3 transition-transform duration-200 group-open:rotate-90"
+            className="size-3 shrink-0 transition-transform duration-200 group-open:rotate-90"
           />
-          Local data
         </summary>
-        <div className="flex flex-col gap-2 border-t border-hairline px-3 py-3">
+        <div className="flex flex-col gap-2 border-t border-hairline px-3 py-3 sm:w-80">
           <FileDrop
             accept=".csv,.parquet"
             onFile={(file) => void handleFile(file)}

--- a/webapp/src/features/race/components/RadioBrowser.tsx
+++ b/webapp/src/features/race/components/RadioBrowser.tsx
@@ -3,7 +3,10 @@
 // means guessing a lap number blind, unlike the old Streamlit lookup which
 // asked for a lap number with no preview of what was actually said. Rows
 // without a transcript (audio only) are shown but disabled, since there is
-// nothing for the NLP pipeline to analyse yet.
+// nothing for the NLP pipeline to analyse yet. The rail badge counts ALL
+// messages for a driver (not just the transcribed ones) so a driver with
+// audio-only radio never looks like a failed load; a driver whose every
+// message is audio-only gets an explicit empty state instead of a silent void.
 //
 // The backend returns one `laps[]` entry PER MESSAGE, not per lap — a driver
 // can key the radio twice in the same lap, so two entries sharing a `lap`
@@ -11,6 +14,7 @@
 // INDEX into that driver's `laps[]` array, never the lap number alone.
 
 import { useEffect, useState } from 'react'
+import { Mic, MicOff } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { EmptyState } from '@/components/EmptyState'
 import { RACE_YEAR, type RadioDriver } from '@/lib/api/race'
@@ -31,6 +35,9 @@ export interface RadioBrowserProps {
   onSelect: (driver?: string, lap?: number, msg?: number) => void
   /** Offered on the empty-corpus fallback (re-fetch after a transient failure). */
   onRetry?: () => void
+  /** Opens the free-text composer below, offered when the active driver has
+   *  radio calls but none of them carry a transcript to analyse. */
+  onOpenComposer?: () => void
 }
 
 /** First rail entry to show: the current URL selection, else the first
@@ -54,6 +61,7 @@ export function RadioBrowser({
   selectedMsg,
   onSelect,
   onRetry,
+  onOpenComposer,
 }: RadioBrowserProps) {
   const [activeDriver, setActiveDriver] = useState<string | undefined>(() =>
     pickInitialDriver(radioDrivers, contextDrivers, selectedDriver),
@@ -91,12 +99,14 @@ export function RadioBrowser({
   // sorting the objects directly would sever that tie for the common case of
   // two messages sharing a lap.
   const messageOrder = [...activeLaps.keys()].sort((a, b) => activeLaps[a].lap - activeLaps[b].lap)
+  const hasTranscribed = activeLaps.some((l) => l.has_transcript)
 
   return (
-    <div className="grid gap-4 md:grid-cols-[12rem_1fr]">
+    <div className="grid gap-4 md:min-h-64 md:grid-cols-[12rem_1fr]">
       <div className="flex gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">
         {radioDrivers.map((d) => {
-          const messageCount = d.laps.filter((l) => l.has_transcript).length
+          const total = d.laps.length
+          const withTranscript = d.laps.filter((l) => l.has_transcript).length
           const isActive = d.driver === activeDriver
           return (
             <button
@@ -119,7 +129,17 @@ export function RadioBrowser({
                 />
                 {d.driver}
               </span>
-              <span className="font-mono text-xs text-fg-3">{messageCount}</span>
+              <span
+                className="flex items-center gap-1 font-mono text-xs text-fg-3"
+                title={`${total} radio message${total === 1 ? '' : 's'}, ${withTranscript} with transcript`}
+              >
+                {withTranscript > 0 ? (
+                  <Mic className="size-3" aria-hidden="true" />
+                ) : (
+                  <MicOff className="size-3 text-fg-4" aria-hidden="true" />
+                )}
+                {total}
+              </span>
             </button>
           )
         })}
@@ -128,6 +148,19 @@ export function RadioBrowser({
       <div className="flex flex-col gap-1.5">
         {messageOrder.length === 0 ? (
           <p className="px-1 py-6 text-center text-sm text-fg-3">No radio calls for this driver.</p>
+        ) : !hasTranscribed ? (
+          <EmptyState
+            icon={<MicOff className="size-5" aria-hidden="true" />}
+            title="No transcript to analyse"
+            description={`Audio-only radio for ${activeDriver}. Try another driver or use free text.`}
+            action={
+              onOpenComposer ? (
+                <Button variant="ghost" size="sm" onClick={onOpenComposer}>
+                  Use free text
+                </Button>
+              ) : undefined
+            }
+          />
         ) : (
           messageOrder.map((msgIndex) => {
             const l = activeLaps[msgIndex]

--- a/webapp/src/features/race/components/RadioPanel.tsx
+++ b/webapp/src/features/race/components/RadioPanel.tsx
@@ -6,6 +6,11 @@
 // lookup — a lap selection alone shouldn't fire the NLP pipeline. `rmsg` is
 // the index of the message within that driver's laps, since a lap can carry
 // more than one radio call and `rlap` alone can't tell them apart.
+//
+// The free-text composer's <details> is controlled (not a plain uncontrolled
+// element) so the browser can open it programmatically when the active driver
+// turns out to have no transcript to analyse. A manual click on its summary
+// still works the same way through the same state.
 
 import { useEffect, useMemo, useState } from 'react'
 import { Play } from 'lucide-react'
@@ -79,6 +84,17 @@ export function RadioPanel({ gp, drivers, rdriver, rlap, rmsg, onSelect }: Radio
 
   const analysis = useRadioAnalysis(gp, rdriver, rlap, rmsg, selectedTranscript, analysisEnabled)
 
+  // Controlled (rather than a plain uncontrolled <details>) so the browser's
+  // zero-transcript empty state can open the composer programmatically, while
+  // a manual click on the summary still works via onToggle.
+  const [composerOpen, setComposerOpen] = useState(false)
+  const openComposer = () => {
+    setComposerOpen(true)
+    document
+      .getElementById('radio-free-text')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  }
+
   useEffect(() => {
     if (!analysis.isError) return
     toast({
@@ -108,6 +124,7 @@ export function RadioPanel({ gp, drivers, rdriver, rlap, rmsg, onSelect }: Radio
           selectedMsg={rmsg}
           onSelect={onSelect}
           onRetry={() => void radioLaps.refetch()}
+          onOpenComposer={openComposer}
         />
       )}
 
@@ -139,7 +156,12 @@ export function RadioPanel({ gp, drivers, rdriver, rlap, rmsg, onSelect }: Radio
         <RadioResultCard result={analysis.data} />
       ) : null}
 
-      <details className="group rounded-lg border border-hairline bg-bg-2">
+      <details
+        id="radio-free-text"
+        open={composerOpen}
+        onToggle={(e) => setComposerOpen(e.currentTarget.open)}
+        className="group rounded-lg border border-hairline bg-bg-2"
+      >
         <summary className="cursor-pointer px-3 py-2 text-sm font-medium text-fg-2 marker:content-none">
           Free text
         </summary>

--- a/webapp/src/features/race/components/RagAnswerCard.tsx
+++ b/webapp/src/features/race/components/RagAnswerCard.tsx
@@ -20,10 +20,24 @@ export function CitationChip({ article }: { article: string }) {
   )
 }
 
+/** Turns a snake_case doc-type code into a readable label, e.g. "sporting_regs"
+ *  becomes "Sporting Regs" instead of leaking the raw backend field name. */
+function prettifyDocType(docType: string): string {
+  return docType
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
 /** One retrieved source passage, collapsed by default. The header carries the
- *  article + doc type · year · similarity; the body is the raw chunk text. */
+ *  article + doc type · year · retrieval-similarity score; the body is the
+ *  raw chunk text. */
 export function SourcePassage({ chunk }: { chunk: RagChunk }) {
-  const meta = [chunk.doc_type, chunk.year != null ? String(chunk.year) : null]
+  const meta = [
+    chunk.doc_type ? prettifyDocType(chunk.doc_type) : null,
+    chunk.year != null ? String(chunk.year) : null,
+  ]
     .filter(Boolean)
     .join(' · ')
   return (
@@ -35,7 +49,9 @@ export function SourcePassage({ chunk }: { chunk: RagChunk }) {
           {meta ? <span className="truncate text-xs text-fg-3">{meta}</span> : null}
         </span>
         {chunk.score != null ? (
-          <span className="shrink-0 font-mono text-xs text-fg-3">{chunk.score.toFixed(2)}</span>
+          <span className="shrink-0 font-mono text-xs text-fg-4" title="Retrieval similarity score">
+            sim {chunk.score.toFixed(2)}
+          </span>
         ) : null}
       </summary>
       <p className="border-t border-hairline px-3 py-2 text-sm leading-relaxed text-fg-2">

--- a/webapp/src/features/race/components/RegulationsPanel.tsx
+++ b/webapp/src/features/race/components/RegulationsPanel.tsx
@@ -4,13 +4,14 @@
 // Past answers live in a session history rail (store), one click to restore.
 
 import { useState } from 'react'
-import { Scale, Send } from 'lucide-react'
+import { Send } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { SkeletonText } from '@/components/Skeleton'
 import { useToast } from '@/components/Toast'
 import type { RagResult } from '@/lib/api/race'
 import { RaceApiError } from '@/lib/api/race'
+import { cn } from '@/lib/cn'
 import { useRag } from '../queries'
 import { useRaceStore } from '../store'
 import { RagAnswerCard } from './RagAnswerCard'
@@ -50,7 +51,7 @@ export function RegulationsPanel({ initialQuestion }: { initialQuestion?: string
   const answer = viewing ?? rag.data ?? null
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[1fr_16rem]">
+    <div className={cn('grid gap-4', history.length > 0 && 'lg:grid-cols-[1fr_16rem]')}>
       <div className="flex flex-col gap-4">
         <Card elevation="resting" className="flex flex-col gap-3 p-4">
           <label htmlFor="rag-q" className="text-xs font-medium tracking-wide text-fg-3 uppercase">
@@ -110,12 +111,7 @@ export function RegulationsPanel({ initialQuestion }: { initialQuestion?: string
           </Card>
         ) : answer ? (
           <RagAnswerCard result={answer} />
-        ) : (
-          <Card elevation="resting" className="flex items-center gap-3 p-6 text-sm text-fg-3">
-            <Scale className="size-5 text-fg-4" aria-hidden="true" />
-            Ask a question or tap a suggestion. No race data needed.
-          </Card>
-        )}
+        ) : null}
       </div>
 
       {history.length > 0 ? (

--- a/webapp/src/features/race/components/StintGantt.tsx
+++ b/webapp/src/features/race/components/StintGantt.tsx
@@ -11,6 +11,8 @@ import { getDriverTextColor } from '@/lib/drivers'
 import { COMPOUND_ORDER, compoundVariant, type CompoundVariant } from '@/lib/compounds'
 import { tireColors } from '@/charts/echartsTheme'
 import type { RaceRecord } from '@/lib/api/race'
+import type { Theme } from '@/stores/ui'
+import { useUiStore } from '@/stores/ui'
 import { buildGanttModel, COMPOUND_DASH_PREVIEW, type GanttStint } from '../lib/tyreSeries'
 
 const ROW_HEIGHT = 10
@@ -30,6 +32,16 @@ function prefersReducedMotion(): boolean {
 function blockColor(compound: string): string {
   const variant = compoundVariant(compound)
   return variant ? tireColors[variant] : FALLBACK_BLOCK_COLOR
+}
+
+/** Theme-aware stroke for a stint rect. The default hairline token is a thin
+ *  dark tint (~6% opacity), which reads fine on the dark card but nearly
+ *  disappears around the near-white hard-compound fill on a light card, so
+ *  light mode gets a darker, more opaque outline instead so hard-compound
+ *  stints stay visible. `undefined` on dark keeps the existing hairline
+ *  class in charge there. */
+function rectStrokeColor(theme: Theme): string | undefined {
+  return theme === 'light' ? 'rgba(20,18,31,0.25)' : undefined
 }
 
 /** Orders the compounds present soft→wet using the catalogue's own shared
@@ -85,12 +97,14 @@ function DriverRow({
   maxLap,
   ticks,
   revealed,
+  theme,
 }: {
   driver: string
   stints: GanttStint[]
   maxLap: number
   ticks: number[]
   revealed: boolean
+  theme: Theme
 }) {
   return (
     <div className="flex items-center gap-3">
@@ -127,7 +141,8 @@ function DriverRow({
             width={Math.max(stint.endLap - stint.startLap + 1, 1)}
             height={ROW_HEIGHT}
             fill={blockColor(stint.compound)}
-            className="stroke-hairline"
+            className={theme === 'light' ? undefined : 'stroke-hairline'}
+            stroke={rectStrokeColor(theme)}
             strokeWidth={1}
             vectorEffect="non-scaling-stroke"
             style={{
@@ -149,8 +164,18 @@ function DriverRow({
 }
 
 /** Bridges the gantt's fill-colour compound encoding with the degradation
- *  charts' dash encoding, so the two views read as one system. */
-function CompoundLegend({ compounds }: { compounds: CompoundVariant[] }) {
+ *  charts' dash encoding, so the two views read as one system. The dash
+ *  preview is hidden when the Speed view is active: that view repurposes
+ *  dash for the sector split instead of compound, so showing "this is what
+ *  compound looks like as a dash" here would contradict what dash means on
+ *  screen right now; the colour swatch alone still says "compound". */
+function CompoundLegend({
+  compounds,
+  hideDash,
+}: {
+  compounds: CompoundVariant[]
+  hideDash: boolean
+}) {
   if (compounds.length === 0) return null
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -161,17 +186,19 @@ function CompoundLegend({ compounds }: { compounds: CompoundVariant[] }) {
             style={{ backgroundColor: tireColors[variant] }}
             aria-hidden="true"
           />
-          <svg width="18" height="2" aria-hidden="true">
-            <line
-              x1="0"
-              y1="1"
-              x2="18"
-              y2="1"
-              stroke={tireColors[variant]}
-              strokeWidth="2"
-              strokeDasharray={COMPOUND_DASH_PREVIEW[variant]}
-            />
-          </svg>
+          {hideDash ? null : (
+            <svg width="18" height="2" aria-hidden="true">
+              <line
+                x1="0"
+                y1="1"
+                x2="18"
+                y2="1"
+                stroke={tireColors[variant]}
+                strokeWidth="2"
+                strokeDasharray={COMPOUND_DASH_PREVIEW[variant]}
+              />
+            </svg>
+          )}
           {variant.charAt(0) + variant.slice(1).toLowerCase()}
         </span>
       ))}
@@ -211,11 +238,16 @@ function LapAxis({ ticks, maxLap }: { ticks: number[]; maxLap: number }) {
 export interface StintGanttProps {
   /** Frame filtered to the selected drivers (or the whole field if none). */
   rows: RaceRecord[]
+  /** Hides the compound-dash preview in the legend strip. True when the
+   *  Speed view is the active tyre chart below, since that view repurposes
+   *  dash for the sector split instead of compound. */
+  hideCompoundDash?: boolean
 }
 
 /** Stint-plan card: legend strip + one timeline row per driver. Doubles as
  *  the compound-dash legend for the five charts in TyreChartSwitcher. */
-export function StintGantt({ rows }: StintGanttProps) {
+export function StintGantt({ rows, hideCompoundDash = false }: StintGanttProps) {
+  const theme = useUiStore((state) => state.theme)
   const [revealed, setRevealed] = useState<boolean>(() => prefersReducedMotion())
 
   useEffect(() => {
@@ -259,7 +291,7 @@ export function StintGantt({ rows }: StintGanttProps) {
     <Card elevation="resting" className="flex flex-col gap-4 p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h3 className="font-display text-sm font-medium text-fg-1">Stint plan</h3>
-        <CompoundLegend compounds={compoundsPresent} />
+        <CompoundLegend compounds={compoundsPresent} hideDash={hideCompoundDash} />
       </div>
       <div className="flex flex-col gap-2">
         {groupByDriver(stints).map(([driver, driverStints]) => (
@@ -270,6 +302,7 @@ export function StintGantt({ rows }: StintGanttProps) {
             maxLap={maxLap}
             ticks={ticks}
             revealed={revealed}
+            theme={theme}
           />
         ))}
       </div>

--- a/webapp/src/features/race/components/StrategicWindowCards.tsx
+++ b/webapp/src/features/race/components/StrategicWindowCards.tsx
@@ -7,6 +7,7 @@
 // this component and GapCharts can read/set it.
 
 import type { KeyboardEvent } from 'react'
+import { Crosshair } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { StatCard } from '@/components/StatCard'
 import { Pill } from '@/components/Pill'
@@ -17,10 +18,15 @@ import { calculateStrategicWindows, type RaceStrategicWindow } from '../lib/race
 import { RACE_YEAR } from '../search'
 import type { GapHighlight, GapHighlightKind } from '../lib/gapSeries'
 
-const TONE_TEXT_CLASS: Record<GapHighlightKind, string> = {
-  undercut: 'text-success',
-  overcut: 'text-warning',
-  defensive: 'text-danger',
+// Kind identity now lives ONLY in this small dot (StatCard tile corner, or the
+// leaderboard's column header), and the count itself renders in the neutral
+// `text-fg-1`. Colouring the number by kind used to make magnitude and
+// semantics collide: "0 undercut" glowed green (reads "good"), "18
+// defensive" glowed red (reads "alarm"), when both are just counts.
+const KIND_DOT_CLASS: Record<GapHighlightKind, string> = {
+  undercut: 'bg-success',
+  overcut: 'bg-warning',
+  defensive: 'bg-danger',
 }
 
 const CARD_LABEL: Record<GapHighlightKind, string> = {
@@ -94,7 +100,10 @@ export function StrategicWindowCards({ rows, highlight, onHighlight }: Strategic
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="font-display text-sm font-medium text-fg-1">Strategic windows summary</h3>
+      <div className="flex flex-col gap-1">
+        <h3 className="font-display text-sm font-medium text-fg-1">Strategic windows summary</h3>
+        <p className="text-xs text-fg-4">Click a count to pin those laps on the chart.</p>
+      </div>
       {perDriver.length > MAX_FULL_CARD_DRIVERS ? (
         <StrategicWindowLeaderboard perDriver={perDriver} highlight={highlight} onToggle={toggle} />
       ) : (
@@ -141,25 +150,41 @@ function DriverWindowGroup({
             activate()
           }
           return (
-            <StatCard
-              key={kind}
-              eyebrow={CARD_LABEL[kind]}
-              value={<span className={TONE_TEXT_CLASS[kind]}>{laps.length}</span>}
-              hint={clickable ? undefined : 'None this race'}
-              role="button"
-              tabIndex={clickable ? 0 : -1}
-              aria-pressed={active}
-              aria-disabled={!clickable}
-              onClick={activate}
-              onKeyDown={onKeyDown}
-              className={cn(
-                'p-3 transition-colors',
-                clickable
-                  ? 'cursor-pointer hover:ring-1 hover:ring-purple-400/70'
-                  : 'cursor-not-allowed opacity-60',
-                active && 'ring-2 ring-purple-400',
-              )}
-            />
+            // The kind dot and the "clickable" crosshair sit in the two top
+            // corners of the tile, outside StatCard's own markup. Its
+            // `eyebrow` prop only accepts plain text, so a coloured dot can't
+            // live inline with the label without touching that shared
+            // component, which is out of scope here.
+            <div key={kind} className="relative">
+              <span
+                aria-hidden="true"
+                className={cn('absolute top-3 right-3 size-1.5 rounded-full', KIND_DOT_CLASS[kind])}
+              />
+              {clickable ? (
+                <Crosshair
+                  aria-hidden="true"
+                  className="absolute right-3 bottom-3 size-3 text-fg-4"
+                />
+              ) : null}
+              <StatCard
+                eyebrow={CARD_LABEL[kind]}
+                value={<span className="text-fg-1">{laps.length}</span>}
+                hint={clickable ? undefined : 'None this race'}
+                role="button"
+                tabIndex={clickable ? 0 : -1}
+                aria-pressed={active}
+                aria-disabled={!clickable}
+                onClick={activate}
+                onKeyDown={onKeyDown}
+                className={cn(
+                  'p-3 transition-colors',
+                  clickable
+                    ? 'cursor-pointer ring-1 ring-hairline hover:ring-purple-400/70'
+                    : 'cursor-not-allowed opacity-60',
+                  active && 'ring-2 ring-purple-400',
+                )}
+              />
+            </div>
           )
         })}
       </div>
@@ -185,7 +210,7 @@ function StrategicWindowLeaderboard({
   const sorted = [...perDriver].sort((a, b) => b.laps.undercut.length - a.laps.undercut.length)
 
   return (
-    <Card elevation="resting" className="overflow-x-auto">
+    <Card elevation="resting" className="max-w-3xl overflow-x-auto">
       <table className="w-full min-w-md border-collapse text-sm">
         <thead>
           <tr className="border-b border-hairline">
@@ -197,7 +222,13 @@ function StrategicWindowLeaderboard({
                 key={kind}
                 className="px-3 py-2 text-right text-xs font-medium tracking-wide text-fg-3 uppercase"
               >
-                {CARD_LABEL[kind]}
+                <span className="inline-flex items-center justify-end gap-1.5">
+                  <span
+                    aria-hidden="true"
+                    className={cn('size-1.5 rounded-full', KIND_DOT_CLASS[kind])}
+                  />
+                  {CARD_LABEL[kind]}
+                </span>
               </th>
             ))}
           </tr>
@@ -250,8 +281,7 @@ function LeaderboardRow({
               aria-pressed={active}
               onClick={() => onToggle(entry.driver, kind, laps)}
               className={cn(
-                'rounded-md px-2 py-1 font-mono text-sm tabular-nums transition-colors',
-                TONE_TEXT_CLASS[kind],
+                'rounded-md px-2 py-1 font-mono text-sm tabular-nums text-fg-1 transition-colors',
                 clickable
                   ? 'cursor-pointer hover:ring-1 hover:ring-purple-400/70'
                   : 'cursor-not-allowed opacity-40',

--- a/webapp/src/features/race/components/TyreChartSwitcher.tsx
+++ b/webapp/src/features/race/components/TyreChartSwitcher.tsx
@@ -12,7 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/Tabs'
 import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
 import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
 import { F1_LIGHT_THEME } from '@/charts/echartsTheme'
-import type { RaceRecord } from '@/lib/api/race'
+import { RACE_YEAR, type RaceRecord } from '@/lib/api/race'
+import { getDriverColor, getDriverTextColor, resolvePilotColor } from '@/lib/drivers'
 import type { Theme } from '@/stores/ui'
 import { buildTyreChartOption, TYRE_CHART_META } from '../lib/tyreSeries'
 import { TYRE_CHARTS, useRaceStore, type TyreChartKey } from '../store'
@@ -20,6 +21,63 @@ import { TYRE_CHARTS, useRaceStore, type TyreChartKey } from '../store'
 registerF1Theme()
 
 const CHART_HEIGHT = 360
+/** Chart height inside "Show all": five full-height cards read as a stacked
+ *  scroll of near-identical plots, so the grid below uses a compacted height
+ *  instead of the single-view default. */
+const SHOW_ALL_CHART_HEIGHT = 260
+
+/** Distinct driver codes actually plotted, alphabetical. TyresPanel only ever
+ *  lets 1-3 drivers through to this chart (more would be spaghetti), so this
+ *  never has to scroll or scale like the old per-stint ECharts legend did. */
+function distinctDrivers(rows: RaceRecord[]): string[] {
+  return [...new Set(rows.map((row) => row.Driver))].sort()
+}
+
+/** One driver's identity chip: a dot in the exact colour drawn on the chart
+ *  line (so the eye can match chip to line at a glance) plus the driver code
+ *  in its readable team colour. Same rounded-chip shape PodiumQuickPick uses
+ *  for its quick-pick buttons, reused here as a static (non-clickable) label. */
+function DriverChip({ driver, theme }: { driver: string; theme: Theme }) {
+  const dotColor = resolvePilotColor(getDriverColor(driver, RACE_YEAR), theme)
+  const textColor = getDriverTextColor(driver, RACE_YEAR)
+  return (
+    <span className="flex items-center gap-1.5 rounded-full border border-hairline bg-bg-4 px-2.5 py-1 font-mono text-xs">
+      <span
+        aria-hidden="true"
+        className="size-1.5 rounded-full"
+        style={{ backgroundColor: dotColor }}
+      />
+      <span style={{ color: textColor }}>{driver}</span>
+    </span>
+  )
+}
+
+/** Replaces the old per-(driver, stint) ECharts legend: driver identity shown
+ *  once, in HTML, instead of six to twelve mono entries crammed into an 11px
+ *  scroll strip. Compound is already covered by the stint gantt's legend
+ *  strip above the switcher, so this only needs to say "driver". */
+function DriverLegend({ rows, theme }: { rows: RaceRecord[]; theme: Theme }) {
+  const drivers = distinctDrivers(rows)
+  if (drivers.length === 0) return null
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {drivers.map((driver) => (
+        <DriverChip key={driver} driver={driver} theme={theme} />
+      ))}
+    </div>
+  )
+}
+
+/** Static caption for the two views whose dash encoding needs an explicit
+ *  key: Speed repurposes dash for the sector split rather than compound
+ *  (what every other view uses it for), and Reg-vs-adj introduces a
+ *  bold/faint pairing none of the other views have. The other three views
+ *  don't need a caption. */
+function tyreChartFooter(chartKey: TyreChartKey): string | undefined {
+  if (chartKey === 'speed') return 'Line style = sector: solid S1, dashed S2, dotted FL'
+  if (chartKey === 'regVsAdj') return 'Bold = fuel-adjusted, faint = raw'
+  return undefined
+}
 
 export interface TyreChartSwitcherProps {
   /** Frame filtered to the selected drivers (or the whole field if none). */
@@ -35,11 +93,19 @@ function TyreChart({
   compound,
   theme,
   chartKey,
+  height = CHART_HEIGHT,
+  showDriverLegend = true,
 }: {
   rows: RaceRecord[]
   compound: string | undefined
   theme: Theme
   chartKey: TyreChartKey
+  /** Card chart height in px. Show all passes a compacted value so five
+   *  cards don't each claim the single-view's full height. */
+  height?: number
+  /** False in Show all, where one shared legend renders above the whole
+   *  grid instead of five repeated copies. */
+  showDriverLegend?: boolean
 }) {
   const chartTheme = useChartTheme()
   // Inside the maximized overlay, fill the card instead of holding the fixed
@@ -52,8 +118,13 @@ function TyreChart({
     [chartKey, rows, compound, theme],
   )
   const paintedOption = useFirstPaintAnimation(option)
+  const footerNote = tyreChartFooter(chartKey)
   return (
-    <ChartCard title={TYRE_CHART_META[chartKey].title}>
+    <ChartCard
+      title={TYRE_CHART_META[chartKey].title}
+      actions={showDriverLegend ? <DriverLegend rows={rows} theme={theme} /> : undefined}
+      footer={footerNote ? <span className="text-xs text-fg-3">{footerNote}</span> : undefined}
+    >
       <div
         role="img"
         aria-label={`${TYRE_CHART_META[chartKey].title} chart`}
@@ -63,7 +134,7 @@ function TyreChart({
           theme={chartTheme}
           key={`${chartTheme}-${maximized}`}
           option={paintedOption}
-          style={{ height: maximized ? '100%' : CHART_HEIGHT }}
+          style={{ height: maximized ? '100%' : height }}
           notMerge
         />
       </div>
@@ -103,9 +174,20 @@ export function TyreChartSwitcher({ rows, compound }: TyreChartSwitcherProps) {
 
       {tyreShowAll ? (
         <div className="mt-4 flex flex-col gap-4">
-          {TYRE_CHARTS.map((key) => (
-            <TyreChart key={key} rows={rows} compound={compound} theme={theme} chartKey={key} />
-          ))}
+          <DriverLegend rows={rows} theme={theme} />
+          <div className="grid gap-4 xl:grid-cols-2">
+            {TYRE_CHARTS.map((key) => (
+              <TyreChart
+                key={key}
+                rows={rows}
+                compound={compound}
+                theme={theme}
+                chartKey={key}
+                height={SHOW_ALL_CHART_HEIGHT}
+                showDriverLegend={false}
+              />
+            ))}
+          </div>
         </div>
       ) : (
         TYRE_CHARTS.map((key) => (

--- a/webapp/src/features/race/components/TyresPanel.tsx
+++ b/webapp/src/features/race/components/TyresPanel.tsx
@@ -9,6 +9,7 @@ import { CompoundPill } from '@/components/CompoundPill'
 import { cn } from '@/lib/cn'
 import type { RaceRecord } from '@/lib/api/race'
 import { compoundVariant, type CompoundVariant } from '@/lib/compounds'
+import { useRaceStore } from '../store'
 import { StintGantt } from './StintGantt'
 import { TyreChartSwitcher } from './TyreChartSwitcher'
 import { PodiumQuickPick } from './PodiumQuickPick'
@@ -74,6 +75,13 @@ export function TyresPanel({
   podium,
   onPick,
 }: TyresPanelProps) {
+  // Read directly from the tab's own store rather than a new prop from
+  // RacePage: both the compound-filter gating below and the gantt's
+  // dash-preview toggle need to know which tyre view is active, and
+  // TyreChartSwitcher already reads this same store for its own state.
+  const tyreChart = useRaceStore((s) => s.tyreChart)
+  const tyreShowAll = useRaceStore((s) => s.tyreShowAll)
+
   if (rows.length === 0) {
     return (
       <EmptyState
@@ -84,33 +92,40 @@ export function TyresPanel({
   }
 
   const compounds = compoundsInFrame(rows)
+  // The compound filter only feeds the Speed view (buildSpeedOption is the
+  // only builder that reads it), so showing it above every other view made
+  // it look like a control that silently does nothing on four out of five tabs.
+  const showCompoundFilter = (tyreChart === 'speed' || tyreShowAll) && compounds.length > 0
+
+  if (!hasSelection) {
+    // Quick-pick leads here instead of trailing a 600px gantt off-viewport;
+    // the gantt still follows so the full field's stint plan stays visible.
+    return (
+      <div className="flex flex-col gap-6">
+        <PodiumQuickPick podium={podium} onPick={onPick} />
+        <StintGantt rows={rows} />
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-6">
-      <StintGantt rows={rows} />
+      <StintGantt rows={rows} hideCompoundDash={tyreChart === 'speed'} />
 
-      {hasSelection ? (
-        <>
-          {compounds.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-xs font-medium uppercase tracking-widest text-fg-3">
-                Compound
-              </span>
-              {compounds.map((c) => (
-                <CompoundFilterChip
-                  key={c}
-                  compound={c}
-                  active={compound === c}
-                  onClick={() => onCompound(compound === c ? undefined : c)}
-                />
-              ))}
-            </div>
-          ) : null}
-          <TyreChartSwitcher rows={rows} compound={compound} />
-        </>
-      ) : (
-        <PodiumQuickPick podium={podium} onPick={onPick} />
-      )}
+      {showCompoundFilter ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium uppercase tracking-widest text-fg-3">Compound</span>
+          {compounds.map((c) => (
+            <CompoundFilterChip
+              key={c}
+              compound={c}
+              active={compound === c}
+              onClick={() => onCompound(compound === c ? undefined : c)}
+            />
+          ))}
+        </div>
+      ) : null}
+      <TyreChartSwitcher rows={rows} compound={compound} />
     </div>
   )
 }

--- a/webapp/src/features/race/lib/gapSeries.ts
+++ b/webapp/src/features/race/lib/gapSeries.ts
@@ -27,6 +27,7 @@ import type {
 import type { RaceRecord } from '@/lib/api/race'
 import { getDriverColor, getDriverTextColor } from '@/lib/drivers'
 import { interp } from '@/lib/interp'
+import type { Theme } from '@/stores/ui'
 
 // ── Domain thresholds ─────────────────────────────────────────────────────────
 // Mirror the private UNDERCUT_MAX/OVERCUT_MAX/CONSISTENCY_MIN constants in
@@ -36,14 +37,22 @@ import { interp } from '@/lib/interp'
 const UNDERCUT_MAX = 2.0
 const OVERCUT_MAX = 3.5
 const CONSISTENCY_THRESHOLD = 3
+/** Y-axis cap for the consistency bars: a single long streak (a driver who
+ *  held one window for 40-50 laps) otherwise flattens the 3-lap strategic
+ *  threshold into an unreadable sliver near the x-axis. Box-zoom via the
+ *  toolbox still reaches anything taller. */
+const CONSISTENCY_Y_MAX = 15
 const DEFAULT_Y_MAX = OVERCUT_MAX + 2
 /** Default y-axis ceiling: keeps the strategic band readable when a lapped car
  *  has a huge gap; the toolbox box-zoom reaches anything taller. */
 const Y_MAX_CEILING = 12
 
-const UNDERCUT_ZONE_COLOR = 'rgba(34,197,94,0.12)'
-const OVERCUT_ZONE_COLOR = 'rgba(234,179,8,0.10)'
-const NO_STRATEGY_ZONE_COLOR = 'rgba(239,68,68,0.08)'
+// Zone-band base colours as bare "r,g,b" triples (not full rgba strings), so
+// `zoneColor()` below can apply a different alpha per theme. A wash that
+// reads as a calm hint over a dark card turns into a solid pastel flag over a
+// white one, so light mode needs roughly half the opacity.
+const UNDERCUT_ZONE_RGB = '34,197,94'
+const OVERCUT_ZONE_RGB = '234,179,8'
 const UNDERCUT_LINE_COLOR = '#22c55e'
 const OVERCUT_LINE_COLOR = '#eab308'
 const DEFENSIVE_LINE_COLOR = '#ef4444'
@@ -225,7 +234,11 @@ function buildGrid(hasLegend: boolean): EChartsOption['grid'] {
     top: hasLegend ? 44 : 16,
     left: 8,
     right: 20,
-    bottom: 8,
+    // 28, not 8: `containLabel` reserves room for axis LABELS, never for the
+    // axis NAME. At 8 the centred "Lap" name renders half off the bottom
+    // edge under the tick row; 28 gives the name (nameGap: 28 in lapAxis())
+    // enough room to actually fit inside the card.
+    bottom: 28,
     containLabel: true,
   }
 }
@@ -257,18 +270,26 @@ function zoomToolbox(): EChartsOption['toolbox'] {
 /** One tooltip row per hovered series, in the series' own readable colour —
  *  built from an explicit name→colour map (rather than re-deriving a driver
  *  code from the series name, which carries an " ahead"/" behind" suffix here)
- *  so ghost series (zones/highlight/threshold, absent from the map) never show. */
+ *  so ghost series (zones/highlight/threshold, absent from the map) never show.
+ *  A header line names the hovered lap first (e.g. "Lap 19"), rounded since
+ *  the continuous value x-axis otherwise hands back a raw float like "19.4".
+ *  The header text carries no explicit colour so it inherits the tooltip's own
+ *  theme text colour (white on dark, ink on light) and is only dimmed with
+ *  opacity, keeping it legible in both themes without a hardcoded hex. */
 function buildAxisTooltipFormatter(
   textColorByName: Map<string, string>,
   formatValue: (raw: number) => string,
 ) {
   return (params: TooltipComponentFormatterCallbackParams): string => {
     const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
-    return items
+    const rawLap = (items[0] as { axisValue?: number | string } | undefined)?.axisValue
+    const lap = typeof rawLap === 'number' ? Math.round(rawLap) : rawLap
+    const header = `<div style="font-family:${MONO};margin-bottom:6px;opacity:0.6">Lap ${lap ?? '-'}</div>`
+    const rows = items
       .filter((item) => item.seriesName && textColorByName.has(item.seriesName))
       .map((item) => {
         const raw = Array.isArray(item.value) ? item.value[1] : item.value
-        const display = typeof raw === 'number' ? formatValue(raw) : '—'
+        const display = typeof raw === 'number' ? formatValue(raw) : '-'
         const color = textColorByName.get(item.seriesName ?? '') ?? '#f5f5f5'
         return `<div style="display:flex;justify-content:space-between;gap:20px;">
   <span style="color:${color}">${item.seriesName}</span>
@@ -276,6 +297,7 @@ function buildAxisTooltipFormatter(
 </div>`
       })
       .join('')
+    return header + rows
   }
 }
 
@@ -285,15 +307,28 @@ type MarkAreaEntry = NonNullable<MarkAreaComponentOption['data']>[number]
 type MarkLineEntry = NonNullable<MarkLineComponentOption['data']>[number]
 type MarkPointEntry = NonNullable<MarkPointComponentOption['data']>[number]
 
-/** Ghost series (no visible line of its own) hosting the three zone
- *  `markArea` bands — undercut/overcut/no-strategy, bottom to top — and the
- *  two boundary `markLine`s. A low `z` keeps it painting under every driver's
- *  real line, mirroring RaceTrace.tsx's `buildStintBandsSeries`. */
-function buildZonesSeries(yMax: number): LineSeriesOption {
+/** Zone-band alpha for one theme: dark reads calmly at a slightly richer
+ *  alpha; light needs roughly half that or the same value renders as a solid
+ *  pastel flag over a white card and swallows the drivers' own line colours. */
+function zoneColor(rgb: string, theme: Theme, darkAlpha: number, lightAlpha: number): string {
+  const alpha = theme === 'light' ? lightAlpha : darkAlpha
+  return `rgba(${rgb},${alpha})`
+}
+
+/** Ghost series (no visible line of its own) hosting the two zone
+ *  `markArea` bands, undercut then overcut, and their boundary `markLine`s.
+ *  There is deliberately no third "no strategy" band above the overcut
+ *  threshold: the absence of shading already says "no defined zone" here,
+ *  and a red wash covering the rest of the plot fought the drivers' own
+ *  lines for attention without adding information. A low `z` keeps this
+ *  series painting under every driver's real line, mirroring
+ *  RaceTrace.tsx's `buildStintBandsSeries`. */
+function buildZonesSeries(theme: Theme): LineSeriesOption {
+  const undercutColor = zoneColor(UNDERCUT_ZONE_RGB, theme, 0.1, 0.05)
+  const overcutColor = zoneColor(OVERCUT_ZONE_RGB, theme, 0.08, 0.04)
   const areaData: MarkAreaEntry[] = [
-    [{ yAxis: 0, itemStyle: { color: UNDERCUT_ZONE_COLOR } }, { yAxis: UNDERCUT_MAX }],
-    [{ yAxis: UNDERCUT_MAX, itemStyle: { color: OVERCUT_ZONE_COLOR } }, { yAxis: OVERCUT_MAX }],
-    [{ yAxis: OVERCUT_MAX, itemStyle: { color: NO_STRATEGY_ZONE_COLOR } }, { yAxis: yMax }],
+    [{ yAxis: 0, itemStyle: { color: undercutColor } }, { yAxis: UNDERCUT_MAX }],
+    [{ yAxis: UNDERCUT_MAX, itemStyle: { color: overcutColor } }, { yAxis: OVERCUT_MAX }],
   ]
   const lineData: MarkLineEntry[] = [
     {
@@ -382,14 +417,17 @@ function buildHighlightSeries(
 
 /**
  * Gap-to-car-ahead (solid) and gap-to-car-behind (dashed) per loaded driver,
- * team-coloured, over undercut/overcut/no-strategy zone shading — the merge of
+ * team-coloured, over undercut/overcut zone shading — the merge of
  * `st_plot_gap_evolution` and `st_plot_undercut_opportunities` into one chart.
  * `highlight` (from a clicked StrategicWindowCards tile) adds coloured pins at
- * that driver's qualifying laps.
+ * that driver's qualifying laps. `theme` only feeds the zone-band alpha (see
+ * `zoneColor`); the y-axis unit ("Gap (s)") lives in the ChartCard title
+ * instead of an in-chart axis name, which `containLabel` clips at this grid.
  */
 export function buildGapEvolutionOption(
   rows: RaceRecord[],
   year: number | undefined,
+  theme: Theme,
   highlight?: GapHighlight,
 ): EChartsOption {
   const byDriver = groupRowsByDriver(rows)
@@ -441,7 +479,7 @@ export function buildGapEvolutionOption(
     }
   }
 
-  series.push(buildZonesSeries(yMax))
+  series.push(buildZonesSeries(theme))
   const highlightSeries = buildHighlightSeries(byDriver, highlight)
   if (highlightSeries) series.push(highlightSeries)
 
@@ -458,7 +496,11 @@ export function buildGapEvolutionOption(
     legend: buildLegend(legendEntries),
     grid: buildGrid(hasLegend),
     xAxis: lapAxis(),
-    yAxis: { type: 'value', name: 'Gap (s)', min: 0, max: yMax },
+    // No `name` here: `containLabel` never reserves room for an axis NAME
+    // (only its labels), so a horizontal y-axis name renders half off-canvas
+    // at this grid width. The unit lives in the ChartCard title instead
+    // ("Gap evolution (s)"), matching the tyre charts' fix for the same bug.
+    yAxis: { type: 'value', min: 0, max: yMax },
     toolbox: zoomToolbox(),
     series,
   }
@@ -551,7 +593,11 @@ export function buildGapConsistencyOption(
     legend: buildLegend(legendEntries),
     grid: buildGrid(hasLegend),
     xAxis: lapAxis(),
-    yAxis: { type: 'value', name: 'Consecutive laps', min: 0 },
+    // No `name` (same axis-name clipping fix as gap evolution above; the unit
+    // lives in the ChartCard title as "Gap consistency (laps)"). `max` caps
+    // the cap-worthy streak so the 3-lap threshold stays legible instead of
+    // hugging the x-axis (see `CONSISTENCY_Y_MAX`).
+    yAxis: { type: 'value', min: 0, max: CONSISTENCY_Y_MAX },
     toolbox: zoomToolbox(),
     series,
   }

--- a/webapp/src/features/race/lib/tyreSeries.ts
+++ b/webapp/src/features/race/lib/tyreSeries.ts
@@ -12,13 +12,20 @@
 // silently show a single driver instead of the whole field. Same fix as the
 // Dashboard telemetry charts (`ChannelChart.tsx`, `findDensestDistanceGrid`).
 
-import type { EChartsOption, LineSeriesOption } from 'echarts'
+import type {
+  DefaultLabelFormatterCallbackParams,
+  EChartsOption,
+  LineSeriesOption,
+  TooltipComponentFormatterCallbackParams,
+} from 'echarts'
 import { RACE_YEAR, type RaceRecord } from '@/lib/api/race'
-import { getDriverColor, resolvePilotColor } from '@/lib/drivers'
+import { getDriverColor, getDriverTextColor, resolvePilotColor } from '@/lib/drivers'
 import { compoundLabel, compoundVariant } from '@/lib/compounds'
 import { interp } from '@/lib/interp'
 import type { Theme } from '@/stores/ui'
 import type { TyreChartKey } from '../store'
+
+const MONO = "'JetBrains Mono Variable', ui-monospace, monospace"
 
 // ── Compound dash encoding (ported from race_viz.py COMPOUND_DASHES) ────────
 
@@ -152,17 +159,55 @@ function toSeriesData(
 
 // ── Shared chart scaffolding ─────────────────────────────────────────────────
 
-function baseTyreOption(yAxisName: string, valueSuffix: string): EChartsOption {
+/** The tyres tab's shared axis-tooltip formatter: a "Tyre life N laps" header
+ *  (the shared x-axis value rounded to a whole lap, replacing ECharts' default
+ *  two-decimal float) followed by one coloured row per hovered series. Kept
+ *  as its own copy of the header-plus-rows shape gapSeries.ts's tooltip
+ *  formatter uses, rather than importing it, so the two chart files stay
+ *  independent of each other. The header has no explicit colour, so it
+ *  inherits the tooltip's own theme text colour and just dims via opacity
+ *  instead of hardcoding a light/dark hex here. */
+function tyreAxisTooltipFormatter(textColorByName: Map<string, string>, valueSuffix: string) {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items: DefaultLabelFormatterCallbackParams[] = Array.isArray(params) ? params : [params]
+    const rows = items
+      .filter((item) => item.seriesName && textColorByName.has(item.seriesName))
+      .map((item) => {
+        const raw = Array.isArray(item.value) ? item.value[1] : item.value
+        const display = typeof raw === 'number' ? `${raw.toFixed(2)}${valueSuffix}` : '-'
+        const color = textColorByName.get(item.seriesName ?? '') ?? '#f5f5f5'
+        return `<div style="display:flex;justify-content:space-between;gap:20px;">
+  <span style="color:${color}">${item.seriesName}</span>
+  <span style="font-family:${MONO}">${display}</span>
+</div>`
+      })
+      .join('')
+    const firstAxisValue = (items[0] as { axisValue?: number | string } | undefined)?.axisValue
+    const lap = typeof firstAxisValue === 'number' ? Math.round(firstAxisValue) : firstAxisValue
+    const header = `<div style="font-family:${MONO};margin-bottom:6px;opacity:0.7;">Tyre life ${lap ?? '-'} laps</div>`
+    return header + rows
+  }
+}
+
+/** Scaffolding shared by every degradation view. The ECharts legend stays off
+ *  (`show: false`): with six to twelve (driver, stint) entries it was the
+ *  single most cramped element on the chart, and driver identity is now
+ *  carried once, in HTML, by the chip row in the ChartCard header instead
+ *  (see TyreChartSwitcher.tsx), freeing the top of the grid back down from
+ *  44px to 16px. `textColorByName` feeds the per-series tooltip rows; each
+ *  builder assembles it as it creates its series, since that's where a
+ *  series' driver (and hence its colour) is known. */
+function baseTyreOption(valueSuffix: string, textColorByName: Map<string, string>): EChartsOption {
   return {
     tooltip: {
       trigger: 'axis',
-      valueFormatter: (value) =>
-        typeof value === 'number' ? `${value.toFixed(2)}${valueSuffix}` : '—',
+      extraCssText: 'border-radius:12px;padding:10px 12px',
+      formatter: tyreAxisTooltipFormatter(textColorByName, valueSuffix),
     },
-    legend: { type: 'scroll', top: 0, textStyle: { fontSize: 11 } },
-    grid: { top: 44, left: 8, right: 20, bottom: 8, containLabel: true },
+    legend: { show: false },
+    grid: { top: 16, left: 8, right: 20, bottom: 28, containLabel: true },
     xAxis: { type: 'value', name: 'Tyre life (laps)', nameLocation: 'middle', nameGap: 28 },
-    yAxis: { type: 'value', name: yAxisName, scale: true },
+    yAxis: { type: 'value', scale: true },
     // No `inside` dataZoom — it traps the page's mouse wheel (see
     // ChannelChart.tsx). Zoom stays available through the toolbox box-zoom
     // (drag a box), which never touches the wheel.
@@ -246,25 +291,20 @@ function buildSpeedOption(
   const groups = groupByDriverStint(filtered)
   const grid = tyreLifeGrid(groups)
   const series: LineSeriesOption[] = []
+  const textColorByName = new Map<string, string>()
   for (const group of groups) {
     const color = resolvePilotColor(getDriverColor(group.driver, RACE_YEAR), theme)
+    const textColor = getDriverTextColor(group.driver, RACE_YEAR)
     for (const sector of SECTOR_FIELDS) {
       const { xs, ys } = extractPoints(group.rows, (row) => row[sector.key])
       if (xs.length === 0) continue
       const values = resampleOnGrid(grid, xs, ys)
-      series.push(
-        lineSeries(
-          `${seriesName(group)} · ${sector.label}`,
-          color,
-          sector.dash,
-          2,
-          undefined,
-          toSeriesData(grid, values),
-        ),
-      )
+      const name = `${seriesName(group)} · ${sector.label}`
+      series.push(lineSeries(name, color, sector.dash, 2, undefined, toSeriesData(grid, values)))
+      textColorByName.set(name, textColor)
     }
   }
-  return { ...baseTyreOption('Speed (km/h)', ' km/h'), series }
+  return { ...baseTyreOption(' km/h', textColorByName), series }
 }
 
 // ── Builders 2-3-5: one metric, one line per (driver, stint) ────────────────
@@ -272,21 +312,22 @@ function buildSpeedOption(
 function buildMetricOption(
   rows: RaceRecord[],
   metric: (row: RaceRecord) => number | null,
-  yAxisName: string,
   valueSuffix: string,
   theme: Theme,
 ): EChartsOption {
   const groups = groupByDriverStint(rows)
   const grid = tyreLifeGrid(groups)
   const series: LineSeriesOption[] = []
+  const textColorByName = new Map<string, string>()
   for (const group of groups) {
     const { xs, ys } = extractPoints(group.rows, metric)
     if (xs.length === 0) continue
     const color = resolvePilotColor(getDriverColor(group.driver, RACE_YEAR), theme)
     const values = resampleOnGrid(grid, xs, ys)
+    const name = seriesName(group)
     series.push(
       lineSeries(
-        seriesName(group),
+        name,
         color,
         dashForCompound(group.compoundId, group.compound),
         2,
@@ -294,8 +335,9 @@ function buildMetricOption(
         toSeriesData(grid, values),
       ),
     )
+    textColorByName.set(name, getDriverTextColor(group.driver, RACE_YEAR))
   }
-  return { ...baseTyreOption(yAxisName, valueSuffix), series }
+  return { ...baseTyreOption(valueSuffix, textColorByName), series }
 }
 
 // ── Builder 4: regular vs fuel-adjusted degradation ──────────────────────────
@@ -307,44 +349,65 @@ function buildMetricOption(
  * trace is bold, mirroring race_viz.py's thin-dashed-vs-bold-solid pairing
  * (there the dash was free for this; here it already carries the compound,
  * so weight + opacity take over as the regular/adjusted signal instead).
+ *
+ * The regular trace's opacity and width are themed: at dark-mode's 0.5
+ * opacity the raw line washes out to near-invisible over a white light-mode
+ * card, so light mode gets a stronger 0.65 opacity and a touch more width to
+ * keep the raw-vs-adjusted contrast the whole view exists to show.
  */
 function buildRegVsAdjOption(rows: RaceRecord[], theme: Theme): EChartsOption {
   const groups = groupByDriverStint(rows)
   const grid = tyreLifeGrid(groups)
   const series: LineSeriesOption[] = []
+  const textColorByName = new Map<string, string>()
+  const regularOpacity = theme === 'light' ? 0.65 : 0.5
+  const regularWidth = theme === 'light' ? 1.75 : 1.5
   for (const group of groups) {
     const color = resolvePilotColor(getDriverColor(group.driver, RACE_YEAR), theme)
     const dash = dashForCompound(group.compoundId, group.compound)
     const name = seriesName(group)
+    const textColor = getDriverTextColor(group.driver, RACE_YEAR)
 
     const regular = extractPoints(group.rows, (row) => row.DegradationRate)
     if (regular.xs.length > 0) {
       const values = resampleOnGrid(grid, regular.xs, regular.ys)
+      const regularName = `${name} · regular`
       series.push(
-        lineSeries(`${name} · regular`, color, dash, 1.5, 0.5, toSeriesData(grid, values)),
+        lineSeries(
+          regularName,
+          color,
+          dash,
+          regularWidth,
+          regularOpacity,
+          toSeriesData(grid, values),
+        ),
       )
+      textColorByName.set(regularName, textColor)
     }
 
     const adjusted = extractPoints(group.rows, (row) => row.FuelAdjustedDegAbsolute)
     if (adjusted.xs.length > 0) {
       const values = resampleOnGrid(grid, adjusted.xs, adjusted.ys)
-      series.push(
-        lineSeries(`${name} · adjusted`, color, dash, 2.5, undefined, toSeriesData(grid, values)),
-      )
+      const adjustedName = `${name} · adjusted`
+      series.push(lineSeries(adjustedName, color, dash, 2.5, undefined, toSeriesData(grid, values)))
+      textColorByName.set(adjustedName, textColor)
     }
   }
-  return { ...baseTyreOption('Degradation (s/lap)', 's'), series }
+  return { ...baseTyreOption('s', textColorByName), series }
 }
 
 // ── Public entry point ───────────────────────────────────────────────────────
 
-/** Tab label + chart-card title for each of the five views. */
+/** Tab label + chart-card title for each of the five views. Titles carry the
+ *  unit that used to live in the (clipped) ECharts y-axis name: deleting
+ *  that name in `baseTyreOption` means the title is now the only place the
+ *  unit shows up, so it has to say it. */
 export const TYRE_CHART_META: Record<TyreChartKey, { label: string; title: string }> = {
-  speed: { label: 'Speed', title: 'Speed vs tyre age' },
-  fuelAdj: { label: 'Fuel-adj', title: 'Fuel-adjusted degradation' },
-  regVsAdj: { label: 'Reg vs adj', title: 'Regular vs fuel-adjusted degradation' },
-  rate: { label: 'Rate', title: 'Degradation rate' },
-  pct: { label: '%', title: 'Fuel-adjusted degradation %' },
+  speed: { label: 'Speed', title: 'Speed vs tyre age (km/h)' },
+  fuelAdj: { label: 'Fuel-adj', title: 'Fuel-adjusted degradation (s/lap)' },
+  regVsAdj: { label: 'Raw vs adj', title: 'Regular vs fuel-adjusted degradation (s/lap)' },
+  rate: { label: 'Rate', title: 'Degradation rate (s/lap)' },
+  pct: { label: 'Deg %', title: 'Fuel-adjusted degradation (%)' },
 }
 
 export interface TyreChartBuildOptions {
@@ -364,31 +427,13 @@ export function buildTyreChartOption(
     case 'speed':
       return buildSpeedOption(rows, opts.compound, opts.theme)
     case 'fuelAdj':
-      return buildMetricOption(
-        rows,
-        (row) => row.FuelAdjustedDegAbsolute,
-        'Fuel-adjusted degradation (s/lap)',
-        's',
-        opts.theme,
-      )
+      return buildMetricOption(rows, (row) => row.FuelAdjustedDegAbsolute, 's', opts.theme)
     case 'regVsAdj':
       return buildRegVsAdjOption(rows, opts.theme)
     case 'rate':
-      return buildMetricOption(
-        rows,
-        (row) => row.DegradationRate,
-        'Degradation rate (s/lap)',
-        's',
-        opts.theme,
-      )
+      return buildMetricOption(rows, (row) => row.DegradationRate, 's', opts.theme)
     case 'pct':
-      return buildMetricOption(
-        rows,
-        (row) => row.FuelAdjustedDegPercent,
-        'Fuel-adjusted degradation (%)',
-        '%',
-        opts.theme,
-      )
+      return buildMetricOption(rows, (row) => row.FuelAdjustedDegPercent, '%', opts.theme)
   }
 }
 


### PR DESCRIPTION
## What
Design-refinement pass over the Race Analysis tab, applying a UI-design audit of every sub-tab (Tyres, Gaps, Dataset, Radio, Regulations) in both themes. No behaviour or data changes, no new dependencies.

## Why
The freshly-migrated tab still read too much like the Streamlit original: clipped chart axes, crowded 6-12 entry legends, full-bleed zone washes, and tables stretched to full width with wide gaps between columns.

## How
- Tyres: units moved into card titles (axis names no longer clip), per-stint legend replaced by a driver-only chip row, Show-all rendered as a two-column grid under one shared legend, rounded lap-headed tooltip, per-view micro-legends, light-theme fixes for hard compound and raw traces.
- Gaps: dropped the full-bleed no-strategy zone and made the rest theme-aware, capped the consistency axis at 15 laps, added a lap header to the tooltip, de-coloured and width-capped the strategic-window leaderboard, gave the window cards a resting click affordance.
- Dataset: narrow presets hug their columns via a new opt-in DataTable fit-content prop, compound cells use a dot plus text, a Columns eyebrow separates the preset picker from the page tabs.
- Chrome/Radio/Regs: slimmed the sticky context bar and inlined Local data, made the Radio audio-only state explicit, removed the Regulations ghost column and redundant placeholder card.

## Checks
- typecheck (tsc -b): clean
- build (vite): 2907 modules, green
- oxlint: no new warnings in features/race
- browser-verified all five sub-tabs in dark and light themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact table sizing for selected race data views.
  * Added clearer loaded-race details and local dataset controls.
  * Radio browsing now distinguishes total messages from available transcripts and can open the composer directly.
  * Added driver legends, explanatory chart notes, and theme-aware chart styling.
* **Improvements**
  * Improved race tab defaults when no data is loaded.
  * Refined tyre, gap, stint, strategy, and regulations layouts and tooltips.
  * Updated numeric precision, compound displays, boolean labels, and source metadata readability.
  * Simplified empty-state messaging and removed unnecessary regulation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->