### PR TITLE
feat(webapp): add the Model Lab tab

### DIFF
--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -10,6 +10,7 @@ import { validateDashboardSearch } from '@/features/dashboard/search'
 import { validateStrategySearch } from '@/features/strategy/search'
 import { validateComparisonSearch } from '@/features/comparison/search'
 import { validateRaceSearch } from '@/features/race/search'
+import { validateLabSearch } from '@/features/lab/search'
 
 // Each feature page is a LAZY route component so the first paint of a light tab
 // (Home) doesn't download every other tab's code — the chart-heavy pages
@@ -31,6 +32,7 @@ const ComparisonPage = lazyRouteComponent(
   'ComparisonPage',
 )
 const RacePage = lazyRouteComponent(() => import('@/features/race/RacePage'), 'RacePage')
+const LabPage = lazyRouteComponent(() => import('@/features/lab/LabPage'), 'LabPage')
 const ThemePreview = lazyRouteComponent(() => import('@/features/dev/ThemePreview'), 'ThemePreview')
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
@@ -98,10 +100,13 @@ const raceRoute = createRoute({
   component: RacePage,
 })
 
+// Model Lab (#38) — the model inspector: one of six predictors on the bench,
+// fed a race moment, with its prediction / uncertainty / threshold / reasoning.
 const labRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/lab',
-  component: () => <ComingSoon title="Lab" />,
+  validateSearch: validateLabSearch,
+  component: LabPage,
 })
 
 // Comparison (#36) — the flagship time-clock replay. Shares the Dashboard's

