### PR TITLE
refactor(webapp): refine the Model Lab UI after a design pass

### DIFF
--- a/webapp/src/charts/Gauge.tsx
+++ b/webapp/src/charts/Gauge.tsx
@@ -105,8 +105,9 @@ function buildGaugeOption({
         radius: '90%',
         pointer: { show: false },
         progress: {
-          show: true,
+          show: value > 0,
           width: 10,
+          roundCap: true,
           itemStyle: { color: PURPLE_600 },
         },
         axisLine: {
@@ -187,7 +188,7 @@ export function Gauge({
         notMerge
       />
       {threshold != null ? (
-        <p className="-mt-2 text-xs text-fg-3">
+        <p className="-mt-8 text-xs text-fg-3">
           {thresholdLabel ?? `Action threshold ${formatValue(threshold)}`}
         </p>
       ) : null}

--- a/webapp/src/components/RangeBar.tsx
+++ b/webapp/src/components/RangeBar.tsx
@@ -28,7 +28,7 @@ export function RangeBar({ low, mid, high, format }: RangeBarProps) {
 
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="relative h-1.5 rounded-full bg-bg-5" aria-hidden="true">
+      <div className="relative h-1.5 rounded-full bg-fg-1/10" aria-hidden="true">
         <div className="absolute top-1/2 left-0 h-2 w-px -translate-y-1/2 bg-fg-4" />
         <div className="absolute top-1/2 right-0 h-2 w-px -translate-y-1/2 bg-fg-4" />
         <div

--- a/webapp/src/components/Skeleton.tsx
+++ b/webapp/src/components/Skeleton.tsx
@@ -20,7 +20,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(function Skele
       ref={ref}
       role="presentation"
       aria-hidden="true"
-      className={cn('animate-pulse rounded-lg bg-bg-4 motion-reduce:animate-none', className)}
+      className={cn('animate-pulse rounded-lg bg-fg-1/8 motion-reduce:animate-none', className)}
       {...props}
     />
   )

--- a/webapp/src/components/Tabs.tsx
+++ b/webapp/src/components/Tabs.tsx
@@ -48,7 +48,7 @@ const TRIGGER_VARIANTS: Record<TabsListVariant, string> = {
   underline:
     'border-b-2 border-transparent pb-3 text-fg-3 hover:text-fg-2 data-[state=active]:border-purple-600 data-[state=active]:text-fg-1',
   segmented:
-    'rounded-lg px-3 py-1.5 text-fg-3 hover:text-fg-2 data-[state=active]:bg-bg-4 data-[state=active]:text-fg-1',
+    'rounded-lg px-3 py-1.5 text-fg-3 hover:text-fg-2 data-[state=active]:bg-bg-5 data-[state=active]:text-fg-1 data-[state=active]:shadow-sm',
 }
 
 export const TabsTrigger = forwardRef<

--- a/webapp/src/components/radio/RadioBrowser.tsx
+++ b/webapp/src/components/radio/RadioBrowser.tsx
@@ -133,11 +133,7 @@ export function RadioBrowser({
                 className="flex items-center gap-1 font-mono text-xs text-fg-3"
                 title={`${total} radio message${total === 1 ? '' : 's'}, ${withTranscript} with transcript`}
               >
-                {withTranscript > 0 ? (
-                  <Mic className="size-3" aria-hidden="true" />
-                ) : (
-                  <MicOff className="size-3 text-fg-4" aria-hidden="true" />
-                )}
+                {withTranscript > 0 ? <Mic className="size-3" aria-hidden="true" /> : null}
                 {total}
               </span>
             </button>
@@ -155,7 +151,12 @@ export function RadioBrowser({
             description={`Audio-only radio for ${activeDriver}. Try another driver or use free text.`}
             action={
               onOpenComposer ? (
-                <Button variant="ghost" size="sm" onClick={onOpenComposer}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onOpenComposer}
+                  className="border border-hairline bg-bg-3 hover:bg-bg-4"
+                >
                   Use free text
                 </Button>
               ) : undefined

--- a/webapp/src/features/lab/components/LabContextBar.tsx
+++ b/webapp/src/features/lab/components/LabContextBar.tsx
@@ -60,9 +60,16 @@ export function LabContextBar({ search, onPatch, control }: LabContextBarProps) 
     label: d,
   }))
 
+  // Read-out values for the mono chip beside each slider (kept out of the
+  // Slider's own top-left caption, which we blank via `formatValue`, so the
+  // number lives next to the thumb instead of far away from it).
+  const lapWindow: [number, number] =
+    search.laps ?? (range ? [range.min_lap, range.max_lap] : [0, 0])
+  const lapValue = search.lap ?? range?.max_lap ?? 0
+
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-      <span className="hidden shrink-0 items-center rounded-full border border-hairline bg-bg-4 px-2 py-1 font-mono text-xs text-fg-3 sm:inline-flex">
+      <span className="mb-1 hidden shrink-0 items-center rounded-full border border-hairline bg-bg-4 px-2 py-1 font-mono text-xs text-fg-3 sm:inline-flex">
         {LAB_YEAR} season
       </span>
 
@@ -92,30 +99,40 @@ export function LabContextBar({ search, onPatch, control }: LabContextBarProps) 
       </div>
 
       {control === 'window' && range ? (
-        <div className="flex flex-col gap-1.5 sm:min-w-72 sm:flex-1">
+        <div className="flex flex-col gap-1.5 sm:w-80 lg:w-96">
           <span className={EYEBROW}>Lap window</span>
-          <DualRangeSlider
-            min={range.min_lap}
-            max={range.max_lap}
-            value={search.laps ?? [range.min_lap, range.max_lap]}
-            onValueChange={(laps) => onPatch({ laps })}
-            formatValue={(v) => `L${v}`}
-          />
+          <div className="flex items-center gap-3">
+            <DualRangeSlider
+              min={range.min_lap}
+              max={range.max_lap}
+              value={search.laps ?? [range.min_lap, range.max_lap]}
+              onValueChange={(laps) => onPatch({ laps })}
+              formatValue={() => ''}
+              className="flex-1"
+            />
+            <span className="shrink-0 font-mono text-xs tabular-nums text-fg-2">
+              L{lapWindow[0]} - L{lapWindow[1]}
+            </span>
+          </div>
         </div>
       ) : null}
 
       {control === 'lap' && range ? (
-        <div className="flex flex-col gap-1.5 sm:min-w-56 sm:flex-1">
+        <div className="flex flex-col gap-1.5 sm:w-72 lg:w-80">
           <span className={EYEBROW}>Lap</span>
-          <Slider
-            min={range.min_lap}
-            max={range.max_lap}
-            value={search.lap ?? range.max_lap}
-            onValueChange={(lap) => onPatch({ lap })}
-            formatValue={(v) => `L${v}`}
-          />
+          <div className="flex items-center gap-3">
+            <Slider
+              min={range.min_lap}
+              max={range.max_lap}
+              value={search.lap ?? range.max_lap}
+              onValueChange={(lap) => onPatch({ lap })}
+              formatValue={() => ''}
+              className="flex-1"
+            />
+            <span className="shrink-0 font-mono text-xs tabular-nums text-fg-2">L{lapValue}</span>
+          </div>
           {lapState ? (
-            <div className="flex items-center gap-2">
+            <div className="mt-1 flex items-center gap-2">
               <CompoundPill compound={lapState.driver.compound} />
               <MetricRow
                 items={[

--- a/webapp/src/features/lab/components/ModelRail.tsx
+++ b/webapp/src/features/lab/components/ModelRail.tsx
@@ -37,25 +37,34 @@ export function ModelRail({ models, active, onSelect, doneIds }: ModelRailProps)
               key={m.id}
               value={m.id}
               className={cn(
-                'h-auto shrink-0 items-start gap-2.5 rounded-xl border border-hairline bg-bg-3 px-3 py-2.5 text-left',
-                'data-[state=active]:border-purple-500/50 data-[state=active]:bg-bg-4',
+                'group h-auto shrink-0 items-start gap-2.5 overflow-hidden rounded-xl border border-hairline bg-bg-3 px-3 py-2.5 text-left',
+                'data-[state=active]:border-purple-500/60 data-[state=active]:bg-purple-600/8 data-[state=active]:shadow-[inset_2px_0_0_0_var(--purple-500)]',
                 'lg:w-full',
               )}
+              title={done ? 'Has a run for this moment' : 'Not run yet'}
             >
               <span className="mt-0.5 flex items-center gap-2">
                 <span
                   aria-hidden="true"
                   className={cn(
-                    'size-1.5 rounded-full',
-                    done ? 'bg-purple-400' : 'border border-fg-4',
+                    'size-2 rounded-full',
+                    done ? 'bg-purple-400' : 'border-[1.5px] border-fg-3',
                   )}
                 />
-                <Icon className="size-4 text-fg-2" aria-hidden="true" />
+                <Icon
+                  className="size-4 text-fg-2 group-data-[state=active]:text-accent"
+                  aria-hidden="true"
+                />
               </span>
-              <span className="flex flex-col gap-0.5">
+              <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <span className="font-display text-sm font-medium text-fg-1">{m.title}</span>
-                <span className="hidden font-mono text-xs text-fg-3 lg:inline">{m.modelChip}</span>
-                <span className="hidden font-mono text-xs text-fg-4 lg:inline">
+                <span
+                  className="hidden truncate font-mono text-xs text-fg-3 lg:block"
+                  title={m.modelChip}
+                >
+                  {m.modelChip}
+                </span>
+                <span className="hidden truncate font-mono text-xs text-fg-4 lg:block">
                   {m.evalHeadline}
                 </span>
               </span>

--- a/webapp/src/features/lab/components/RunFrame.tsx
+++ b/webapp/src/features/lab/components/RunFrame.tsx
@@ -6,7 +6,7 @@
 // VerdictRow, ModelTypeChip) keep each ResultView thin and consistent.
 
 import { useEffect, useState } from 'react'
-import { Brain, Play, RotateCw, TriangleAlert, X } from 'lucide-react'
+import { Brain, ChevronRight, Play, RotateCw, TriangleAlert, X } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { Card } from '@/components/Card'
 import { Markdown } from '@/components/Markdown'
@@ -97,9 +97,10 @@ export function RunControls({
   )
 }
 
-/** A pinned "ran for Lap 18 · 14:32" chip so a result never floats context-free. */
+/** A pinned "ran · Lap 18 · 14:32" chip so a shown result never reads as the
+ *  next run's input. */
 export function RanContextChip({ label }: { label: string }) {
-  return <span className="font-mono text-xs text-fg-3">{label}</span>
+  return <span className="font-mono text-xs text-fg-3">ran · {label}</span>
 }
 
 /** The amber stale banner: the bench moved on from the run's context. */
@@ -118,9 +119,11 @@ export function StaleBanner({ message, onRerun }: { message: string; onRerun: ()
   )
 }
 
-/** A flex row for a model's verdict pills + stat cards. */
+/** A flex row for a model's verdict pills + stat cards, stretched to one shared
+ *  height so a qualitative verdict cell reads as tall as its neighboring
+ *  StatCards instead of floating mid-height between them. */
 export function VerdictRow({ children }: { children: React.ReactNode }) {
-  return <div className="flex flex-wrap items-center gap-3">{children}</div>
+  return <div className="flex flex-wrap items-stretch gap-3">{children}</div>
 }
 
 /** The agent's reasoning, one disclosure away, never truncated. */
@@ -128,9 +131,13 @@ export function ReasoningDisclosure({ reasoning }: { reasoning: string }) {
   if (!reasoning) return null
   return (
     <details className="group">
-      <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium tracking-wide text-fg-3 uppercase marker:content-none">
+      <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium tracking-widest text-fg-3 uppercase marker:content-none">
         <Brain className="size-3.5" aria-hidden="true" />
         Agent reasoning
+        <ChevronRight
+          className="size-3.5 transition-transform group-open:rotate-90"
+          aria-hidden="true"
+        />
       </summary>
       <div className="prose-sm mt-2 rounded-lg bg-bg-2 px-3 py-2 text-fg-2">
         <Markdown>{reasoning}</Markdown>
@@ -156,6 +163,7 @@ export function IdleHero({
       <span className="flex size-11 items-center justify-center rounded-xl border border-hairline bg-bg-3 text-fg-2">
         <Icon className="size-5" aria-hidden="true" />
       </span>
+      <h3 className="font-display text-base font-medium text-fg-1">{meta.title}</h3>
       <div className="flex flex-col gap-1">
         <p className="max-w-md text-sm text-fg-2">{meta.blurb}</p>
         <p className="font-mono text-xs text-fg-4">
@@ -172,7 +180,7 @@ export function IdleHero({
 export function RunFrame({ def, ...props }: { def: ModelDef } & ResultViewProps) {
   const { ResultView } = def
   return (
-    <Card elevation="resting" className="flex flex-col gap-4 p-4">
+    <Card elevation="resting" className="flex flex-col gap-4 p-4 lg:min-h-120">
       <ResultView {...props} />
     </Card>
   )

--- a/webapp/src/features/lab/components/RunHistoryStrip.tsx
+++ b/webapp/src/features/lab/components/RunHistoryStrip.tsx
@@ -27,22 +27,22 @@ export function RunHistoryStrip({ model }: { model: ModelId }) {
 
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-xs font-medium tracking-wide text-fg-3 uppercase">Run history</span>
-      <div className="flex flex-col gap-1">
+      <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">Run history</span>
+      <div className="flex flex-wrap items-center gap-1.5">
         {modelRuns.map((run) => (
           <button
             key={run.id}
             type="button"
             onClick={() => setActiveRun(model, run.id)}
             className={cn(
-              'flex items-center justify-between gap-3 rounded-lg border px-3 py-1.5 text-left text-sm transition-colors',
+              'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition-colors',
               run.id === activeId
                 ? 'border-purple-500/50 bg-bg-4 text-fg-1'
-                : 'border-hairline bg-bg-3 text-fg-2 hover:bg-bg-4 hover:text-fg-1',
+                : 'border-hairline bg-bg-3 text-fg-3 hover:bg-bg-4 hover:text-fg-1',
             )}
           >
-            <span className="truncate">{run.label}</span>
-            <span className="shrink-0 font-mono text-xs text-fg-4">{clockLabel(run.ranAt)}</span>
+            {run.label}
+            <span className="font-mono text-fg-4">{clockLabel(run.ranAt)}</span>
           </button>
         ))}
       </div>

--- a/webapp/src/features/lab/components/StintRunway.tsx
+++ b/webapp/src/features/lab/components/StintRunway.tsx
@@ -1,9 +1,12 @@
-// StintRunway — a lap-axis strip reading "how many laps of tyre life are left".
+// StintRunway: a lap-axis strip reading "how many laps of tyre life are left".
 // Plain DOM/CSS (the RangeBar idiom, no chart lib): a track from the stint
 // start to the horizon, a "now" marker at the current tyre age, and a cliff
 // zone shaded from the P10 (earliest) to P90 (latest) laps-to-cliff estimate
 // with a firmer P50 line. It turns three abstract cliff quantiles into one
-// legible "you're here, the cliff is roughly there" read.
+// legible "you're here, the cliff is roughly there" read. It is the Lab's
+// only bespoke instrument, so it carries a little more craft than a plain
+// bar: lap ticks give it a ruler, and the "now" marker is filled with the
+// tyre's own compound colour when the caller knows it.
 
 interface StintRunwayProps {
   /** Current tyre age in laps (the "now" position). */
@@ -13,6 +16,10 @@ interface StintRunwayProps {
   cliffP10: number
   cliffP50: number
   cliffP90: number
+  /** The compound currently fitted (FastF1 name, e.g. "soft"/"medium"/"hard"/
+   *  "intermediate"/"wet", case-insensitive). Colours the "now" marker with
+   *  its brand hue; an unknown or omitted compound keeps the default purple. */
+  compound?: string
 }
 
 /** Percent position of an absolute tyre-age lap on a [0, max] track. */
@@ -21,7 +28,41 @@ function pct(lap: number, max: number): number {
   return Math.min(100, Math.max(0, (lap / max) * 100))
 }
 
-export function StintRunway({ tyreLife, cliffP10, cliffP50, cliffP90 }: StintRunwayProps) {
+const MARKER_CLASS_BY_COMPOUND: Record<string, string> = {
+  soft: 'bg-tire-soft',
+  medium: 'bg-tire-medium',
+  hard: 'bg-tire-hard',
+  intermediate: 'bg-tire-inter',
+  inter: 'bg-tire-inter',
+  wet: 'bg-tire-wet',
+}
+
+/** Background class for the "now" marker: the compound's brand colour when
+ *  recognised, the default accent purple otherwise. */
+function markerClass(compound: string | undefined): string {
+  if (!compound) return 'bg-purple-500'
+  return MARKER_CLASS_BY_COMPOUND[compound.toLowerCase()] ?? 'bg-purple-500'
+}
+
+const TICK_STEP_LAPS = 10
+
+/** Lap numbers for the ruler ticks: every `TICK_STEP_LAPS` laps from 0 up to
+ *  the track's horizon, so the strip reads as a ruler, not just two dots. */
+function tickLaps(max: number): number[] {
+  const ticks: number[] = []
+  for (let lap = 0; lap <= max; lap += TICK_STEP_LAPS) {
+    ticks.push(lap)
+  }
+  return ticks
+}
+
+export function StintRunway({
+  tyreLife,
+  cliffP10,
+  cliffP50,
+  cliffP90,
+  compound,
+}: StintRunwayProps) {
   const nowLap = Math.max(0, tyreLife)
   const p10Lap = nowLap + Math.max(0, cliffP10)
   const p50Lap = nowLap + Math.max(0, cliffP50)
@@ -33,25 +74,75 @@ export function StintRunway({ tyreLife, cliffP10, cliffP50, cliffP90 }: StintRun
   const zoneStart = pct(p10Lap, max)
   const zoneEnd = pct(p90Lap, max)
   const p50Pct = pct(p50Lap, max)
+  const ticks = tickLaps(max)
+
+  // Degenerate-zone guard: when the quantiles collapse (P10 = P50 = P90) the
+  // raw zone has zero width and the whole uncertainty band disappears. Force
+  // a minimum sliver, centred on the P50 line rather than pinned to its start,
+  // so the read stays "there's a cliff roughly here" instead of vanishing.
+  const rawZoneWidth = zoneEnd - zoneStart
+  const zoneWidth = Math.max(rawZoneWidth, 1.5)
+  const zoneLeft =
+    rawZoneWidth < 1.5 ? Math.min(Math.max(p50Pct - zoneWidth / 2, 0), 100 - zoneWidth) : zoneStart
 
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="relative h-3 rounded-full bg-bg-5" aria-hidden="true">
-        {/* Cliff zone P10 -> P90 */}
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-widest text-fg-3">
+          Stint runway
+        </span>
+        <span className="font-mono text-xs text-fg-4">laps</span>
+      </div>
+      <div
+        className="relative h-4 rounded-full border border-hairline bg-fg-1/10"
+        aria-hidden="true"
+      >
+        {/* Lap ruler ticks */}
+        {ticks.map((lap) => (
+          <div
+            key={lap}
+            className="absolute top-0 bottom-0 w-px bg-fg-1/15"
+            style={{ left: `${pct(lap, max)}%` }}
+          />
+        ))}
+        {/* Cliff zone P10 -> P90, with a subtle dot-matrix texture layered
+            under the gradient so the uncertainty band reads as textured risk,
+            not just a flat fill. */}
         <div
           className="absolute top-0 bottom-0 rounded-full bg-gradient-to-r from-warning/25 to-danger/35"
-          style={{ left: `${zoneStart}%`, width: `${Math.max(0, zoneEnd - zoneStart)}%` }}
+          style={{ left: `${zoneLeft}%`, width: `${zoneWidth}%` }}
+        />
+        <div
+          className="absolute top-0 bottom-0 rounded-full"
+          style={{
+            left: `${zoneLeft}%`,
+            width: `${zoneWidth}%`,
+            backgroundImage: 'radial-gradient(circle, var(--danger) 35%, transparent 36%)',
+            backgroundSize: '4px 4px',
+            opacity: 0.5,
+          }}
         />
         {/* P50 cliff line */}
         <div
-          className="absolute top-1/2 h-4 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-danger"
+          className="absolute top-1/2 h-5 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-danger"
           style={{ left: `${p50Pct}%` }}
         />
-        {/* "now" marker */}
+        {/* "now" marker, filled with the current compound's colour */}
         <div
-          className="absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-bg-2 bg-purple-500"
+          className={`absolute top-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-bg-2 ${markerClass(compound)}`}
           style={{ left: `${nowPct}%` }}
         />
+      </div>
+      <div className="relative h-3" aria-hidden="true">
+        {ticks.map((lap) => (
+          <span
+            key={lap}
+            className="absolute -translate-x-1/2 font-mono text-[10px] text-fg-4"
+            style={{ left: `${pct(lap, max)}%` }}
+          >
+            {lap}
+          </span>
+        ))}
       </div>
       <div className="flex items-center justify-between font-mono text-xs tabular-nums text-fg-4">
         <span className="text-fg-2">now L{Math.round(nowLap)}</span>

--- a/webapp/src/features/lab/models/PitResultView.tsx
+++ b/webapp/src/features/lab/models/PitResultView.tsx
@@ -142,8 +142,13 @@ export function PitResultView({ gp, driver, lap }: ResultViewProps) {
       ) : null}
 
       <VerdictRow>
-        <ActionBadge action={agent.action} />
-        <CompoundPill compound={agent.compound_recommendation} />
+        <div className="flex flex-col items-start justify-center gap-1.5 rounded-2xl border border-hairline bg-bg-3 px-4 py-3 shadow-[var(--shadow-card)]">
+          <span className="text-xs font-medium uppercase tracking-widest text-fg-3">Verdict</span>
+          <div className="flex items-center gap-1.5">
+            <ActionBadge action={agent.action} />
+            <CompoundPill compound={agent.compound_recommendation} />
+          </div>
+        </div>
         <StatCard
           eyebrow="Recommended lap"
           value={agent.recommended_lap != null ? `L${agent.recommended_lap}` : 'None'}

--- a/webapp/src/features/lab/models/SituationResultView.tsx
+++ b/webapp/src/features/lab/models/SituationResultView.tsx
@@ -7,6 +7,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { ArrowDown, ArrowUp, ShieldAlert, Swords } from 'lucide-react'
 import { Gauge } from '@/charts/Gauge'
+import { ChartCard } from '@/components/ChartCard'
 import { MetricRow } from '@/components/StatCard'
 import { Pill } from '@/components/Pill'
 import { Skeleton } from '@/components/Skeleton'
@@ -122,7 +123,7 @@ function BarRow({
   return (
     <div className="flex items-center gap-2">
       <span className="w-24 shrink-0 text-xs text-fg-4">{label}</span>
-      <div className="h-2 flex-1 rounded-full bg-bg-5" aria-hidden="true">
+      <div className="h-2 flex-1 rounded-full bg-fg-1/10" aria-hidden="true">
         <div className={`h-2 rounded-full ${tone}`} style={{ width: `${pct}%` }} />
       </div>
       <span className="w-12 shrink-0 text-right font-mono text-xs tabular-nums text-fg-1">
@@ -241,10 +242,6 @@ export function SituationResultView({
           </>
         }
       />
-      <p className="text-xs text-fg-4">
-        Shared run, the situation agent scores both overtake and safety car.
-      </p>
-
       {stale ? (
         <StaleBanner
           message={`Result is for ${run.label}. Re-run for the current lap.`}
@@ -256,26 +253,27 @@ export function SituationResultView({
         <Pill tone={threatTone(agent.threat_level)}>{agent.threat_level} threat</Pill>
       </VerdictRow>
 
-      <SituationFacts agent={agent} />
+      <ChartCard title={lens === 'overtake' ? 'Overtake probability' : 'SC probability (3 laps)'}>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,20rem)_1fr] lg:items-center">
+          <div className="mx-auto w-full max-w-xs">
+            <Gauge
+              value={lens === 'overtake' ? agent.overtake_prob : agent.sc_prob_3lap}
+              label={lens === 'overtake' ? 'Overtake' : 'SC in 3 laps'}
+              threshold={lens === 'overtake' ? 0.8 : 0.3}
+              thresholdLabel={lens === 'overtake' ? 'Action threshold 80%' : 'Alert threshold 30%'}
+              height={170}
+            />
+          </div>
+          <div className="flex flex-col gap-3">
+            <SituationFacts agent={agent} />
+            {lens === 'safetycar' ? <BaselineLiftBar current={agent.sc_prob_3lap} /> : null}
+          </div>
+        </div>
+      </ChartCard>
 
-      {lens === 'overtake' ? (
-        <Gauge
-          value={agent.overtake_prob}
-          label="Overtake"
-          threshold={0.8}
-          thresholdLabel="Action threshold 80%"
-        />
-      ) : (
-        <>
-          <Gauge
-            value={agent.sc_prob_3lap}
-            label="SC in 3 laps"
-            threshold={0.3}
-            thresholdLabel="Alert threshold 30%"
-          />
-          <BaselineLiftBar current={agent.sc_prob_3lap} />
-        </>
-      )}
+      <p className="text-xs text-fg-4">
+        One run scores both lenses. Overtake and Safety car share the situation agent.
+      </p>
 
       <ReasoningDisclosure reasoning={agent.reasoning} />
     </div>

--- a/webapp/src/features/lab/models/TyreResultView.tsx
+++ b/webapp/src/features/lab/models/TyreResultView.tsx
@@ -24,6 +24,7 @@ import {
   runAgent,
   type TireRangePoint,
 } from '@/lib/api/strategy'
+import { compoundVariant } from '@/lib/compounds'
 import { LAB_YEAR } from '../search'
 import { StintRunway } from '../components/StintRunway'
 import { selectActiveRun, useLabStore, type LabRun } from '../store'
@@ -49,11 +50,22 @@ export const TYRE_META: ModelMeta = {
   control: 'lap',
 }
 
-/** One lap count, formatted "L18", the same shorthand StintRunway already
- *  uses for tyre age and the cliff quantiles, so the StatCards and the strip
- *  read as one vocabulary. */
+/** Formats an ABSOLUTE lap number as "L46", the same shorthand the runway
+ *  strip and the rest of the app use for a specific lap. Reserved strictly
+ *  for absolute laps: a relative count (tyre age, laps-to-cliff) is a number
+ *  of laps FROM NOW, not a lap on the calendar, and printing it as "L<n>"
+ *  reads as the wrong lap entirely (see the cliff StatCard below). */
 function fmtLap(n: number): string {
   return `L${Math.round(n)}`
+}
+
+/** True when the agent's compound verdict is a Pirelli C-number ("C4")
+ *  rather than a named compound ("SOFT"). The tyre model reports whichever
+ *  one it was trained on; the branded CompoundPill only knows named
+ *  compounds, so a C-number verdict needs the lap's own compound name to
+ *  pick its colour (see `compoundName` below). */
+function isCNumber(compound: string): boolean {
+  return /^C\d$/i.test(compound)
 }
 
 /** Pill tone for the agent's warning level. PIT_SOON is the only urgent call,
@@ -146,6 +158,16 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
 
   const stale = run.context.gp !== gp || run.context.driver !== driver || run.context.lap !== lap
 
+  // The compound name for the run's own lap, read back from the trajectory
+  // points already fetched for the chart (no extra call). When the agent's
+  // verdict is a C-number, this is the only way to know which brand colour
+  // it refers to; otherwise the agent's own compound string is used as-is.
+  const rangeCompoundAtLap = range.find((p) => p.lap === run.context.lap)?.compound
+  const compoundName = isCNumber(agent.compound) ? rangeCompoundAtLap : agent.compound
+  const brandedVariant = isCNumber(agent.compound)
+    ? compoundVariant(rangeCompoundAtLap ?? '')
+    : null
+
   return (
     <div className="flex flex-col gap-4">
       <RunHeader
@@ -167,14 +189,23 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
       ) : null}
 
       <VerdictRow>
-        <Pill tone={warningTone(agent.warning_level)}>{agent.warning_level}</Pill>
-        <CompoundPill compound={agent.compound} />
-        <StatCard eyebrow="Tyre life" value={fmtLap(agent.current_tyre_life)} />
+        <div className="flex flex-col items-start justify-center gap-1.5 rounded-2xl border border-hairline bg-bg-3 px-4 py-3 shadow-[var(--shadow-card)]">
+          <span className="text-xs font-medium uppercase tracking-widest text-fg-3">Verdict</span>
+          <div className="flex items-center gap-1.5">
+            <Pill tone={warningTone(agent.warning_level)}>{agent.warning_level}</Pill>
+            {brandedVariant ? (
+              <Pill compound={brandedVariant}>{agent.compound}</Pill>
+            ) : (
+              <CompoundPill compound={agent.compound} />
+            )}
+          </div>
+        </div>
+        <StatCard eyebrow="Tyre life" value={`${Math.round(agent.current_tyre_life)} laps`} />
         <StatCard eyebrow="Deg rate" value={`${agent.deg_rate.toFixed(3)} s/lap`} />
         <StatCard
-          eyebrow="Cliff P50"
-          value={fmtLap(agent.laps_to_cliff_p50)}
-          hint={`P10 ${fmtLap(agent.laps_to_cliff_p10)} · P90 ${fmtLap(agent.laps_to_cliff_p90)}`}
+          eyebrow="Laps to cliff"
+          value={`+${Math.round(agent.laps_to_cliff_p50)}`}
+          hint={`≈ ${fmtLap(agent.current_tyre_life + agent.laps_to_cliff_p50)} · P10 +${Math.round(agent.laps_to_cliff_p10)} · P90 +${Math.round(agent.laps_to_cliff_p90)}`}
         />
       </VerdictRow>
 
@@ -183,14 +214,15 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
         cliffP10={agent.laps_to_cliff_p10}
         cliffP50={agent.laps_to_cliff_p50}
         cliffP90={agent.laps_to_cliff_p90}
+        compound={compoundName}
       />
 
-      <ChartCard title="Tyre degradation trajectory">
+      <ChartCard title="Tyre degradation trajectory (s vs. fresh tyre)">
         <AgentModelChart
           points={toChartPoints(range)}
           actualLabel="Actual"
           predLabel="TCN estimate"
-          yUnit=""
+          yUnit="s"
           compoundDots
           height={220}
         />


### PR DESCRIPTION
## What
Design-refinement pass over the just-built Model Lab, from a UI-design audit of all six models in both themes.

## P0 (fixed)
- Rail identity chip overflowed its card and collided with Run history (truncate + min-w-0 in ModelRail).
- Tyre life / laps-to-cliff printed relative counts in absolute-lap notation, contradicting the stint runway (relabelled to counts, absolute lap folded into the hint).

## P1
- Gauges framed in a ChartCard with SituationFacts beside them + threshold tick and caption (no more empty circle dominating the bench).
- Verdict pills get their own StatCard-height cell so the row reads as equal instruments.
- StintRunway promoted to the Lab's hero instrument: lap ruler, compound-coloured now marker, dot-matrix cliff texture, degenerate-zone guard.
- Light-theme parity: skeleton + plain-CSS tracks no longer dissolve into white.
- Idle bench names the model; context-bar slider width tamed with the value beside the thumb; run history compacted to chips; trajectory chart carries its unit.

## P2
- Reasoning chevron, gauge nub at 0, ran-context framing, eyebrow spec, radio driver badge + free-text affordance, segmented-tab active state.

## Checks
- typecheck / build / oxlint: clean
- browser-verified all six models both themes; Race dataset (segmented tabs) + radio re-verified for the shared-component changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer lap-window and active-lap readouts in the lab controls.
  * Improved stint runway visuals with lap markers, uncertainty bands, and compound-colored current-lap indicators.
  * Added clearer tyre verdict branding and relative “Laps to cliff” information.
  * Refined lab result cards, verdict displays, run history, and model status indicators.
* **Bug Fixes**
  * Gauge progress arcs now remain hidden when values are zero or negative.
  * Improved transcript and driver icon indicators.
  * Ensured narrow uncertainty ranges remain visible.
* **Style**
  * Refreshed tabs, range bars, skeletons, charts, spacing, typography, and responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->