### PR TITLE
fix(webapp): clarify radio hint, wrap radio messages, reveal regulation answers

### DIFF
--- a/webapp/src/components/Combobox.tsx
+++ b/webapp/src/components/Combobox.tsx
@@ -155,11 +155,26 @@ export interface ComboboxProps {
   className?: string
   /** Accessible name for the trigger when the visible label lives elsewhere. */
   ariaLabel?: string
+  /** Optional trailing marker rendered on the right of an option row (e.g. a
+   *  small "radio available" badge on circuits that have team radio). Returns
+   *  null for options that carry no marker. Shows only in the dropdown, not on
+   *  the collapsed trigger, so the selected value stays clean. */
+  getOptionHint?: (value: string) => ReactNode
 }
 
 /** Single-select typeahead combobox (e.g. "pick a circuit"). */
 export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
-  { options, value, onChange, placeholder = 'Select...', disabled, loading, className, ariaLabel },
+  {
+    options,
+    value,
+    onChange,
+    placeholder = 'Select...',
+    disabled,
+    loading,
+    className,
+    ariaLabel,
+    getOptionHint,
+  },
   ref,
 ) {
   const [open, setOpen] = useState(false)
@@ -207,7 +222,10 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Co
             className={cn(ITEM_CLASSNAME, 'cursor-pointer')}
           >
             <span className="truncate">{option.label}</span>
-            {option.value === value && <CheckIcon className="size-4 shrink-0 text-purple-400" />}
+            <span className="flex shrink-0 items-center gap-2">
+              {getOptionHint?.(option.value)}
+              {option.value === value && <CheckIcon className="size-4 shrink-0 text-purple-400" />}
+            </span>
           </Command.Item>
         ))}
       </ComboboxPanel>

--- a/webapp/src/features/race/components/RaceContextBar.tsx
+++ b/webapp/src/features/race/components/RaceContextBar.tsx
@@ -1,7 +1,7 @@
 // Context row for Race Analysis: the GP selector + a driver multiselect (cap
 // 3, options come from the loaded frame). No year/session (Race is always the
 // 2025 featured parquet), and no explicit load gate: picking a GP auto-fetches.
-// A dot on a GP option flags radio availability.
+// A small "radio" badge on a GP option flags team-radio availability.
 //
 // This is the only part meant to stay pinned under the page header. The
 // loaded-frame summary and the local-data drop zone live in the separate
@@ -9,7 +9,7 @@
 // a chart never pins a quarter of the viewport as chrome.
 
 import { useState } from 'react'
-import { ChevronRight, CircleDot, Database, X } from 'lucide-react'
+import { ChevronRight, CircleDot, Database, Mic, X } from 'lucide-react'
 import { Combobox, MultiCombobox, type ComboboxOption } from '@/components/Combobox'
 import { FileDrop } from '@/components/FileDrop'
 import { Pill } from '@/components/Pill'