--- a/webapp/src/features/lab/LabPage.tsx
+++ b/webapp/src/features/lab/LabPage.tsx
@@ -1,0 +1,92 @@
+// The Model Lab page: put one predictor on the bench, feed it a race moment,
+// read what it says. Owns the URL (bench config), the model rail, and the shared
+// RunFrame that renders the active model's ResultView. The six models keep their
+// run history and stale-run state in the store; the page only threads context.
+
+import { useCallback, useMemo } from 'react'
+import { getRouteApi, Link } from '@tanstack/react-router'
+import { ArrowUpRight } from 'lucide-react'
+import { Header } from '@/app/Header'
+import { LabContextBar } from './components/LabContextBar'
+import { ModelRail } from './components/ModelRail'
+import { RunFrame } from './components/RunFrame'
+import { RunHistoryStrip } from './components/RunHistoryStrip'
+import { MODEL_DEFS, MODEL_DEF_BY_ID } from './models/registry'
+import { applyLabPatch, fromRaw, toRaw, type LabSearch, type ModelId } from './search'
+import { useLabStore } from './store'
+
+const routeApi = getRouteApi('/lab')
+
+/** The lap window to carry into Strategy: the pace window, or the single lap as
+ *  a one-lap window, or nothing. */
+function strategyWindow(search: LabSearch): string | undefined {
+  if (search.laps) return `${search.laps[0]}-${search.laps[1]}`
+  if (search.lap != null) return `${search.lap}-${search.lap}`
+  return undefined
+}
+
+export function LabPage() {
+  const raw = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const search = useMemo(() => fromRaw(raw), [raw])
+
+  const patch = useCallback(
+    (p: Partial<LabSearch>) => {
+      void navigate({ search: (prev) => toRaw(applyLabPatch(fromRaw(prev), p)) })
+    },
+    [navigate],
+  )
+
+  const def = MODEL_DEF_BY_ID[search.model]
+  const activeRunByModel = useLabStore((s) => s.activeRunByModel)
+  const doneIds = useMemo(
+    () => new Set(Object.keys(activeRunByModel) as ModelId[]),
+    [activeRunByModel],
+  )
+
+  const window = strategyWindow(search)
+  const canSendToStrategy = !!search.gp && !!search.driver
+
+  return (
+    <>
+      <Header title="Model Lab">
+        {canSendToStrategy ? (
+          <Link
+            to="/strategy"
+            search={{ gp: search.gp, driver: search.driver, ...(window ? { laps: window } : {}) }}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-hairline bg-bg-3 px-3 py-1.5 text-sm text-fg-2 transition-colors hover:bg-bg-4 hover:text-fg-1"
+          >
+            Send to Strategy
+            <ArrowUpRight className="size-3.5" aria-hidden="true" />
+          </Link>
+        ) : null}
+      </Header>
+
+      <div className="flex flex-col gap-4 p-6">
+        <div className="sticky top-14 z-10 -mx-6 border-b border-hairline bg-bg-1/80 px-6 py-3 backdrop-blur-md">
+          <LabContextBar search={search} onPatch={patch} control={def.control} />
+        </div>
+
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <ModelRail
+            models={MODEL_DEFS}
+            active={search.model}
+            onSelect={(id) => patch({ model: id })}
+            doneIds={doneIds}
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <RunFrame
+              def={def}
+              gp={search.gp}
+              driver={search.driver}
+              lap={search.lap}
+              laps={search.laps}
+              onPatch={patch}
+            />
+            <RunHistoryStrip model={search.model} />
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/webapp/src/features/lab/components/LabContextBar.tsx
+++ b/webapp/src/features/lab/components/LabContextBar.tsx
@@ -1,0 +1,139 @@
+// The bench context bar: GP + driver selectors and the ONE lap control the
+// active model uses (a window for Pace, a single lap for the per-lap models,
+// nothing extra for Radio, which owns its own picker below). A lap-state chip
+// previews the compound / tyre age / position for the chosen lap before any run.
+
+import { useEffect, useRef } from 'react'
+import { Combobox, type ComboboxOption } from '@/components/Combobox'
+import { CompoundPill } from '@/components/CompoundPill'
+import { DualRangeSlider, Slider } from '@/components/Slider'
+import { MetricRow } from '@/components/StatCard'
+import { useLabDrivers, useLabGps, useLabRange, useLabState } from '../queries'
+import { LAB_YEAR, type LabSearch } from '../search'
+import type { LabControl } from '../models/types'
+
+const EYEBROW = 'text-xs font-medium uppercase tracking-widest text-fg-3'
+
+export interface LabContextBarProps {
+  search: LabSearch
+  onPatch: (patch: Partial<LabSearch>) => void
+  control: LabControl
+}
+
+export function LabContextBar({ search, onPatch, control }: LabContextBarProps) {
+  const gpsQuery = useLabGps()
+  const driversQuery = useLabDrivers(search.gp)
+  const rangeQuery = useLabRange(search.gp, search.driver)
+  const range = rangeQuery.data
+  const lapStateQuery = useLabState(
+    search.gp,
+    search.driver,
+    control === 'lap' ? search.lap : undefined,
+  )
+  const lapState = lapStateQuery.data
+
+  // Seed the lap control once a driver's lap range lands, so a freshly picked
+  // driver can Run immediately instead of first hunting for a valid lap. Depends
+  // on PRIMITIVES only: `search.laps` is a fresh array every render, so using it
+  // as a dep would re-fire this effect forever (an infinite navigate loop).
+  const driver = search.driver
+  const hasLap = search.lap != null
+  const hasLaps = search.laps != null
+  const minLap = range?.min_lap
+  const maxLap = range?.max_lap
+  // Seed at most once per (driver, control): the ref key is claimed BEFORE the
+  // patch so the effect re-firing before the URL reflects the new lap can't seed
+  // twice (which would be an infinite navigate loop).
+  const seedKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (minLap == null || maxLap == null || !driver) return
+    const key = `${driver}:${control}`
+    if (seedKeyRef.current === key) return
+    seedKeyRef.current = key
+    if (control === 'lap' && !hasLap) onPatch({ lap: maxLap })
+    else if (control === 'window' && !hasLaps) onPatch({ laps: [minLap, maxLap] })
+  }, [minLap, maxLap, driver, control, hasLap, hasLaps, onPatch])
+
+  const gpOptions: ComboboxOption[] = (gpsQuery.data ?? []).map((gp) => ({ value: gp, label: gp }))
+  const driverOptions: ComboboxOption[] = (driversQuery.data ?? []).map((d) => ({
+    value: d,
+    label: d,
+  }))
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <span className="hidden shrink-0 items-center rounded-full border border-hairline bg-bg-4 px-2 py-1 font-mono text-xs text-fg-3 sm:inline-flex">
+        {LAB_YEAR} season
+      </span>
+
+      <div className="flex flex-col gap-1.5 sm:w-56">
+        <span className={EYEBROW}>Grand Prix</span>
+        <Combobox
+          ariaLabel="Grand Prix"
+          options={gpOptions}
+          value={search.gp}
+          onChange={(gp) => onPatch({ gp })}
+          placeholder="Select a Grand Prix"
+          loading={gpsQuery.isLoading}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5 sm:w-40">
+        <span className={EYEBROW}>Driver</span>
+        <Combobox
+          ariaLabel="Driver"
+          options={driverOptions}
+          value={search.driver}
+          onChange={(driver) => onPatch({ driver })}
+          placeholder={!search.gp ? 'Pick a GP first' : 'Driver'}
+          disabled={!search.gp}
+          loading={driversQuery.isLoading}
+        />
+      </div>
+
+      {control === 'window' && range ? (
+        <div className="flex flex-col gap-1.5 sm:min-w-72 sm:flex-1">
+          <span className={EYEBROW}>Lap window</span>
+          <DualRangeSlider
+            min={range.min_lap}
+            max={range.max_lap}
+            value={search.laps ?? [range.min_lap, range.max_lap]}
+            onValueChange={(laps) => onPatch({ laps })}
+            formatValue={(v) => `L${v}`}
+          />
+        </div>
+      ) : null}
+
+      {control === 'lap' && range ? (
+        <div className="flex flex-col gap-1.5 sm:min-w-56 sm:flex-1">
+          <span className={EYEBROW}>Lap</span>
+          <Slider
+            min={range.min_lap}
+            max={range.max_lap}
+            value={search.lap ?? range.max_lap}
+            onValueChange={(lap) => onPatch({ lap })}
+            formatValue={(v) => `L${v}`}
+          />
+          {lapState ? (
+            <div className="flex items-center gap-2">
+              <CompoundPill compound={lapState.driver.compound} />
+              <MetricRow
+                items={[
+                  { label: 'age', value: `${lapState.driver.tyre_life}` },
+                  { label: 'pos', value: `P${lapState.driver.position}` },
+                  { label: 'stint', value: `${lapState.driver.stint}` },
+                ]}
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {control === 'radio' ? (
+        <span className="flex items-end pb-2 text-xs text-fg-4">
+          Pick a message or type free text in the bench below.
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/webapp/src/features/lab/components/ModelRail.tsx
+++ b/webapp/src/features/lab/components/ModelRail.tsx
@@ -1,0 +1,68 @@
+// The model rail: a vertical tablist of identity cards (icon, title, model-type
+// chip, eval headline) with a status dot showing which models have been run
+// against the current moment. Built on the shared Radix Tabs so arrow-key
+// navigation and ARIA come for free. Below lg it collapses to a horizontal,
+// scrollable strip of compact chips.
+
+import { Tabs, TabsList, TabsTrigger } from '@/components/Tabs'
+import { cn } from '@/lib/cn'
+import type { ModelId } from '../search'
+import type { ModelMeta } from '../models/types'
+
+export interface ModelRailProps {
+  models: ModelMeta[]
+  active: ModelId
+  onSelect: (id: ModelId) => void
+  /** Model ids that currently have a run to show (filled status dot). */
+  doneIds: Set<ModelId>
+}
+
+export function ModelRail({ models, active, onSelect, doneIds }: ModelRailProps) {
+  return (
+    <Tabs
+      value={active}
+      onValueChange={(v) => onSelect(v as ModelId)}
+      orientation="vertical"
+      className="w-full lg:w-60"
+    >
+      <TabsList
+        variant="segmented"
+        className="flex h-auto w-full gap-1.5 overflow-x-auto bg-transparent p-0 lg:flex-col lg:overflow-visible"
+      >
+        {models.map((m) => {
+          const { Icon } = m
+          const done = doneIds.has(m.id)
+          return (
+            <TabsTrigger
+              key={m.id}
+              value={m.id}
+              className={cn(
+                'h-auto shrink-0 items-start gap-2.5 rounded-xl border border-hairline bg-bg-3 px-3 py-2.5 text-left',
+                'data-[state=active]:border-purple-500/50 data-[state=active]:bg-bg-4',
+                'lg:w-full',
+              )}
+            >
+              <span className="mt-0.5 flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'size-1.5 rounded-full',
+                    done ? 'bg-purple-400' : 'border border-fg-4',
+                  )}
+                />
+                <Icon className="size-4 text-fg-2" aria-hidden="true" />
+              </span>
+              <span className="flex flex-col gap-0.5">
+                <span className="font-display text-sm font-medium text-fg-1">{m.title}</span>
+                <span className="hidden font-mono text-xs text-fg-3 lg:inline">{m.modelChip}</span>
+                <span className="hidden font-mono text-xs text-fg-4 lg:inline">
+                  {m.evalHeadline}
+                </span>
+              </span>
+            </TabsTrigger>
+          )
+        })}
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/webapp/src/features/lab/components/RunFrame.tsx
+++ b/webapp/src/features/lab/components/RunFrame.tsx
@@ -1,0 +1,179 @@
+// The shared bench scaffold + the kit every model's ResultView composes, so all
+// six read the same: run header (title, model-type chip, run-context timestamp,
+// Run/Cancel) -> verdict row -> viz zone -> reasoning disclosure. RunFrame is
+// the outer Card that LabPage renders for the active model; the exported pieces
+// (RunControls, RanContextChip, ReasoningDisclosure, StaleBanner, IdleHero,
+// VerdictRow, ModelTypeChip) keep each ResultView thin and consistent.
+
+import { useEffect, useState } from 'react'
+import { Brain, Play, RotateCw, TriangleAlert, X } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { Card } from '@/components/Card'
+import { Markdown } from '@/components/Markdown'
+import type { ModelDef, ModelMeta, ResultViewProps } from '../models/types'
+
+/** Seconds since the run started, updated ~4x/s while `active`, reset to 0 when
+ *  it ends. Drives the pace-range "typically 45-60 s" elapsed readout. */
+export function useElapsedSeconds(active: boolean): number {
+  const [seconds, setSeconds] = useState(0)
+  useEffect(() => {
+    if (!active) {
+      setSeconds(0)
+      return
+    }
+    const start = Date.now()
+    const id = setInterval(() => setSeconds((Date.now() - start) / 1000), 250)
+    return () => clearInterval(id)
+  }, [active])
+  return seconds
+}
+
+/** The model-type pill, e.g. "TCN + MC-Dropout". */
+export function ModelTypeChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="rounded-full border border-hairline bg-bg-4 px-2 py-0.5 font-mono text-xs text-fg-3">
+      {children}
+    </span>
+  )
+}
+
+/** The run header every ResultView shows: title + model-type chip on the left,
+ *  a run-context chip + Run/Cancel controls on the right. */
+export function RunHeader({
+  title,
+  modelChip,
+  right,
+}: {
+  title: string
+  modelChip: string
+  right: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <h3 className="font-display text-sm font-medium text-fg-1">{title}</h3>
+        <ModelTypeChip>{modelChip}</ModelTypeChip>
+      </div>
+      <div className="flex items-center gap-3">{right}</div>
+    </div>
+  )
+}
+
+/** The Run / Cancel control with an optional elapsed timer and a
+ *  disabled-with-reason tooltip. */
+export function RunControls({
+  isRunning,
+  onRun,
+  onCancel,
+  disabledReason,
+  elapsed,
+}: {
+  isRunning: boolean
+  onRun: () => void
+  onCancel?: () => void
+  disabledReason?: string
+  elapsed?: number
+}) {
+  if (isRunning) {
+    return (
+      <div className="flex items-center gap-2">
+        {elapsed != null ? (
+          <span className="font-mono text-xs tabular-nums text-fg-3">{elapsed.toFixed(1)}s</span>
+        ) : null}
+        {onCancel ? (
+          <Button size="sm" variant="ghost" onClick={onCancel}>
+            <X className="size-3.5" aria-hidden="true" />
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    )
+  }
+  return (
+    <Button size="sm" onClick={onRun} disabled={!!disabledReason} title={disabledReason}>
+      <Play className="size-3.5" aria-hidden="true" />
+      Run
+    </Button>
+  )
+}
+
+/** A pinned "ran for Lap 18 · 14:32" chip so a result never floats context-free. */
+export function RanContextChip({ label }: { label: string }) {
+  return <span className="font-mono text-xs text-fg-3">{label}</span>
+}
+
+/** The amber stale banner: the bench moved on from the run's context. */
+export function StaleBanner({ message, onRerun }: { message: string; onRerun: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-fg-1">
+      <span className="flex items-center gap-2">
+        <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
+        {message}
+      </span>
+      <Button size="sm" variant="ghost" onClick={onRerun}>
+        <RotateCw className="size-3.5" aria-hidden="true" />
+        Re-run
+      </Button>
+    </div>
+  )
+}
+
+/** A flex row for a model's verdict pills + stat cards. */
+export function VerdictRow({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap items-center gap-3">{children}</div>
+}
+
+/** The agent's reasoning, one disclosure away, never truncated. */
+export function ReasoningDisclosure({ reasoning }: { reasoning: string }) {
+  if (!reasoning) return null
+  return (
+    <details className="group">
+      <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium tracking-wide text-fg-3 uppercase marker:content-none">
+        <Brain className="size-3.5" aria-hidden="true" />
+        Agent reasoning
+      </summary>
+      <div className="prose-sm mt-2 rounded-lg bg-bg-2 px-3 py-2 text-fg-2">
+        <Markdown>{reasoning}</Markdown>
+      </div>
+    </details>
+  )
+}
+
+/** The idle hero shown before a model has run: what it does, its eval headline,
+ *  and the Run button (disabled-with-reason until the context is complete). */
+export function IdleHero({
+  meta,
+  disabledReason,
+  onRun,
+}: {
+  meta: ModelMeta
+  disabledReason?: string
+  onRun: () => void
+}) {
+  const { Icon } = meta
+  return (
+    <div className="flex flex-col items-center gap-3 px-4 py-10 text-center">
+      <span className="flex size-11 items-center justify-center rounded-xl border border-hairline bg-bg-3 text-fg-2">
+        <Icon className="size-5" aria-hidden="true" />
+      </span>
+      <div className="flex flex-col gap-1">
+        <p className="max-w-md text-sm text-fg-2">{meta.blurb}</p>
+        <p className="font-mono text-xs text-fg-4">
+          {meta.modelChip} · {meta.evalHeadline}
+        </p>
+      </div>
+      <RunControls isRunning={false} onRun={onRun} disabledReason={disabledReason} />
+    </div>
+  )
+}
+
+/** The outer bench Card. LabPage renders it for the active model; the ResultView
+ *  owns everything inside (run controls, verdict, viz, reasoning). */
+export function RunFrame({ def, ...props }: { def: ModelDef } & ResultViewProps) {
+  const { ResultView } = def
+  return (
+    <Card elevation="resting" className="flex flex-col gap-4 p-4">
+      <ResultView {...props} />
+    </Card>
+  )
+}

--- a/webapp/src/features/lab/components/RunHistoryStrip.tsx
+++ b/webapp/src/features/lab/components/RunHistoryStrip.tsx
@@ -1,0 +1,51 @@
+// Per-model run history: the past runs for the active model, newest first. Click
+// one to restore it as the shown result. Two runs at the same context expose the
+// model's run-to-run spread (a feature to see, not hide). Session-scoped.
+
+import { useMemo } from 'react'
+import { runsForModel, useLabStore } from '../store'
+import { cn } from '@/lib/cn'
+import type { ModelId } from '../search'
+
+function clockLabel(ranAt: number): string {
+  const d = new Date(ranAt)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+export function RunHistoryStrip({ model }: { model: ModelId }) {
+  // Select the raw arrays (stable references) and filter in a memo. Returning a
+  // freshly .filter()'d array straight from a zustand selector re-renders every
+  // tick (a new ref each call), which React caps as an infinite update loop.
+  const runs = useLabStore((s) => s.runs)
+  const activeId = useLabStore((s) => s.activeRunByModel[model])
+  const setActiveRun = useLabStore((s) => s.setActiveRun)
+  const modelRuns = useMemo(() => runsForModel(runs, model), [runs, model])
+
+  if (modelRuns.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium tracking-wide text-fg-3 uppercase">Run history</span>
+      <div className="flex flex-col gap-1">
+        {modelRuns.map((run) => (
+          <button
+            key={run.id}
+            type="button"
+            onClick={() => setActiveRun(model, run.id)}
+            className={cn(
+              'flex items-center justify-between gap-3 rounded-lg border px-3 py-1.5 text-left text-sm transition-colors',
+              run.id === activeId
+                ? 'border-purple-500/50 bg-bg-4 text-fg-1'
+                : 'border-hairline bg-bg-3 text-fg-2 hover:bg-bg-4 hover:text-fg-1',
+            )}
+          >
+            <span className="truncate">{run.label}</span>
+            <span className="shrink-0 font-mono text-xs text-fg-4">{clockLabel(run.ranAt)}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/lab/components/StintRunway.tsx
+++ b/webapp/src/features/lab/components/StintRunway.tsx
@@ -1,0 +1,65 @@
+// StintRunway — a lap-axis strip reading "how many laps of tyre life are left".
+// Plain DOM/CSS (the RangeBar idiom, no chart lib): a track from the stint
+// start to the horizon, a "now" marker at the current tyre age, and a cliff
+// zone shaded from the P10 (earliest) to P90 (latest) laps-to-cliff estimate
+// with a firmer P50 line. It turns three abstract cliff quantiles into one
+// legible "you're here, the cliff is roughly there" read.
+
+interface StintRunwayProps {
+  /** Current tyre age in laps (the "now" position). */
+  tyreLife: number
+  /** Laps remaining until the degradation cliff, at the P10/P50/P90 quantiles
+   *  (relative to now, so the absolute cliff lap is tyreLife + this). */
+  cliffP10: number
+  cliffP50: number
+  cliffP90: number
+}
+
+/** Percent position of an absolute tyre-age lap on a [0, max] track. */
+function pct(lap: number, max: number): number {
+  if (max <= 0) return 0
+  return Math.min(100, Math.max(0, (lap / max) * 100))
+}
+
+export function StintRunway({ tyreLife, cliffP10, cliffP50, cliffP90 }: StintRunwayProps) {
+  const nowLap = Math.max(0, tyreLife)
+  const p10Lap = nowLap + Math.max(0, cliffP10)
+  const p50Lap = nowLap + Math.max(0, cliffP50)
+  const p90Lap = nowLap + Math.max(0, cliffP90)
+  // Give the horizon a little air beyond the latest cliff estimate.
+  const max = Math.max(p90Lap + 2, nowLap + 4)
+
+  const nowPct = pct(nowLap, max)
+  const zoneStart = pct(p10Lap, max)
+  const zoneEnd = pct(p90Lap, max)
+  const p50Pct = pct(p50Lap, max)
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="relative h-3 rounded-full bg-bg-5" aria-hidden="true">
+        {/* Cliff zone P10 -> P90 */}
+        <div
+          className="absolute top-0 bottom-0 rounded-full bg-gradient-to-r from-warning/25 to-danger/35"
+          style={{ left: `${zoneStart}%`, width: `${Math.max(0, zoneEnd - zoneStart)}%` }}
+        />
+        {/* P50 cliff line */}
+        <div
+          className="absolute top-1/2 h-4 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-danger"
+          style={{ left: `${p50Pct}%` }}
+        />
+        {/* "now" marker */}
+        <div
+          className="absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-bg-2 bg-purple-500"
+          style={{ left: `${nowPct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between font-mono text-xs tabular-nums text-fg-4">
+        <span className="text-fg-2">now L{Math.round(nowLap)}</span>
+        <span>
+          cliff <span className="text-fg-1">~L{Math.round(p50Lap)}</span> (P10 L{Math.round(p10Lap)}{' '}
+          · P90 L{Math.round(p90Lap)})
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/PaceResultView.tsx
+++ b/webapp/src/features/lab/models/PaceResultView.tsx
@@ -1,0 +1,211 @@
+// Pace model bench: the XGBoost lap-time predictor across a lap window. Runs on
+// POST /pace-range (pure ML, 45-60 s, rate-limited), shows actual vs predicted
+// with a p10-p90 CI band, compound-coloured dots and stint boundaries, plus the
+// last prediction / CI / window MAE. The reference ResultView the other models
+// mirror: idle hero -> running (skeleton + elapsed + Cancel) -> done (verdict +
+// chart + reasoning) with a stale banner when the bench moves off the run.
+
+import { useRef } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Gauge as PaceIcon } from 'lucide-react'
+import { AgentModelChart, type AgentModelPoint } from '@/charts/AgentModelChart'
+import { ChartCard } from '@/components/ChartCard'
+import { Skeleton } from '@/components/Skeleton'
+import { StatCard } from '@/components/StatCard'
+import { fetchPaceRange, type PaceRangePoint } from '@/lib/api/strategy'
+import { LAB_YEAR } from '../search'
+import { selectActiveRun, useLabStore, type LabRun } from '../store'
+import type { ModelMeta, ResultViewProps } from './types'
+import {
+  IdleHero,
+  RanContextChip,
+  RunControls,
+  RunHeader,
+  StaleBanner,
+  useElapsedSeconds,
+  VerdictRow,
+} from '../components/RunFrame'
+
+export const PACE_META: ModelMeta = {
+  id: 'pace',
+  Icon: PaceIcon,
+  title: 'Race pace',
+  modelChip: 'XGBoost',
+  evalHeadline: 'MAE 0.411 s',
+  blurb: 'Predicts each lap time from tyre, fuel and track state, with a p10-p90 interval.',
+  control: 'window',
+}
+
+const s2 = (v: number) => `${v.toFixed(2)}s`
+
+/** Mean absolute error over the laps where both an actual and a prediction
+ *  exist. Null when no lap has both. */
+function windowMae(points: PaceRangePoint[]): number | null {
+  const paired = points.filter((p) => p.actual != null && p.pred != null)
+  if (paired.length === 0) return null
+  const total = paired.reduce(
+    (sum, p) => sum + Math.abs((p.actual as number) - (p.pred as number)),
+    0,
+  )
+  return total / paired.length
+}
+
+/** PaceRangePoint[] -> the chart's point shape, flagging a stint's first lap. */
+function toChartPoints(points: PaceRangePoint[]): AgentModelPoint[] {
+  let prevStint: number | null = null
+  return points.map((p) => {
+    const stintStart = p.stint !== prevStint
+    prevStint = p.stint
+    return {
+      lap: p.lap,
+      actual: p.actual,
+      pred: p.pred,
+      ciLow: p.ci_p10,
+      ciHigh: p.ci_p90,
+      compound: p.compound,
+      stintStart,
+    }
+  })
+}
+
+/** The last lap that carries a prediction, the verdict's headline. */
+function lastPredicted(points: PaceRangePoint[]): PaceRangePoint | undefined {
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i].pred != null) return points[i]
+  }
+  return undefined
+}
+
+function sameWindow(a: [number, number] | undefined, b: [number, number] | undefined): boolean {
+  if (!a || !b) return a === b
+  return a[0] === b[0] && a[1] === b[1]
+}
+
+export function PaceResultView({ gp, driver, laps }: ResultViewProps) {
+  const addRun = useLabStore((s) => s.addRun)
+  const activeRun = useLabStore((s) => selectActiveRun(s, 'pace'))
+  const abortRef = useRef<AbortController | null>(null)
+
+  const runMut = useMutation({
+    mutationFn: async ({ signal }: { signal: AbortSignal }) =>
+      fetchPaceRange(gp!, driver!, laps![0], laps![1], LAB_YEAR, signal),
+    onSuccess: (range) => {
+      const run: LabRun = {
+        id: crypto.randomUUID(),
+        model: 'pace',
+        context: { gp, driver, laps },
+        result: { kind: 'pace', range },
+        label: laps ? `Laps ${laps[0]}-${laps[1]}` : 'Pace',
+        ranAt: Date.now(),
+      }
+      addRun(run)
+    },
+  })
+
+  const elapsed = useElapsedSeconds(runMut.isPending)
+  const disabledReason = !gp
+    ? 'Pick a Grand Prix'
+    : !driver
+      ? 'Pick a driver'
+      : !laps
+        ? 'Pick a lap window'
+        : undefined
+
+  function onRun() {
+    if (disabledReason) return
+    const ac = new AbortController()
+    abortRef.current = ac
+    runMut.mutate({ signal: ac.signal })
+  }
+  function onCancel() {
+    abortRef.current?.abort()
+    runMut.reset()
+  }
+
+  if (runMut.isPending) {
+    const span = laps ? laps[1] - laps[0] + 1 : 0
+    return (
+      <div className="flex flex-col gap-4">
+        <RunHeader
+          title={PACE_META.title}
+          modelChip={PACE_META.modelChip}
+          right={<RunControls isRunning onRun={onRun} onCancel={onCancel} elapsed={elapsed} />}
+        />
+        <Skeleton className="h-52 w-full" />
+        <p className="text-center text-xs text-fg-4">
+          Scoring {span > 0 ? `~${span} laps` : 'the window'} · typically 45-60 s
+        </p>
+      </div>
+    )
+  }
+
+  const run = activeRun?.result.kind === 'pace' ? activeRun : undefined
+  if (!run) {
+    return <IdleHero meta={PACE_META} disabledReason={disabledReason} onRun={onRun} />
+  }
+
+  const range = run.result.kind === 'pace' ? run.result.range : []
+  const mae = windowMae(range)
+  const last = lastPredicted(range)
+  const stale =
+    run.context.gp !== gp || run.context.driver !== driver || !sameWindow(run.context.laps, laps)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RunHeader
+        title={PACE_META.title}
+        modelChip={PACE_META.modelChip}
+        right={
+          <>
+            <RanContextChip label={run.label} />
+            <RunControls isRunning={false} onRun={onRun} disabledReason={disabledReason} />
+          </>
+        }
+      />
+
+      {stale ? (
+        <StaleBanner
+          message={`Result is for ${run.label}. Re-run for the current window.`}
+          onRerun={onRun}
+        />
+      ) : null}
+
+      <VerdictRow>
+        <StatCard
+          eyebrow="Last prediction"
+          value={last?.pred != null ? s2(last.pred) : '-'}
+          hint={last ? `Lap ${last.lap}` : undefined}
+        />
+        <StatCard
+          eyebrow="Interval P10-P90"
+          value={
+            last && last.ci_p10 != null && last.ci_p90 != null
+              ? `${s2(last.ci_p10)} - ${s2(last.ci_p90)}`
+              : '-'
+          }
+        />
+        <StatCard eyebrow="Window MAE" value={mae != null ? s2(mae) : '-'} />
+      </VerdictRow>
+
+      <ChartCard
+        title="Actual vs predicted lap time"
+        actions={
+          mae != null ? (
+            <span className="font-mono text-xs text-fg-3">MAE {s2(mae)}</span>
+          ) : undefined
+        }
+      >
+        <AgentModelChart
+          points={toChartPoints(range)}
+          actualLabel="Actual"
+          predLabel="XGBoost"
+          yUnit="s"
+          ciBand
+          compoundDots
+          stintLines
+          height={240}
+        />
+      </ChartCard>
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/PitResultView.tsx
+++ b/webapp/src/features/lab/models/PitResultView.tsx
@@ -1,0 +1,179 @@
+// Pit bench (HistGBT stop duration + LightGBM undercut). Verdict: action badge
+// (incl. REACTIVE_SC), compound rec, rec lap; viz: stop-duration RangeBar +
+// undercut Gauge (threshold 0.522) + a small target/lap detail line.
+
+import { useMutation } from '@tanstack/react-query'
+import { Wrench } from 'lucide-react'
+import { Gauge } from '@/charts/Gauge'
+import { ActionBadge } from '@/components/ActionBadge'
+import { ChartCard } from '@/components/ChartCard'
+import { CompoundPill } from '@/components/CompoundPill'
+import { Pill } from '@/components/Pill'
+import { RangeBar } from '@/components/RangeBar'
+import { Skeleton } from '@/components/Skeleton'
+import { MetricRow, StatCard, type MetricRowItem } from '@/components/StatCard'
+import { fetchLapState, runAgent, type PitResult } from '@/lib/api/strategy'
+import { LAB_YEAR } from '../search'
+import { selectActiveRun, useLabStore, type LabRun } from '../store'
+import type { ModelMeta, ResultViewProps } from './types'
+import {
+  IdleHero,
+  RanContextChip,
+  ReasoningDisclosure,
+  RunControls,
+  RunHeader,
+  StaleBanner,
+  useElapsedSeconds,
+  VerdictRow,
+} from '../components/RunFrame'
+
+export const PIT_META: ModelMeta = {
+  id: 'pit',
+  Icon: Wrench,
+  title: 'Pit strategy',
+  modelChip: 'HistGBT + LightGBM',
+  evalHeadline: 'Stop P50 MAE 0.489 s',
+  blurb: 'Recommends a pit action and predicts the stop duration and undercut probability.',
+  control: 'lap',
+}
+
+/** The LightGBM undercut model's operating point, the same 0.522 used by the
+ *  Strategy agent tab so the two surfaces read the probability against the
+ *  same line. */
+const UNDERCUT_THRESHOLD = 0.522
+
+const s2 = (v: number) => `${v.toFixed(2)}s`
+
+export function PitResultView({ gp, driver, lap }: ResultViewProps) {
+  const addRun = useLabStore((s) => s.addRun)
+  const activeRun = useLabStore((s) => selectActiveRun(s, 'pit'))
+
+  const runMut = useMutation({
+    mutationFn: async (): Promise<PitResult> => {
+      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR)
+      return runAgent('pit', lapState)
+    },
+    onSuccess: (agent) => {
+      const run: LabRun = {
+        id: crypto.randomUUID(),
+        model: 'pit',
+        context: { gp, driver, lap },
+        result: { kind: 'pit', agent },
+        label: lap != null ? `Lap ${lap}` : 'Pit',
+        ranAt: Date.now(),
+      }
+      addRun(run)
+    },
+  })
+
+  const elapsed = useElapsedSeconds(runMut.isPending)
+  const disabledReason = !gp
+    ? 'Pick a Grand Prix'
+    : !driver
+      ? 'Pick a driver'
+      : lap == null
+        ? 'Pick a lap'
+        : undefined
+
+  function onRun() {
+    if (disabledReason) return
+    runMut.mutate()
+  }
+  function onCancel() {
+    runMut.reset()
+  }
+
+  if (runMut.isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        <RunHeader
+          title={PIT_META.title}
+          modelChip={PIT_META.modelChip}
+          right={<RunControls isRunning onRun={onRun} onCancel={onCancel} elapsed={elapsed} />}
+        />
+        <Skeleton className="h-52 w-full" />
+        <p className="text-center text-xs text-fg-4">Running the pit model...</p>
+      </div>
+    )
+  }
+
+  const run = activeRun?.result.kind === 'pit' ? activeRun : undefined
+  if (!run) {
+    return <IdleHero meta={PIT_META} disabledReason={disabledReason} onRun={onRun} />
+  }
+
+  const agent = run.result.kind === 'pit' ? run.result.agent : undefined
+  if (!agent) return null
+
+  const stale = run.context.gp !== gp || run.context.driver !== driver || run.context.lap !== lap
+
+  // The undercut detail line: target driver and the lap the model is timing
+  // the undercut against. Both are nullable independently of undercut_prob
+  // itself, so each earns its own guard rather than assuming the pair.
+  const undercutItems: MetricRowItem[] = []
+  if (agent.undercut_target) {
+    undercutItems.push({
+      label: 'Target',
+      value: <Pill tone="info">{agent.undercut_target}</Pill>,
+    })
+  }
+  if (agent.recommended_lap != null) {
+    undercutItems.push({ label: 'Lap', value: `L${agent.recommended_lap}` })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RunHeader
+        title={PIT_META.title}
+        modelChip={PIT_META.modelChip}
+        right={
+          <>
+            <RanContextChip label={run.label} />
+            <RunControls isRunning={false} onRun={onRun} disabledReason={disabledReason} />
+          </>
+        }
+      />
+
+      {stale ? (
+        <StaleBanner
+          message={`Result is for ${run.label}. Re-run for the current lap.`}
+          onRerun={onRun}
+        />
+      ) : null}
+
+      <VerdictRow>
+        <ActionBadge action={agent.action} />
+        <CompoundPill compound={agent.compound_recommendation} />
+        <StatCard
+          eyebrow="Recommended lap"
+          value={agent.recommended_lap != null ? `L${agent.recommended_lap}` : 'None'}
+        />
+      </VerdictRow>
+
+      <ChartCard title="Stop duration (s)">
+        <RangeBar
+          low={agent.stop_duration_p05}
+          mid={agent.stop_duration_p50}
+          high={agent.stop_duration_p95}
+          format={s2}
+        />
+      </ChartCard>
+
+      {agent.undercut_prob != null ? (
+        <ChartCard title="Undercut probability">
+          <div className="flex flex-col items-center gap-3">
+            <Gauge
+              value={agent.undercut_prob}
+              label="Undercut"
+              threshold={UNDERCUT_THRESHOLD}
+              thresholdLabel="Operating point 52%"
+            />
+            {undercutItems.length > 0 ? <MetricRow items={undercutItems} /> : null}
+          </div>
+        </ChartCard>
+      ) : null}
+
+      <ReasoningDisclosure reasoning={agent.reasoning} />
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/RadioResultView.tsx
+++ b/webapp/src/features/lab/models/RadioResultView.tsx
@@ -1,0 +1,188 @@
+// Radio bench (N24 NLP pipeline). Reuses the Race tab's promoted radio
+// components wholesale: RadioBrowser (driver rail + message list),
+// RadioFreeTextComposer (self-contained textarea + analyse), RadioResultCard
+// (sentiment/intent/entities + corrections + Race Control rows). A segmented
+// Tabs toggle switches between the two entry points, since Radio has no
+// single "Run" button the way the other five models do -- it is either "pick
+// a recorded message" or "type one".
+//
+// The lookup selection lives in LOCAL component state, not the URL, unlike
+// the Race tab's rdriver/rlap/rmsg (v1 keeps the bench simple; nothing else
+// on the Lab needs to deep-link into a radio message yet). Analysis still
+// needs an explicit "Analyse radio" press -- selecting a message alone must
+// not fire the NLP pipeline, same rule as Race.
+
+import { useEffect, useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Play, Radio } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { Card } from '@/components/Card'
+import { EmptyState } from '@/components/EmptyState'
+import { Skeleton, SkeletonText } from '@/components/Skeleton'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/Tabs'
+import { useToast } from '@/components/Toast'
+import { RadioBrowser } from '@/components/radio/RadioBrowser'
+import { RadioFreeTextComposer } from '@/components/radio/RadioFreeTextComposer'
+import { RadioResultCard } from '@/components/radio/RadioResultCard'
+import { analyzeRadio, RaceApiError, type RadioResult } from '@/lib/api/race'
+import { fetchLapState } from '@/lib/api/strategy'
+import { useLabRadioCorpus } from '../queries'
+import { RunHeader } from '../components/RunFrame'
+import type { ModelMeta, ResultViewProps } from './types'
+
+export const RADIO_META: ModelMeta = {
+  id: 'radio',
+  Icon: Radio,
+  title: 'Team radio',
+  modelChip: 'Whisper + RoBERTa + SetFit + NER',
+  evalHeadline: 'GPU 47.8 ms',
+  blurb: 'Runs the NLP pipeline over team radio: sentiment, intent, entities and alerts.',
+  control: 'radio',
+}
+
+type RadioMode = 'lookup' | 'free-text'
+
+/** Prefer a `RaceApiError`'s own message (already unwrapped from the FastAPI
+ *  `{detail}` body); fall back to a generic description for anything else
+ *  (a network failure, an aborted request). Mirrors RadioPanel's helper --
+ *  duplicated rather than shared since this file may only be edited alone. */
+function errorDescription(error: unknown, fallback: string): string {
+  return error instanceof RaceApiError ? error.message : fallback
+}
+
+export function RadioResultView({ gp, driver }: ResultViewProps) {
+  const { toast } = useToast()
+  const [mode, setMode] = useState<RadioMode>('lookup')
+
+  const [selDriver, setSelDriver] = useState<string | undefined>()
+  const [selLap, setSelLap] = useState<number | undefined>()
+  const [selMsg, setSelMsg] = useState<number | undefined>()
+
+  const corpus = useLabRadioCorpus(gp)
+  const radioDrivers = useMemo(() => corpus.data ?? [], [corpus.data])
+
+  useEffect(() => {
+    if (!corpus.isError) return
+    toast({
+      title: 'Radio corpus unavailable',
+      description: errorDescription(corpus.error, 'Could not load radio data for this GP.'),
+      tone: 'danger',
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [corpus.isError])
+
+  const selectedTranscript = useMemo(() => {
+    const d = radioDrivers.find((r) => r.driver === selDriver)
+    if (!d) return ''
+    // `selMsg` is the precise identity (an index into `laps[]`); without one
+    // fall back to the first message on that lap.
+    if (selMsg != null) return d.laps[selMsg]?.text ?? ''
+    return d.laps.find((l) => l.lap === selLap)?.text ?? ''
+  }, [radioDrivers, selDriver, selLap, selMsg])
+
+  const analysis = useMutation<RadioResult, Error, void>({
+    mutationFn: async () => {
+      const lapState = await fetchLapState(gp!, selDriver!, selLap!)
+      // LapState is a typed struct (no index signature); the radio endpoint
+      // just serialises it as the opaque lap_state context object.
+      return analyzeRadio(lapState as unknown as Record<string, unknown>, [
+        { driver: selDriver!, lap: selLap!, text: selectedTranscript },
+      ])
+    },
+    onError: (error) => {
+      toast({
+        title: 'Radio analysis failed',
+        description: errorDescription(error, 'The Radio Agent could not process this message.'),
+        tone: 'danger',
+      })
+    },
+  })
+
+  // A GP swap invalidates any selection made against the previous corpus --
+  // reset so a stale result card never lingers under the new context.
+  useEffect(() => {
+    setSelDriver(undefined)
+    setSelLap(undefined)
+    setSelMsg(undefined)
+    analysis.reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gp])
+
+  function onSelect(d?: string, lap?: number, msg?: number) {
+    setSelDriver(d)
+    setSelLap(lap)
+    setSelMsg(msg)
+    analysis.reset()
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RunHeader title={RADIO_META.title} modelChip={RADIO_META.modelChip} right={null} />
+
+      <Tabs value={mode} onValueChange={(v) => setMode(v as RadioMode)}>
+        <TabsList variant="segmented">
+          <TabsTrigger value="lookup">Race radio</TabsTrigger>
+          <TabsTrigger value="free-text">Free text</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="lookup" className="mt-4 flex flex-col gap-4">
+          {!gp ? (
+            <EmptyState
+              icon={<Radio className="size-5" aria-hidden="true" />}
+              title="Pick a Grand Prix"
+              description="Pick a Grand Prix to browse its radio, or use the Free text tab instead."
+            />
+          ) : corpus.isLoading ? (
+            <div className="flex flex-col gap-3">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-64 w-full" />
+            </div>
+          ) : (
+            <RadioBrowser
+              radioDrivers={radioDrivers}
+              contextDrivers={driver ? [driver] : []}
+              selectedDriver={selDriver}
+              selectedLap={selLap}
+              selectedMsg={selMsg}
+              onSelect={onSelect}
+              onRetry={() => void corpus.refetch()}
+              onOpenComposer={() => setMode('free-text')}
+            />
+          )}
+
+          {gp && selDriver && selLap != null ? (
+            <Card
+              elevation="resting"
+              className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <p className="min-w-0 truncate text-sm text-fg-2">
+                <span className="font-medium text-fg-1">{selDriver}</span> · Lap {selLap} ·{' '}
+                {selectedTranscript || 'No transcript preview.'}
+              </p>
+              <Button
+                size="sm"
+                onClick={() => analysis.mutate()}
+                disabled={analysis.isPending || !selectedTranscript.trim()}
+              >
+                <Play className="size-3.5" aria-hidden="true" />
+                {analysis.isPending ? 'Analysing…' : 'Analyse radio'}
+              </Button>
+            </Card>
+          ) : null}
+
+          {analysis.isPending ? (
+            <Card elevation="resting" className="p-4">
+              <SkeletonText lines={4} />
+            </Card>
+          ) : analysis.data ? (
+            <RadioResultCard result={analysis.data} />
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="free-text" className="mt-4">
+          <RadioFreeTextComposer />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/SituationResultView.tsx
+++ b/webapp/src/features/lab/models/SituationResultView.tsx
@@ -1,0 +1,283 @@
+// Race-situation bench (LightGBM). ONE /situation run feeds two lenses: Overtake
+// (overtake_prob, action threshold 0.80) and Safety car (sc_prob_3lap, alert
+// threshold 0.30, plus a lift-over-season-base compare). Both lenses read the
+// same SituationFacts strip (gap/DRS, pace delta, SC/VSC flags) because a
+// single backend call answers both questions in one shot.
+
+import { useMutation } from '@tanstack/react-query'
+import { ArrowDown, ArrowUp, ShieldAlert, Swords } from 'lucide-react'
+import { Gauge } from '@/charts/Gauge'
+import { MetricRow } from '@/components/StatCard'
+import { Pill } from '@/components/Pill'
+import { Skeleton } from '@/components/Skeleton'
+import { fetchLapState, runAgent, type SituationResult } from '@/lib/api/strategy'
+import { LAB_YEAR } from '../search'
+import { selectActiveRun, useLabStore, type LabRun } from '../store'
+import type { ModelMeta, ResultViewProps } from './types'
+import {
+  IdleHero,
+  RanContextChip,
+  ReasoningDisclosure,
+  RunControls,
+  RunHeader,
+  StaleBanner,
+  useElapsedSeconds,
+  VerdictRow,
+} from '../components/RunFrame'
+
+export const OVERTAKE_META: ModelMeta = {
+  id: 'overtake',
+  Icon: Swords,
+  title: 'Overtake',
+  modelChip: 'LightGBM',
+  evalHeadline: 'AUC-PR 0.549',
+  blurb: 'Estimates the probability the driver completes an overtake within the window.',
+  control: 'lap',
+}
+
+export const SAFETYCAR_META: ModelMeta = {
+  id: 'safetycar',
+  Icon: ShieldAlert,
+  title: 'Safety car',
+  modelChip: 'LightGBM',
+  evalHeadline: 'AUC-PR 0.072 (lift 1.67x)',
+  blurb: 'Estimates the probability of a safety car within the next three laps.',
+  control: 'lap',
+}
+
+export type SituationLens = 'overtake' | 'safetycar'
+
+/** Approximate season prevalence of "safety car within the next 3 laps",
+ *  used only as the "season base" bar the current lap's sc_prob_3lap gets
+ *  compared against so the number reads as a lift over normal odds instead
+ *  of in isolation. This is a rough figure; verify the exact prevalence
+ *  against the technical report's safety-car dataset stats before quoting it
+ *  anywhere outside this comparison. */
+const SC_BASE_RATE_3LAP = 0.043
+
+const THREAT_TONE: Record<string, 'danger' | 'warning' | 'success'> = {
+  HIGH: 'danger',
+  MEDIUM: 'warning',
+  LOW: 'success',
+}
+
+/** Pill tone for a threat_level string. Falls back to a neutral-reading
+ *  "success" tone for any value the backend hasn't defined yet, so an
+ *  unexpected label never renders as an alarming red by accident. */
+function threatTone(level: string): 'danger' | 'warning' | 'success' {
+  return THREAT_TONE[level] ?? 'success'
+}
+
+/** The gap/DRS, pace-delta and SC/VSC facts both lenses share, so a viewer
+ *  reads the same race context whether the bench is showing Overtake or
+ *  Safety car odds. */
+function SituationFacts({ agent }: { agent: SituationResult }) {
+  const inDrsWindow = agent.gap_ahead_s < 1.0
+  const paceRising = agent.pace_delta_s > 0
+  const PaceArrow = paceRising ? ArrowUp : ArrowDown
+  const paceText = `${paceRising ? '+' : ''}${agent.pace_delta_s.toFixed(2)}s/lap`
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <MetricRow
+        items={[
+          { label: 'Gap ahead', value: `${agent.gap_ahead_s.toFixed(1)}s` },
+          {
+            label: 'Pace delta',
+            value: (
+              <span className="inline-flex items-center gap-0.5">
+                <PaceArrow className="size-3" aria-hidden="true" />
+                {paceText}
+              </span>
+            ),
+          },
+        ]}
+      />
+      {inDrsWindow ? <Pill tone="info">DRS</Pill> : null}
+      {agent.sc_currently_active ? (
+        <Pill tone="danger">SC</Pill>
+      ) : agent.vsc_active ? (
+        <Pill tone="warning">VSC</Pill>
+      ) : (
+        <span className="text-xs text-fg-4">Green flag</span>
+      )}
+    </div>
+  )
+}
+
+/** One horizontal bar in the baseline-lift compare: a label, a track scaled
+ *  to `scaleMax`, and a mono percentage readout. */
+function BarRow({
+  label,
+  value,
+  scaleMax,
+  tone,
+}: {
+  label: string
+  value: number
+  scaleMax: number
+  tone: string
+}) {
+  const pct = (value / scaleMax) * 100
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-24 shrink-0 text-xs text-fg-4">{label}</span>
+      <div className="h-2 flex-1 rounded-full bg-bg-5" aria-hidden="true">
+        <div className={`h-2 rounded-full ${tone}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="w-12 shrink-0 text-right font-mono text-xs tabular-nums text-fg-1">
+        {`${Math.round(value * 100)}%`}
+      </span>
+    </div>
+  )
+}
+
+/** Two-bar compare of this lap's 3-lap safety-car probability against the
+ *  season base rate, plus a lift caption. Plain CSS bars, no chart lib, for a
+ *  single static shape that only the Safety car lens needs. */
+function BaselineLiftBar({ current }: { current: number }) {
+  const scaleMax = Math.max(current, SC_BASE_RATE_3LAP, 0.0001) // floor avoids a 0/0 width when both are 0
+  const lift = SC_BASE_RATE_3LAP > 0 ? current / SC_BASE_RATE_3LAP : 0
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">
+        Vs. season base rate
+      </span>
+      <BarRow label="This lap" value={current} scaleMax={scaleMax} tone="bg-purple-500" />
+      <BarRow label="Season base" value={SC_BASE_RATE_3LAP} scaleMax={scaleMax} tone="bg-fg-4" />
+      <p className="text-xs text-fg-3">
+        Lift <span className="font-mono text-fg-1">{lift.toFixed(2)}x</span> over the season base
+        rate
+      </p>
+    </div>
+  )
+}
+
+function sameLap(a: LabRun['context'], gp?: string, driver?: string, lap?: number): boolean {
+  return a.gp === gp && a.driver === driver && a.lap === lap
+}
+
+export function SituationResultView({
+  gp,
+  driver,
+  lap,
+  lens,
+}: ResultViewProps & { lens: SituationLens }) {
+  const meta = lens === 'overtake' ? OVERTAKE_META : SAFETYCAR_META
+  const addRun = useLabStore((s) => s.addRun)
+  const activeRun = useLabStore((s) => selectActiveRun(s, lens))
+
+  const runMut = useMutation({
+    mutationFn: async () => {
+      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR)
+      return runAgent('situation', lapState)
+    },
+    onSuccess: (agent) => {
+      const run: LabRun = {
+        id: crypto.randomUUID(),
+        model: lens,
+        context: { gp, driver, lap },
+        result: { kind: 'situation', agent },
+        label: `Lap ${lap}`,
+        ranAt: Date.now(),
+      }
+      addRun(run)
+    },
+  })
+
+  const elapsed = useElapsedSeconds(runMut.isPending)
+  const disabledReason = !gp
+    ? 'Pick a Grand Prix'
+    : !driver
+      ? 'Pick a driver'
+      : lap == null
+        ? 'Pick a lap'
+        : undefined
+
+  function onRun() {
+    if (disabledReason) return
+    runMut.mutate()
+  }
+  // Neither fetchLapState nor runAgent accepts an AbortSignal, so Cancel just
+  // drops the pending mutation locally rather than aborting a network call.
+  function onCancel() {
+    runMut.reset()
+  }
+
+  if (runMut.isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        <RunHeader
+          title={meta.title}
+          modelChip={meta.modelChip}
+          right={<RunControls isRunning onRun={onRun} onCancel={onCancel} elapsed={elapsed} />}
+        />
+        <Skeleton className="h-48 w-full" />
+        <p className="text-center text-xs text-fg-4">Running the situation model...</p>
+      </div>
+    )
+  }
+
+  const run = activeRun?.result.kind === 'situation' ? activeRun : undefined
+  if (!run) {
+    return <IdleHero meta={meta} disabledReason={disabledReason} onRun={onRun} />
+  }
+
+  const agent = run.result.kind === 'situation' ? run.result.agent : undefined
+  if (!agent) return null
+
+  const stale = !sameLap(run.context, gp, driver, lap)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RunHeader
+        title={meta.title}
+        modelChip={meta.modelChip}
+        right={
+          <>
+            <RanContextChip label={run.label} />
+            <RunControls isRunning={false} onRun={onRun} disabledReason={disabledReason} />
+          </>
+        }
+      />
+      <p className="text-xs text-fg-4">
+        Shared run, the situation agent scores both overtake and safety car.
+      </p>
+
+      {stale ? (
+        <StaleBanner
+          message={`Result is for ${run.label}. Re-run for the current lap.`}
+          onRerun={onRun}
+        />
+      ) : null}
+
+      <VerdictRow>
+        <Pill tone={threatTone(agent.threat_level)}>{agent.threat_level} threat</Pill>
+      </VerdictRow>
+
+      <SituationFacts agent={agent} />
+
+      {lens === 'overtake' ? (
+        <Gauge
+          value={agent.overtake_prob}
+          label="Overtake"
+          threshold={0.8}
+          thresholdLabel="Action threshold 80%"
+        />
+      ) : (
+        <>
+          <Gauge
+            value={agent.sc_prob_3lap}
+            label="SC in 3 laps"
+            threshold={0.3}
+            thresholdLabel="Alert threshold 30%"
+          />
+          <BaselineLiftBar current={agent.sc_prob_3lap} />
+        </>
+      )}
+
+      <ReasoningDisclosure reasoning={agent.reasoning} />
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/TyreResultView.tsx
+++ b/webapp/src/features/lab/models/TyreResultView.tsx
@@ -1,0 +1,202 @@
+// Tyre degradation bench (TCN + MC-Dropout). One run fires two independent
+// calls: the agent verdict (POST /tire, off a single lap_state, giving deg
+// rate, cliff quantiles, warning level) and the trajectory across the
+// driver's whole lap window (POST /tire-range, actual vs predicted
+// degradation per lap). Both are pure ML (no LLM, no rate limit), so the run
+// is fast. Same idle/running/done/stale shape as PaceResultView, see that
+// file's header for the state-machine rationale; this one adds a warning
+// Pill and StintRunway cliff read since, unlike Pace, Tyres carries a
+// verdict class.
+
+import { useRef } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Disc3 } from 'lucide-react'
+import { AgentModelChart, type AgentModelPoint } from '@/charts/AgentModelChart'
+import { ChartCard } from '@/components/ChartCard'
+import { CompoundPill } from '@/components/CompoundPill'
+import { Pill } from '@/components/Pill'
+import { Skeleton } from '@/components/Skeleton'
+import { StatCard } from '@/components/StatCard'
+import {
+  fetchLapRange,
+  fetchLapState,
+  fetchTireRange,
+  runAgent,
+  type TireRangePoint,
+} from '@/lib/api/strategy'
+import { LAB_YEAR } from '../search'
+import { StintRunway } from '../components/StintRunway'
+import { selectActiveRun, useLabStore, type LabRun } from '../store'
+import type { ModelMeta, ResultViewProps } from './types'
+import {
+  IdleHero,
+  RanContextChip,
+  ReasoningDisclosure,
+  RunControls,
+  RunHeader,
+  StaleBanner,
+  useElapsedSeconds,
+  VerdictRow,
+} from '../components/RunFrame'
+
+export const TYRE_META: ModelMeta = {
+  id: 'tyres',
+  Icon: Disc3,
+  title: 'Tyre degradation',
+  modelChip: 'TCN + MC-Dropout',
+  evalHeadline: 'Coverage 0.708',
+  blurb: 'Projects tyre degradation and the laps until the performance cliff, with uncertainty.',
+  control: 'lap',
+}
+
+/** One lap count, formatted "L18", the same shorthand StintRunway already
+ *  uses for tyre age and the cliff quantiles, so the StatCards and the strip
+ *  read as one vocabulary. */
+function fmtLap(n: number): string {
+  return `L${Math.round(n)}`
+}
+
+/** Pill tone for the agent's warning level. PIT_SOON is the only urgent call,
+ *  MONITOR is a heads-up, and OK (or anything unrecognised) reads as fine. */
+function warningTone(level: string): 'danger' | 'warning' | 'success' {
+  if (level === 'PIT_SOON') return 'danger'
+  if (level === 'MONITOR') return 'warning'
+  return 'success'
+}
+
+/** TireRangePoint[] -> the chart's point shape. No CI band and no stint
+ *  markers here, /tire-range carries neither, unlike /pace-range. */
+function toChartPoints(points: TireRangePoint[]): AgentModelPoint[] {
+  return points.map((p) => ({
+    lap: p.lap,
+    actual: p.actual,
+    pred: p.pred,
+    compound: p.compound,
+  }))
+}
+
+export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
+  const addRun = useLabStore((s) => s.addRun)
+  const activeRun = useLabStore((s) => selectActiveRun(s, 'tyres'))
+  const abortRef = useRef<AbortController | null>(null)
+
+  const runMut = useMutation({
+    mutationFn: async ({ signal }: { signal: AbortSignal }) => {
+      const [agent, range] = await Promise.all([
+        fetchLapState(gp!, driver!, lap!, LAB_YEAR).then((lapState) => runAgent('tire', lapState)),
+        fetchLapRange(gp!, driver!, LAB_YEAR).then((lapRange) =>
+          fetchTireRange(gp!, driver!, lapRange.min_lap, lapRange.max_lap, LAB_YEAR, signal),
+        ),
+      ])
+      return { agent, range }
+    },
+    onSuccess: ({ agent, range }) => {
+      const run: LabRun = {
+        id: crypto.randomUUID(),
+        model: 'tyres',
+        context: { gp, driver, lap },
+        result: { kind: 'tyres', agent, range },
+        label: lap != null ? `Lap ${lap}` : 'Tyres',
+        ranAt: Date.now(),
+      }
+      addRun(run)
+    },
+  })
+
+  const elapsed = useElapsedSeconds(runMut.isPending)
+  const disabledReason = !gp
+    ? 'Pick a Grand Prix'
+    : !driver
+      ? 'Pick a driver'
+      : lap == null
+        ? 'Pick a lap'
+        : undefined
+
+  function onRun() {
+    if (disabledReason) return
+    const ac = new AbortController()
+    abortRef.current = ac
+    runMut.mutate({ signal: ac.signal })
+  }
+  function onCancel() {
+    abortRef.current?.abort()
+    runMut.reset()
+  }
+
+  if (runMut.isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        <RunHeader
+          title={TYRE_META.title}
+          modelChip={TYRE_META.modelChip}
+          right={<RunControls isRunning onRun={onRun} onCancel={onCancel} elapsed={elapsed} />}
+        />
+        <Skeleton className="h-52 w-full" />
+        <p className="text-center text-xs text-fg-4">Running the tyre model...</p>
+      </div>
+    )
+  }
+
+  const run = activeRun?.result.kind === 'tyres' ? activeRun : undefined
+  if (!run) {
+    return <IdleHero meta={TYRE_META} disabledReason={disabledReason} onRun={onRun} />
+  }
+  if (run.result.kind !== 'tyres') return null // unreachable, narrows the result type below
+  const { agent, range } = run.result
+
+  const stale = run.context.gp !== gp || run.context.driver !== driver || run.context.lap !== lap
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RunHeader
+        title={TYRE_META.title}
+        modelChip={TYRE_META.modelChip}
+        right={
+          <>
+            <RanContextChip label={run.label} />
+            <RunControls isRunning={false} onRun={onRun} disabledReason={disabledReason} />
+          </>
+        }
+      />
+
+      {stale ? (
+        <StaleBanner
+          message={`Result is for ${run.label}. Re-run for the current lap.`}
+          onRerun={onRun}
+        />
+      ) : null}
+
+      <VerdictRow>
+        <Pill tone={warningTone(agent.warning_level)}>{agent.warning_level}</Pill>
+        <CompoundPill compound={agent.compound} />
+        <StatCard eyebrow="Tyre life" value={fmtLap(agent.current_tyre_life)} />
+        <StatCard eyebrow="Deg rate" value={`${agent.deg_rate.toFixed(3)} s/lap`} />
+        <StatCard
+          eyebrow="Cliff P50"
+          value={fmtLap(agent.laps_to_cliff_p50)}
+          hint={`P10 ${fmtLap(agent.laps_to_cliff_p10)} · P90 ${fmtLap(agent.laps_to_cliff_p90)}`}
+        />
+      </VerdictRow>
+
+      <StintRunway
+        tyreLife={agent.current_tyre_life}
+        cliffP10={agent.laps_to_cliff_p10}
+        cliffP50={agent.laps_to_cliff_p50}
+        cliffP90={agent.laps_to_cliff_p90}
+      />
+
+      <ChartCard title="Tyre degradation trajectory">
+        <AgentModelChart
+          points={toChartPoints(range)}
+          actualLabel="Actual"
+          predLabel="TCN estimate"
+          yUnit=""
+          compoundDots
+          height={220}
+        />
+      </ChartCard>
+
+      <ReasoningDisclosure reasoning={agent.reasoning} />
+    </div>
+  )
+}

--- a/webapp/src/features/lab/models/registry.tsx
+++ b/webapp/src/features/lab/models/registry.tsx
@@ -1,0 +1,32 @@
+// The model registry: the six bench entries in rail order. Adding a model is
+// one entry here. Overtake and Safety car share SituationResultView (one run,
+// two lenses), so their entries wrap it with a fixed lens.
+
+import type { ModelId } from '../search'
+import type { ModelDef, ResultViewProps } from './types'
+import { PACE_META, PaceResultView } from './PaceResultView'
+import { TYRE_META, TyreResultView } from './TyreResultView'
+import { OVERTAKE_META, SAFETYCAR_META, SituationResultView } from './SituationResultView'
+import { PIT_META, PitResultView } from './PitResultView'
+import { RADIO_META, RadioResultView } from './RadioResultView'
+
+function OvertakeResultView(props: ResultViewProps) {
+  return <SituationResultView {...props} lens="overtake" />
+}
+function SafetyCarResultView(props: ResultViewProps) {
+  return <SituationResultView {...props} lens="safetycar" />
+}
+
+export const MODEL_DEFS: ModelDef[] = [
+  { ...PACE_META, ResultView: PaceResultView },
+  { ...TYRE_META, ResultView: TyreResultView },
+  { ...OVERTAKE_META, ResultView: OvertakeResultView },
+  { ...SAFETYCAR_META, ResultView: SafetyCarResultView },
+  { ...PIT_META, ResultView: PitResultView },
+  { ...RADIO_META, ResultView: RadioResultView },
+]
+
+export const MODEL_DEF_BY_ID = Object.fromEntries(MODEL_DEFS.map((d) => [d.id, d])) as Record<
+  ModelId,
+  ModelDef
+>

--- a/webapp/src/features/lab/models/types.ts
+++ b/webapp/src/features/lab/models/types.ts
@@ -1,0 +1,43 @@
+import type { ComponentType } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import type { LabSearch, ModelId } from '../search'
+
+// The contract every model on the bench follows. Adding a seventh model is one
+// registry entry: an identity (icon/title/model-type/eval headline), which
+// context control it needs, and a ResultView that owns its run + verdict + viz.
+
+/** Which context control the bar shows for a model. */
+export type LabControl = 'window' | 'lap' | 'radio'
+
+/** Props the bench passes to every model's ResultView: the current moment plus
+ *  a URL patcher (for "jump to last valid lap" and "Send to Strategy"). The
+ *  ResultView reads its own active run from the store and owns its run mutation. */
+export interface ResultViewProps {
+  gp?: string
+  driver?: string
+  lap?: number
+  laps?: [number, number]
+  onPatch: (patch: Partial<LabSearch>) => void
+}
+
+/** A model's identity, without its view, so a ResultView can export its own
+ *  identity and the registry can build the rail from it without importing the
+ *  view (which would import back, a cycle). */
+export interface ModelMeta {
+  id: ModelId
+  Icon: LucideIcon
+  /** Rail + run-header title, e.g. "Tyre degradation". */
+  title: string
+  /** Model-type chip, e.g. "TCN + MC-Dropout". */
+  modelChip: string
+  /** Headline evaluation metric from the IEEE report, e.g. "MAE 0.411 s". */
+  evalHeadline: string
+  /** One-line "what this model does", shown on the idle hero. */
+  blurb: string
+  control: LabControl
+}
+
+/** A model registry entry: its identity plus the view that runs it. */
+export interface ModelDef extends ModelMeta {
+  ResultView: ComponentType<ResultViewProps>
+}

--- a/webapp/src/features/lab/queries.ts
+++ b/webapp/src/features/lab/queries.ts
@@ -1,0 +1,81 @@
+// TanStack Query reads for the Model Lab. Context lookups (gps / drivers /
+// lap-range / lap-state / radio corpus) are deterministic historical data:
+// cache forever, and reuse the SAME query keys as the Strategy tab so the cache
+// is shared across pages with no cross-feature import. Model RUNS are mutations
+// and live inside each model's ResultView (a run history must record runs, not
+// serve cache hits), so they are not here.
+
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/queryKeys'
+import {
+  fetchLapRange,
+  fetchLapState,
+  fetchStrategyDrivers,
+  fetchStrategyGps,
+  type LapRange,
+  type LapState,
+} from '@/lib/api/strategy'
+import { fetchRadioLaps, type RadioDriver } from '@/lib/api/race'
+
+// Historical/deterministic data: cache forever, one retry so a downed backend
+// fails fast instead of a multi-minute backoff.
+const STATIC = { staleTime: Infinity, gcTime: Infinity, retry: 1 } as const
+
+/** GPs in the 2025 featured parquet (shared cache with Strategy). */
+export function useLabGps() {
+  return useQuery({
+    queryKey: queryKeys.strategy.gps(),
+    queryFn: () => fetchStrategyGps(),
+    ...STATIC,
+  })
+}
+
+/** Driver codes for a GP (gated on GP, like the Streamlit cascade). */
+export function useLabDrivers(gp: string | undefined) {
+  return useQuery({
+    queryKey: gp ? queryKeys.strategy.drivers(gp) : ['strategy', 'drivers', 'idle'],
+    queryFn: () => fetchStrategyDrivers(gp!),
+    enabled: !!gp,
+    ...STATIC,
+  })
+}
+
+/** Min/max lap for a (gp, driver) — bounds the lap slider / pace window. */
+export function useLabRange(gp: string | undefined, driver: string | undefined) {
+  return useQuery({
+    queryKey:
+      gp && driver ? queryKeys.strategy.lapRange(gp, driver) : ['strategy', 'lap-range', 'idle'],
+    queryFn: (): Promise<LapRange> => fetchLapRange(gp!, driver!),
+    enabled: !!gp && !!driver,
+    ...STATIC,
+  })
+}
+
+/** The lap snapshot for one (gp, driver, lap) — previews compound/age/position
+ *  in the context bar before any run. Cached per lap. */
+export function useLabState(
+  gp: string | undefined,
+  driver: string | undefined,
+  lap: number | undefined,
+) {
+  return useQuery({
+    queryKey:
+      gp && driver && lap != null
+        ? queryKeys.strategy.lapState(gp, driver, lap)
+        : ['strategy', 'lap-state', 'idle'],
+    queryFn: (): Promise<LapState> => fetchLapState(gp!, driver!, lap!),
+    enabled: !!gp && !!driver && lap != null,
+    ...STATIC,
+  })
+}
+
+/** The team-radio corpus for a GP: one entry per driver with recorded radio,
+ *  each carrying its per-message transcript previews. Feeds the RadioBrowser. */
+export function useLabRadioCorpus(gp: string | undefined) {
+  return useQuery({
+    queryKey: gp ? ['lab', 'radio-laps', gp] : ['lab', 'radio-laps', 'idle'],
+    queryFn: (): Promise<RadioDriver[]> => fetchRadioLaps(gp!),
+    enabled: !!gp,
+    ...STATIC,
+  })
+}

--- a/webapp/src/features/lab/search.ts
+++ b/webapp/src/features/lab/search.ts
@@ -1,0 +1,164 @@
+// URL search-param contract for the Model Lab. The bench config lives in the
+// URL so a model + race moment is a shareable link: `?model=tyres&gp=Austin&
+// driver=NOR&lap=18&laps=8-28`. Same raw<->component boundary as the Dashboard
+// and Strategy search files.
+//
+// Deep links reproduce the CONFIG only, they never auto-run a model (an ML/LLM
+// call, rate-limited). A shared link lands on a prefilled idle bench.
+//
+// The six model ids are the UI-facing rail entries. Overtake and Safety car both
+// read the ONE `/situation` agent, so they share a run; the id split is purely
+// which lens the bench shows. Free-text radio input NEVER enters the URL.
+
+export const LAB_YEAR = 2025
+
+export const MODEL_IDS = ['pace', 'tyres', 'overtake', 'safetycar', 'pit', 'radio'] as const
+export type ModelId = (typeof MODEL_IDS)[number]
+const DEFAULT_MODEL: ModelId = 'pace'
+
+/** Radio bench mode: browse the corpus, or type a free message. */
+export const RADIO_MODES = ['lookup', 'freetext'] as const
+export type RadioMode = (typeof RADIO_MODES)[number]
+
+/** Component-facing bench config. */
+export interface LabSearch {
+  model: ModelId
+  gp?: string
+  driver?: string
+  /** Single decision lap for the per-lap models (Tyres/Overtake/SC/Pit). */
+  lap?: number
+  /** [start, end] lap window for the Pace batch run. */
+  laps?: [number, number]
+  /** Radio lookup overrides; only serialized when they differ from the page context. */
+  rmode?: RadioMode
+  rgp?: string
+  rdrv?: string
+  rlap?: number
+}
+
+/** URL / validated bench config. */
+export interface RawLabSearch {
+  model?: string
+  gp?: string
+  driver?: string
+  lap?: number
+  laps?: string
+  rmode?: string
+  rgp?: string
+  rdrv?: string
+  rlap?: number
+}
+
+function coerceStr(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined
+}
+
+function coerceModel(raw: unknown): ModelId {
+  return MODEL_IDS.includes(raw as ModelId) ? (raw as ModelId) : DEFAULT_MODEL
+}
+
+function coerceMode(raw: unknown): RadioMode | undefined {
+  return RADIO_MODES.includes(raw as RadioMode) ? (raw as RadioMode) : undefined
+}
+
+function coerceInt(raw: unknown): number | undefined {
+  if (raw == null || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isNaN(n) ? undefined : Math.round(n)
+}
+
+/** Parse a "a-b" lap window into an ordered [start, end] tuple, or undefined. */
+function parseLaps(raw: unknown): [number, number] | undefined {
+  if (typeof raw !== 'string' || raw === '') return undefined
+  const parts = raw.split('-').map((p) => Number(p.trim()))
+  if (parts.length !== 2 || parts.some((n) => Number.isNaN(n))) return undefined
+  const [a, b] = parts
+  return a <= b ? [a, b] : [b, a]
+}
+
+/**
+ * `validateSearch` for the /lab route: coerce raw router search AND enforce the
+ * cascade (lap/laps/radio overrides need a driver, driver needs a GP). A
+ * hand-edited link with an orphan field drops it rather than rendering a broken
+ * half-selected bench.
+ */
+export function validateLabSearch(raw: Record<string, unknown>): RawLabSearch {
+  const model = coerceModel(raw.model)
+  const gp = coerceStr(raw.gp)
+  const driver = gp ? coerceStr(raw.driver) : undefined
+  const lap = driver ? coerceInt(raw.lap) : undefined
+  const laps = driver ? parseLaps(raw.laps) : undefined
+  const rmode = coerceMode(raw.rmode)
+  const rgp = coerceStr(raw.rgp)
+  const rdrv = rgp ? coerceStr(raw.rdrv) : undefined
+  const rlap = coerceInt(raw.rlap)
+  return {
+    ...(model !== DEFAULT_MODEL ? { model } : {}),
+    ...(gp ? { gp } : {}),
+    ...(driver ? { driver } : {}),
+    ...(lap != null ? { lap } : {}),
+    ...(laps ? { laps: `${laps[0]}-${laps[1]}` } : {}),
+    ...(rmode ? { rmode } : {}),
+    ...(rgp ? { rgp } : {}),
+    ...(rdrv ? { rdrv } : {}),
+    ...(rlap != null ? { rlap } : {}),
+  }
+}
+
+/**
+ * Apply a single-key bench patch with the cascading reset of dependent levels.
+ * Changing the GP clears driver/lap/laps/radio overrides; changing the driver
+ * clears lap/laps. Switching model keeps the moment. Re-picking the SAME value
+ * is a no-op returning the ORIGINAL object (so callers can `if (next === search)
+ * return`). Pure.
+ */
+export function applyLabPatch(search: LabSearch, patch: Partial<LabSearch>): LabSearch {
+  if ('model' in patch && patch.model === search.model) return search
+  if ('gp' in patch && patch.gp === search.gp) return search
+  if ('driver' in patch && patch.driver === search.driver) return search
+  if ('lap' in patch && patch.lap === search.lap) return search
+
+  const next: LabSearch = { ...search, ...patch }
+  if ('gp' in patch) {
+    next.driver = undefined
+    next.lap = undefined
+    next.laps = undefined
+    next.rgp = undefined
+    next.rdrv = undefined
+    next.rlap = undefined
+  } else if ('driver' in patch) {
+    next.lap = undefined
+    next.laps = undefined
+  }
+  return next
+}
+
+/** URL shape -> component shape. */
+export function fromRaw(raw: RawLabSearch): LabSearch {
+  return {
+    model: coerceModel(raw.model),
+    gp: raw.gp,
+    driver: raw.driver,
+    lap: raw.lap,
+    laps: parseLaps(raw.laps),
+    rmode: coerceMode(raw.rmode),
+    rgp: raw.rgp,
+    rdrv: raw.rdrv,
+    rlap: raw.rlap,
+  }
+}
+
+/** Component shape -> URL shape (empty fields + the default model dropped). */
+export function toRaw(search: LabSearch): RawLabSearch {
+  return {
+    ...(search.model !== DEFAULT_MODEL ? { model: search.model } : {}),
+    ...(search.gp ? { gp: search.gp } : {}),
+    ...(search.driver ? { driver: search.driver } : {}),
+    ...(search.lap != null ? { lap: search.lap } : {}),
+    ...(search.laps ? { laps: `${search.laps[0]}-${search.laps[1]}` } : {}),
+    ...(search.rmode ? { rmode: search.rmode } : {}),
+    ...(search.rgp ? { rgp: search.rgp } : {}),
+    ...(search.rdrv ? { rdrv: search.rdrv } : {}),
+    ...(search.rlap != null ? { rlap: search.rlap } : {}),
+  }
+}

--- a/webapp/src/features/lab/store.ts
+++ b/webapp/src/features/lab/store.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type {
+  PaceRangePoint,
+  PitResult,
+  SituationResult,
+  TireRangePoint,
+  TireResult,
+} from '@/lib/api/strategy'
+import type { RadioResult } from '@/lib/api/race'
+import type { ModelId } from './search'
+
+// Run store for the Model Lab. Each model RUN (not a cache hit) is recorded so
+// the bench can show a per-model history and detect a stale result (one whose
+// context no longer matches the bench). Runs are session-scoped (sessionStorage)
+// and capped, so a long defense demo stays bounded. A Situation run feeds BOTH
+// the Overtake and Safety-car models, so it registers as the active run under
+// both ids.
+
+const RUN_CAP = 30
+
+/** The race moment a run was fired against, kept so a later context change can
+ *  be flagged as stale. Radio runs carry a short input label instead of a lap. */
+export interface LabRunContext {
+  gp?: string
+  driver?: string
+  lap?: number
+  laps?: [number, number]
+  radioLabel?: string
+}
+
+/** A run's result, tagged by the shape it carries. `situation` backs both the
+ *  Overtake and Safety-car models; `tyres` carries the agent verdict AND the
+ *  degradation trajectory (two calls, one run). */
+export type LabRunResult =
+  | { kind: 'pace'; range: PaceRangePoint[] }
+  | { kind: 'tyres'; agent: TireResult; range: TireRangePoint[] }
+  | { kind: 'situation'; agent: SituationResult }
+  | { kind: 'pit'; agent: PitResult }
+  | { kind: 'radio'; agent: RadioResult }
+
+export interface LabRun {
+  id: string
+  /** The model whose Run button fired this (Situation runs use 'overtake' or
+   *  'safetycar' depending on which lens was active). */
+  model: ModelId
+  context: LabRunContext
+  result: LabRunResult
+  /** Short human label for the history strip, e.g. "Lap 18" or "Free text". */
+  label: string
+  ranAt: number
+}
+
+interface LabState {
+  runs: LabRun[]
+  /** The run currently shown per model id. A model with no entry is idle. */
+  activeRunByModel: Partial<Record<ModelId, string>>
+  addRun: (run: LabRun) => void
+  setActiveRun: (model: ModelId, runId: string) => void
+  clearRuns: () => void
+}
+
+/** Which model ids a run should light up. A Situation run answers both the
+ *  Overtake and Safety-car benches; every other run answers only its own. */
+function activeIdsFor(run: LabRun): ModelId[] {
+  if (run.result.kind === 'situation') return ['overtake', 'safetycar']
+  return [run.model]
+}
+
+export const useLabStore = create<LabState>()(
+  persist(
+    (set) => ({
+      runs: [],
+      activeRunByModel: {},
+      addRun: (run) =>
+        set((s) => {
+          const runs = [run, ...s.runs].slice(0, RUN_CAP)
+          const activeRunByModel = { ...s.activeRunByModel }
+          for (const id of activeIdsFor(run)) activeRunByModel[id] = run.id
+          return { runs, activeRunByModel }
+        }),
+      setActiveRun: (model, runId) =>
+        set((s) => ({ activeRunByModel: { ...s.activeRunByModel, [model]: runId } })),
+      clearRuns: () => set({ runs: [], activeRunByModel: {} }),
+    }),
+    {
+      name: 'f1sl.lab',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (s) => ({ runs: s.runs, activeRunByModel: s.activeRunByModel }),
+    },
+  ),
+)
+
+/** The active run for a model, or undefined when the model is idle. */
+export function selectActiveRun(state: LabState, model: ModelId): LabRun | undefined {
+  const id = state.activeRunByModel[model]
+  return id ? state.runs.find((r) => r.id === id) : undefined
+}
+
+/** Past runs for one model, newest first (Situation runs show under both). A
+ *  pure helper over the runs array (NOT a zustand selector): filtering inside a
+ *  selector returns a fresh array each call and loops the render, so callers
+ *  select `runs` and pass it here inside a useMemo. */
+export function runsForModel(runs: LabRun[], model: ModelId): LabRun[] {
+  const situationLens = model === 'overtake' || model === 'safetycar'
+  return runs.filter((r) =>
+    situationLens ? r.result.kind === 'situation' : r.result.kind === modelKind(model),
+  )
+}
+
+/** The result kind a model reads (Overtake/SC both read 'situation'). */
+function modelKind(model: ModelId): LabRunResult['kind'] {
+  switch (model) {
+    case 'pace':
+      return 'pace'
+    case 'tyres':
+      return 'tyres'
+    case 'overtake':
+    case 'safetycar':
+      return 'situation'
+    case 'pit':
+      return 'pit'
+    case 'radio':
+      return 'radio'
+  }
+}


### PR DESCRIPTION
## What
The Model Lab (#38): the model inspector. One of six predictors on the bench, fed a real race moment, with its prediction / uncertainty / decision threshold / reasoning. Builds on the L0 shared-primitive promotions (submodule #150).

## The bench
- **Model rail** of identity cards (icon + type chip + IEEE eval headline + run-status dot); collapses to a horizontal strip below lg.
- **One shared RunFrame** grammar: run header -> verdict row -> viz zone -> reasoning disclosure, per model.
- **Six models:** Pace (XGBoost, actual-vs-pred + CI band + compound dots + stint lines, cancelable 45-60 s batch), Tyres (TCN, StintRunway + degradation trajectory), Overtake + Safety car (LightGBM, ONE shared /situation run feeds both, SituationFacts strip + threshold gauges + SC baseline-lift bar), Pit (HistGBT + LightGBM, ActionBadge incl. REACTIVE_SC + stop-duration RangeBar + undercut gauge), Radio (reuses the promoted browser/composer/result-card, dual mode).
- **Per-model run history** (session-scoped) with click-to-restore; **stale banner** when the bench moves off a run; **Send to Strategy** deep-link.
- URL carries the bench config and never auto-runs.

## Checks
- typecheck (tsc -b): clean · build (vite): 2925 modules · oxlint: only pre-existing fast-refresh warnings
- browser-verified all six models with real backend data, dark and light themes.