@@ -45,7 +45,7 @@ export function RaceContextBar({ value, onChange, driverOptions, loading }: Race
 
   const gpOptions: ComboboxOption[] = (gpsQuery.data ?? []).map((gp) => ({
     value: gp,
-    label: radioGps.has(gp) ? `${gp}  ●` : gp,
+    label: gp,
   }))
   const driverComboOptions: ComboboxOption[] = driverOptions.map((code) => ({
     value: code,
@@ -70,6 +70,14 @@ export function RaceContextBar({ value, onChange, driverOptions, loading }: Race
           onChange={(gp) => onChange({ gp })}
           placeholder="Select a Grand Prix"
           loading={gpsQuery.isLoading}
+          getOptionHint={(gp) =>
+            radioGps.has(gp) ? (
+              <span className="flex items-center gap-1 text-xs text-fg-3">
+                <Mic className="size-3" aria-hidden="true" />
+                radio
+              </span>
+            ) : null
+          }
         />
       </div>
 

--- a/webapp/src/features/race/components/RadioBrowser.tsx
+++ b/webapp/src/features/race/components/RadioBrowser.tsx
@@ -102,7 +102,7 @@ export function RadioBrowser({
   const hasTranscribed = activeLaps.some((l) => l.has_transcript)
 
   return (
-    <div className="grid gap-4 md:min-h-64 md:grid-cols-[12rem_1fr]">
+    <div className="grid gap-4 md:min-h-64 md:grid-cols-[12rem_minmax(0,1fr)]">
       <div className="flex gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">
         {radioDrivers.map((d) => {
           const total = d.laps.length
@@ -188,7 +188,7 @@ export function RadioBrowser({
                   Lap {l.lap}
                   {!l.has_transcript ? <span className="text-fg-4">(audio only)</span> : null}
                 </span>
-                <span className="truncate">{l.text || 'No transcript preview.'}</span>
+                <span className="wrap-break-word">{l.text || 'No transcript preview.'}</span>
               </button>
             )
           })

--- a/webapp/src/features/race/components/RadioResultCard.tsx
+++ b/webapp/src/features/race/components/RadioResultCard.tsx
@@ -175,7 +175,7 @@ function CorrectionsFootnote({
       {corrections.map((c, i) => (
         <p key={i}>
           <span className="font-medium text-fg-2">{c.driver}</span>: {c.original_intent} &rarr;{' '}
-          {c.suggested_intent} &mdash; {c.reason}
+          {c.suggested_intent} · {c.reason}
           {c.span ? <span className="italic"> ({c.span})</span> : null}
         </p>
       ))}

--- a/webapp/src/features/race/components/RagAnswerCard.tsx
+++ b/webapp/src/features/race/components/RagAnswerCard.tsx
@@ -8,6 +8,7 @@
 import { FileText, Scale } from 'lucide-react'
 import { Card } from '@/components/Card'
 import { Markdown } from '@/components/Markdown'
+import { useTypewriter } from '@/lib/useTypewriter'
 import type { RagChunk, RagResult } from '@/lib/api/race'
 
 /** A regulation reference chip, e.g. "⚖ Art 55.1". */
@@ -62,15 +63,23 @@ export function SourcePassage({ chunk }: { chunk: RagChunk }) {
 }
 
 /** The answer card: the plain-English answer, its citation chips, and the
- *  expandable source passages backing it. */
-export function RagAnswerCard({ result }: { result: RagResult }) {
+ *  expandable source passages backing it. When `stream` is set (a freshly
+ *  asked question, not a restored history entry) the answer types itself out
+ *  and the citations/passages hold back until it finishes, so the card reads
+ *  as if the answer were being generated live. */
+export function RagAnswerCard({ result, stream = false }: { result: RagResult; stream?: boolean }) {
+  const answerText = result.answer || ''
+  const { revealed, done } = useTypewriter(answerText, stream)
+  const body = stream && !done ? `${revealed}▌` : answerText || '_No answer returned._'
+  const showBacking = !stream || done
+
   return (
     <Card elevation="resting" className="flex flex-col gap-4 p-4">
       <div className="prose-sm text-fg-1">
-        <Markdown>{result.answer || '_No answer returned._'}</Markdown>
+        <Markdown>{body}</Markdown>
       </div>
 
-      {result.articles.length > 0 ? (
+      {showBacking && result.articles.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="text-xs font-medium tracking-wide text-fg-3 uppercase">Cites</span>
           {result.articles.map((article) => (
@@ -79,7 +88,7 @@ export function RagAnswerCard({ result }: { result: RagResult }) {
         </div>
       ) : null}
 
-      {result.chunks.length > 0 ? (
+      {showBacking && result.chunks.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           <span className="text-xs font-medium tracking-wide text-fg-3 uppercase">
             Source passages

--- a/webapp/src/features/race/components/RegulationsPanel.tsx
+++ b/webapp/src/features/race/components/RegulationsPanel.tsx
@@ -110,7 +110,7 @@ export function RegulationsPanel({ initialQuestion }: { initialQuestion?: string
             <SkeletonText lines={4} />
           </Card>
         ) : answer ? (
-          <RagAnswerCard result={answer} />
+          <RagAnswerCard result={answer} stream={viewing === null} />
         ) : null}
       </div>
 

--- a/webapp/src/lib/useTypewriter.ts
+++ b/webapp/src/lib/useTypewriter.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+
+// Progressively reveals a finished string so an already-fetched answer READS
+// as if it were being generated live. The backend RAG endpoint returns the
+// whole answer in one response (the agent internals that could stream tokens
+// are out of scope to touch), so this is a client-side reveal, not real token
+// streaming. The Chat tab, once built, should stream for real over SSE instead.
+
+const PREFERS_REDUCED_MOTION =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+export interface TypewriterState {
+  /** The portion of `text` revealed so far. */
+  revealed: string
+  /** True once the whole string is shown. */
+  done: boolean
+}
+
+/**
+ * Reveal `text` a few characters at a time for a typewriter effect.
+ *
+ * Jumps straight to the full string when `enabled` is false or the user
+ * prefers reduced motion, so the content is never withheld for accessibility
+ * or non-animated views. Restarts from the beginning whenever `text` changes,
+ * so asking a second question re-plays the effect on the new answer.
+ */
+export function useTypewriter(
+  text: string,
+  enabled = true,
+  charsPerTick = 4,
+  tickMs = 20,
+): TypewriterState {
+  const instant = !enabled || PREFERS_REDUCED_MOTION || text.length === 0
+  const [count, setCount] = useState(instant ? text.length : 0)
+
+  useEffect(() => {
+    if (instant) {
+      setCount(text.length)
+      return
+    }
+    setCount(0)
+    let shown = 0
+    const timer = setInterval(() => {
+      shown = Math.min(shown + charsPerTick, text.length)
+      setCount(shown)
+      if (shown >= text.length) clearInterval(timer)
+    }, tickMs)
+    return () => clearInterval(timer)
+  }, [text, instant, charsPerTick, tickMs])
+
+  return { revealed: text.slice(0, count), done: count >= text.length }
+}


### PR DESCRIPTION
## What
Close-out polish on the Race Analysis tab, from a review of the live tab.

## Fixes
- **Radio-available hint**: GP dropdown options showed a bare bullet whose meaning was unclear. Now a Mic icon + `radio` badge, via a new optional `getOptionHint` prop on the single `Combobox` (mirrors `MultiCombobox`'s `getOptionAccent`). The collapsed trigger stays clean.
- **Radio message overflow**: long transcript rows forced a horizontal scroll because `truncate` (nowrap) kept the grid column from shrinking. They now wrap (`wrap-break-word` + a `minmax(0,1fr)` track) and fit the container.
- **Regulation answer reveal**: the RAG answer now types itself out with a client-side typewriter (`useTypewriter`), holding its citations and source passages back until it finishes, so it reads as if generated live. The `/rag` endpoint returns the whole answer in one response, so this is a reveal, not token streaming; the Chat tab should stream for real over SSE when it is built.
- Minor: an em-dash swapped for a middot in the radio corrections footnote.

## Checks
- typecheck (tsc -b): clean
- build (vite): 2908 modules, green
- browser-verified: GP dropdown hint, RAG typewriter (mid-stream cursor + citations-after), both deterministic. Radio wrap is a CSS-only fix (no cached transcripts on this machine to render the rows).