### PR TITLE
fix(webapp): correctness fixes for the Model Lab from an adversarial audit

### DIFF
--- a/webapp/src/features/lab/components/LabContextBar.tsx
+++ b/webapp/src/features/lab/components/LabContextBar.tsx
@@ -47,7 +47,7 @@ export function LabContextBar({ search, onPatch, control }: LabContextBarProps) 
   const seedKeyRef = useRef<string | null>(null)
   useEffect(() => {
     if (minLap == null || maxLap == null || !driver) return
-    const key = `${driver}:${control}`
+    const key = `${search.gp}:${driver}:${control}`
     if (seedKeyRef.current === key) return
     seedKeyRef.current = key
     if (control === 'lap' && !hasLap) onPatch({ lap: maxLap })

--- a/webapp/src/features/lab/components/StintRunway.tsx
+++ b/webapp/src/features/lab/components/StintRunway.tsx
@@ -145,10 +145,10 @@ export function StintRunway({
         ))}
       </div>
       <div className="flex items-center justify-between font-mono text-xs tabular-nums text-fg-4">
-        <span className="text-fg-2">now L{Math.round(nowLap)}</span>
+        <span className="text-fg-2">now age {Math.round(nowLap)}</span>
         <span>
-          cliff <span className="text-fg-1">~L{Math.round(p50Lap)}</span> (P10 L{Math.round(p10Lap)}{' '}
-          · P90 L{Math.round(p90Lap)})
+          cliff <span className="text-fg-1">~age {Math.round(p50Lap)}</span> (P10{' '}
+          {Math.round(p10Lap)} · P90 {Math.round(p90Lap)})
         </span>
       </div>
     </div>

--- a/webapp/src/features/lab/models/PaceResultView.tsx
+++ b/webapp/src/features/lab/models/PaceResultView.tsx
@@ -12,7 +12,9 @@ import { AgentModelChart, type AgentModelPoint } from '@/charts/AgentModelChart'
 import { ChartCard } from '@/components/ChartCard'
 import { Skeleton } from '@/components/Skeleton'
 import { StatCard } from '@/components/StatCard'
+import { useToast } from '@/components/Toast'
 import { fetchPaceRange, type PaceRangePoint } from '@/lib/api/strategy'
+import { runFailureToast } from './runError'
 import { LAB_YEAR } from '../search'
 import { selectActiveRun, useLabStore, type LabRun } from '../store'
 import type { ModelMeta, ResultViewProps } from './types'
@@ -54,7 +56,9 @@ function windowMae(points: PaceRangePoint[]): number | null {
 function toChartPoints(points: PaceRangePoint[]): AgentModelPoint[] {
   let prevStint: number | null = null
   return points.map((p) => {
-    const stintStart = p.stint !== prevStint
+    // Never mark the window's first lap as a stint boundary: prevStint is null
+    // there, so it would draw a phantom pit line where no stop happened.
+    const stintStart = prevStint !== null && p.stint !== prevStint
     prevStint = p.stint
     return {
       lap: p.lap,
@@ -84,12 +88,18 @@ function sameWindow(a: [number, number] | undefined, b: [number, number] | undef
 export function PaceResultView({ gp, driver, laps }: ResultViewProps) {
   const addRun = useLabStore((s) => s.addRun)
   const activeRun = useLabStore((s) => selectActiveRun(s, 'pace'))
+  const { toast } = useToast()
   const abortRef = useRef<AbortController | null>(null)
+  const runSeqRef = useRef(0)
 
   const runMut = useMutation({
-    mutationFn: async ({ signal }: { signal: AbortSignal }) =>
-      fetchPaceRange(gp!, driver!, laps![0], laps![1], LAB_YEAR, signal),
-    onSuccess: (range) => {
+    mutationFn: async ({ signal, seq }: { signal: AbortSignal; seq: number }) => {
+      const range = await fetchPaceRange(gp!, driver!, laps![0], laps![1], LAB_YEAR, signal)
+      return { range, seq }
+    },
+    onSuccess: ({ range, seq }) => {
+      // Drop a run the user cancelled or superseded before it resolved.
+      if (seq !== runSeqRef.current) return
       const run: LabRun = {
         id: crypto.randomUUID(),
         model: 'pace',
@@ -100,6 +110,7 @@ export function PaceResultView({ gp, driver, laps }: ResultViewProps) {
       }
       addRun(run)
     },
+    onError: (error) => runFailureToast(toast, 'Pace', error),
   })
 
   const elapsed = useElapsedSeconds(runMut.isPending)
@@ -113,11 +124,13 @@ export function PaceResultView({ gp, driver, laps }: ResultViewProps) {
 
   function onRun() {
     if (disabledReason) return
+    const seq = ++runSeqRef.current
     const ac = new AbortController()
     abortRef.current = ac
-    runMut.mutate({ signal: ac.signal })
+    runMut.mutate({ signal: ac.signal, seq })
   }
   function onCancel() {
+    runSeqRef.current++
     abortRef.current?.abort()
     runMut.reset()
   }

--- a/webapp/src/features/lab/models/PitResultView.tsx
+++ b/webapp/src/features/lab/models/PitResultView.tsx
@@ -2,6 +2,7 @@
 // (incl. REACTIVE_SC), compound rec, rec lap; viz: stop-duration RangeBar +
 // undercut Gauge (threshold 0.522) + a small target/lap detail line.
 
+import { useRef } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Wrench } from 'lucide-react'
 import { Gauge } from '@/charts/Gauge'
@@ -12,7 +13,9 @@ import { Pill } from '@/components/Pill'
 import { RangeBar } from '@/components/RangeBar'
 import { Skeleton } from '@/components/Skeleton'
 import { MetricRow, StatCard, type MetricRowItem } from '@/components/StatCard'
+import { useToast } from '@/components/Toast'
 import { fetchLapState, runAgent, type PitResult } from '@/lib/api/strategy'
+import { runFailureToast } from './runError'
 import { LAB_YEAR } from '../search'
 import { selectActiveRun, useLabStore, type LabRun } from '../store'
 import type { ModelMeta, ResultViewProps } from './types'
@@ -47,13 +50,25 @@ const s2 = (v: number) => `${v.toFixed(2)}s`
 export function PitResultView({ gp, driver, lap }: ResultViewProps) {
   const addRun = useLabStore((s) => s.addRun)
   const activeRun = useLabStore((s) => selectActiveRun(s, 'pit'))
+  const { toast } = useToast()
+  const abortRef = useRef<AbortController | null>(null)
+  const runSeqRef = useRef(0)
 
   const runMut = useMutation({
-    mutationFn: async (): Promise<PitResult> => {
-      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR)
-      return runAgent('pit', lapState)
+    mutationFn: async ({
+      signal,
+      seq,
+    }: {
+      signal: AbortSignal
+      seq: number
+    }): Promise<{ agent: PitResult; seq: number }> => {
+      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR, signal)
+      const agent = await runAgent('pit', lapState, signal)
+      return { agent, seq }
     },
-    onSuccess: (agent) => {
+    onSuccess: ({ agent, seq }) => {
+      // Drop a run the user cancelled or superseded before it resolved.
+      if (seq !== runSeqRef.current) return
       const run: LabRun = {
         id: crypto.randomUUID(),
         model: 'pit',
@@ -64,6 +79,7 @@ export function PitResultView({ gp, driver, lap }: ResultViewProps) {
       }
       addRun(run)
     },
+    onError: (error) => runFailureToast(toast, 'Pit', error),
   })
 
   const elapsed = useElapsedSeconds(runMut.isPending)
@@ -77,9 +93,14 @@ export function PitResultView({ gp, driver, lap }: ResultViewProps) {
 
   function onRun() {
     if (disabledReason) return
-    runMut.mutate()
+    const seq = ++runSeqRef.current
+    const ac = new AbortController()
+    abortRef.current = ac
+    runMut.mutate({ signal: ac.signal, seq })
   }
   function onCancel() {
+    runSeqRef.current++
+    abortRef.current?.abort()
     runMut.reset()
   }
 

--- a/webapp/src/features/lab/models/RadioResultView.tsx
+++ b/webapp/src/features/lab/models/RadioResultView.tsx
@@ -27,6 +27,7 @@ import { RadioResultCard } from '@/components/radio/RadioResultCard'
 import { analyzeRadio, RaceApiError, type RadioResult } from '@/lib/api/race'
 import { fetchLapState } from '@/lib/api/strategy'
 import { useLabRadioCorpus } from '../queries'
+import { selectActiveRun, useLabStore, type LabRun } from '../store'
 import { RunHeader } from '../components/RunFrame'
 import type { ModelMeta, ResultViewProps } from './types'
 
@@ -52,6 +53,8 @@ function errorDescription(error: unknown, fallback: string): string {
 
 export function RadioResultView({ gp, driver }: ResultViewProps) {
   const { toast } = useToast()
+  const addRun = useLabStore((s) => s.addRun)
+  const activeRadioRun = useLabStore((s) => selectActiveRun(s, 'radio'))
   const [mode, setMode] = useState<RadioMode>('lookup')
 
   const [selDriver, setSelDriver] = useState<string | undefined>()
@@ -89,6 +92,23 @@ export function RadioResultView({ gp, driver }: ResultViewProps) {
         { driver: selDriver!, lap: selLap!, text: selectedTranscript },
       ])
     },
+    // Record the analysed message as a proper Lab run so it survives a
+    // model switch and lights up the rail's status dot, same as the other
+    // five benches. Guarded because the selection can in principle change
+    // shape while the request is still in flight.
+    onSuccess: (agent) => {
+      if (!selDriver || selLap == null) return
+      const label = `${selDriver} · Lap ${selLap}`
+      const run: LabRun = {
+        id: crypto.randomUUID(),
+        model: 'radio',
+        context: { gp, radioLabel: label },
+        result: { kind: 'radio', agent },
+        label,
+        ranAt: Date.now(),
+      }
+      addRun(run)
+    },
     onError: (error) => {
       toast({
         title: 'Radio analysis failed',
@@ -114,6 +134,12 @@ export function RadioResultView({ gp, driver }: ResultViewProps) {
     setSelMsg(msg)
     analysis.reset()
   }
+
+  // Sourced from the store rather than `analysis.data` so the last radio
+  // result survives a switch away to another model and back -- the store
+  // entry is what makes the rail's status dot light up too.
+  const shownResult =
+    activeRadioRun?.result.kind === 'radio' ? activeRadioRun.result.agent : undefined
 
   return (
     <div className="flex flex-col gap-4">
@@ -174,8 +200,8 @@ export function RadioResultView({ gp, driver }: ResultViewProps) {
             <Card elevation="resting" className="p-4">
               <SkeletonText lines={4} />
             </Card>
-          ) : analysis.data ? (
-            <RadioResultCard result={analysis.data} />
+          ) : shownResult ? (
+            <RadioResultCard result={shownResult} />
           ) : null}
         </TabsContent>
 

--- a/webapp/src/features/lab/models/SituationResultView.tsx
+++ b/webapp/src/features/lab/models/SituationResultView.tsx
@@ -4,6 +4,7 @@
 // same SituationFacts strip (gap/DRS, pace delta, SC/VSC flags) because a
 // single backend call answers both questions in one shot.
 
+import { useRef } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { ArrowDown, ArrowUp, ShieldAlert, Swords } from 'lucide-react'
 import { Gauge } from '@/charts/Gauge'
@@ -11,7 +12,9 @@ import { ChartCard } from '@/components/ChartCard'
 import { MetricRow } from '@/components/StatCard'
 import { Pill } from '@/components/Pill'
 import { Skeleton } from '@/components/Skeleton'
+import { useToast } from '@/components/Toast'
 import { fetchLapState, runAgent, type SituationResult } from '@/lib/api/strategy'
+import { runFailureToast } from './runError'
 import { LAB_YEAR } from '../search'
 import { selectActiveRun, useLabStore, type LabRun } from '../store'
 import type { ModelMeta, ResultViewProps } from './types'
@@ -168,13 +171,25 @@ export function SituationResultView({
   const meta = lens === 'overtake' ? OVERTAKE_META : SAFETYCAR_META
   const addRun = useLabStore((s) => s.addRun)
   const activeRun = useLabStore((s) => selectActiveRun(s, lens))
+  const { toast } = useToast()
+  const abortRef = useRef<AbortController | null>(null)
+  const runSeqRef = useRef(0)
 
   const runMut = useMutation({
-    mutationFn: async () => {
-      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR)
-      return runAgent('situation', lapState)
+    mutationFn: async ({
+      signal,
+      seq,
+    }: {
+      signal: AbortSignal
+      seq: number
+    }): Promise<{ agent: SituationResult; seq: number }> => {
+      const lapState = await fetchLapState(gp!, driver!, lap!, LAB_YEAR, signal)
+      const agent = await runAgent('situation', lapState, signal)
+      return { agent, seq }
     },
-    onSuccess: (agent) => {
+    onSuccess: ({ agent, seq }) => {
+      // Drop a run the user cancelled or superseded before it resolved.
+      if (seq !== runSeqRef.current) return
       const run: LabRun = {
         id: crypto.randomUUID(),
         model: lens,
@@ -185,6 +200,7 @@ export function SituationResultView({
       }
       addRun(run)
     },
+    onError: (error) => runFailureToast(toast, meta.title, error),
   })
 
   const elapsed = useElapsedSeconds(runMut.isPending)
@@ -198,11 +214,14 @@ export function SituationResultView({
 
   function onRun() {
     if (disabledReason) return
-    runMut.mutate()
+    const seq = ++runSeqRef.current
+    const ac = new AbortController()
+    abortRef.current = ac
+    runMut.mutate({ signal: ac.signal, seq })
   }
-  // Neither fetchLapState nor runAgent accepts an AbortSignal, so Cancel just
-  // drops the pending mutation locally rather than aborting a network call.
   function onCancel() {
+    runSeqRef.current++
+    abortRef.current?.abort()
     runMut.reset()
   }
 

--- a/webapp/src/features/lab/models/TyreResultView.tsx
+++ b/webapp/src/features/lab/models/TyreResultView.tsx
@@ -17,14 +17,17 @@ import { CompoundPill } from '@/components/CompoundPill'
 import { Pill } from '@/components/Pill'
 import { Skeleton } from '@/components/Skeleton'
 import { StatCard } from '@/components/StatCard'
+import { useToast } from '@/components/Toast'
 import {
   fetchLapRange,
   fetchLapState,
   fetchTireRange,
   runAgent,
   type TireRangePoint,
+  type TireResult,
 } from '@/lib/api/strategy'
 import { compoundVariant } from '@/lib/compounds'
+import { runFailureToast } from './runError'
 import { LAB_YEAR } from '../search'
 import { StintRunway } from '../components/StintRunway'
 import { selectActiveRun, useLabStore, type LabRun } from '../store'
@@ -90,19 +93,31 @@ function toChartPoints(points: TireRangePoint[]): AgentModelPoint[] {
 export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
   const addRun = useLabStore((s) => s.addRun)
   const activeRun = useLabStore((s) => selectActiveRun(s, 'tyres'))
+  const { toast } = useToast()
   const abortRef = useRef<AbortController | null>(null)
+  const runSeqRef = useRef(0)
 
   const runMut = useMutation({
-    mutationFn: async ({ signal }: { signal: AbortSignal }) => {
+    mutationFn: async ({
+      signal,
+      seq,
+    }: {
+      signal: AbortSignal
+      seq: number
+    }): Promise<{ agent: TireResult; range: TireRangePoint[]; seq: number }> => {
       const [agent, range] = await Promise.all([
-        fetchLapState(gp!, driver!, lap!, LAB_YEAR).then((lapState) => runAgent('tire', lapState)),
+        fetchLapState(gp!, driver!, lap!, LAB_YEAR, signal).then((lapState) =>
+          runAgent('tire', lapState, signal),
+        ),
         fetchLapRange(gp!, driver!, LAB_YEAR).then((lapRange) =>
           fetchTireRange(gp!, driver!, lapRange.min_lap, lapRange.max_lap, LAB_YEAR, signal),
         ),
       ])
-      return { agent, range }
+      return { agent, range, seq }
     },
-    onSuccess: ({ agent, range }) => {
+    onSuccess: ({ agent, range, seq }) => {
+      // Drop a run the user cancelled or superseded before it resolved.
+      if (seq !== runSeqRef.current) return
       const run: LabRun = {
         id: crypto.randomUUID(),
         model: 'tyres',
@@ -113,6 +128,7 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
       }
       addRun(run)
     },
+    onError: (error) => runFailureToast(toast, 'Tyres', error),
   })
 
   const elapsed = useElapsedSeconds(runMut.isPending)
@@ -126,11 +142,13 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
 
   function onRun() {
     if (disabledReason) return
+    const seq = ++runSeqRef.current
     const ac = new AbortController()
     abortRef.current = ac
-    runMut.mutate({ signal: ac.signal })
+    runMut.mutate({ signal: ac.signal, seq })
   }
   function onCancel() {
+    runSeqRef.current++
     abortRef.current?.abort()
     runMut.reset()
   }
@@ -205,7 +223,11 @@ export function TyreResultView({ gp, driver, lap }: ResultViewProps) {
         <StatCard
           eyebrow="Laps to cliff"
           value={`+${Math.round(agent.laps_to_cliff_p50)}`}
-          hint={`≈ ${fmtLap(agent.current_tyre_life + agent.laps_to_cliff_p50)} · P10 +${Math.round(agent.laps_to_cliff_p10)} · P90 +${Math.round(agent.laps_to_cliff_p90)}`}
+          hint={
+            run.context.lap != null
+              ? `≈ ${fmtLap(run.context.lap + agent.laps_to_cliff_p50)} · P10 +${Math.round(agent.laps_to_cliff_p10)} · P90 +${Math.round(agent.laps_to_cliff_p90)}`
+              : `P10 +${Math.round(agent.laps_to_cliff_p10)} · P90 +${Math.round(agent.laps_to_cliff_p90)}`
+          }
         />
       </VerdictRow>
 

--- a/webapp/src/features/lab/models/runError.ts
+++ b/webapp/src/features/lab/models/runError.ts
@@ -1,0 +1,30 @@
+// Shared failure handling for the ML benches. A model run is a mutation whose
+// error path must be visible (a silent failure reads as "the model re-ran and
+// confirmed"), except for a user-initiated cancel, which aborts the request and
+// must NOT raise an error toast.
+
+import type { useToast } from '@/components/Toast'
+import { StrategyApiError } from '@/lib/api/strategy'
+
+type ToastFn = ReturnType<typeof useToast>['toast']
+
+/** True for an aborted request (a user pressing Cancel), which is not a failure. */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
+/** Surface a run failure as a danger toast, with a tailored rate-limit message,
+ *  and swallow user-initiated cancels. */
+export function runFailureToast(toast: ToastFn, model: string, error: unknown): void {
+  if (isAbortError(error)) return
+  const rateLimited = error instanceof StrategyApiError && error.isRateLimited
+  toast({
+    title: rateLimited ? 'Rate limit reached' : `${model} run failed`,
+    description: rateLimited
+      ? 'Too many runs in a short window. Wait a minute and try again.'
+      : error instanceof StrategyApiError
+        ? error.message
+        : 'The model could not run. Check the backend and try again.',
+    tone: 'danger',
+  })
+}

--- a/webapp/src/features/lab/search.ts
+++ b/webapp/src/features/lab/search.ts
@@ -67,11 +67,15 @@ function coerceInt(raw: unknown): number | undefined {
   return Number.isNaN(n) ? undefined : Math.round(n)
 }
 
-/** Parse a "a-b" lap window into an ordered [start, end] tuple, or undefined. */
+/** Parse a "a-b" lap window into an ordered [start, end] tuple, or undefined.
+ *  Empty segments are rejected first, since `Number('')` is 0, not NaN, so a
+ *  half-written "18-" would otherwise pass the NaN check as a bogus [0, 18]. */
 function parseLaps(raw: unknown): [number, number] | undefined {
   if (typeof raw !== 'string' || raw === '') return undefined
-  const parts = raw.split('-').map((p) => Number(p.trim()))
-  if (parts.length !== 2 || parts.some((n) => Number.isNaN(n))) return undefined
+  const segments = raw.split('-').map((p) => p.trim())
+  if (segments.length !== 2 || segments.some((s) => s === '')) return undefined
+  const parts = segments.map(Number)
+  if (parts.some((n) => Number.isNaN(n))) return undefined
   const [a, b] = parts
   return a <= b ? [a, b] : [b, a]
 }
@@ -91,7 +95,7 @@ export function validateLabSearch(raw: Record<string, unknown>): RawLabSearch {
   const rmode = coerceMode(raw.rmode)
   const rgp = coerceStr(raw.rgp)
   const rdrv = rgp ? coerceStr(raw.rdrv) : undefined
-  const rlap = coerceInt(raw.rlap)
+  const rlap = rdrv ? coerceInt(raw.rlap) : undefined
   return {
     ...(model !== DEFAULT_MODEL ? { model } : {}),
     ...(gp ? { gp } : {}),

--- a/webapp/src/features/lab/store.ts
+++ b/webapp/src/features/lab/store.ts
@@ -75,12 +75,27 @@ export const useLabStore = create<LabState>()(
       addRun: (run) =>
         set((s) => {
           const runs = [run, ...s.runs].slice(0, RUN_CAP)
-          const activeRunByModel = { ...s.activeRunByModel }
+          // Drop any active pointer whose run was evicted by the cap, so the
+          // rail never shows a filled dot for a model whose run is gone.
+          const alive = new Set(runs.map((r) => r.id))
+          const activeRunByModel: Partial<Record<ModelId, string>> = {}
+          for (const [model, id] of Object.entries(s.activeRunByModel)) {
+            if (id && alive.has(id)) activeRunByModel[model as ModelId] = id
+          }
           for (const id of activeIdsFor(run)) activeRunByModel[id] = run.id
           return { runs, activeRunByModel }
         }),
+      // Restoring a run activates it under EVERY id it answers, so restoring a
+      // Situation run from history keeps the Overtake and Safety-car lenses in
+      // sync (they share one run) instead of splitting them.
       setActiveRun: (model, runId) =>
-        set((s) => ({ activeRunByModel: { ...s.activeRunByModel, [model]: runId } })),
+        set((s) => {
+          const run = s.runs.find((r) => r.id === runId)
+          const ids = run ? activeIdsFor(run) : [model]
+          const activeRunByModel = { ...s.activeRunByModel }
+          for (const id of ids) activeRunByModel[id] = runId
+          return { activeRunByModel }
+        }),
       clearRuns: () => set({ runs: [], activeRunByModel: {} }),
     }),
     {

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -249,11 +249,15 @@ async function parseOrThrow<T>(res: Response): Promise<T> {
   return body as T
 }
 
-async function getJson<T>(path: string, query: Record<string, string | number>): Promise<T> {
+async function getJson<T>(
+  path: string,
+  query: Record<string, string | number>,
+  signal?: AbortSignal,
+): Promise<T> {
   const params = new URLSearchParams(
     Object.entries(query).map(([k, v]) => [k, String(v)]),
   ).toString()
-  const res = await fetch(`${base()}/api/v1/strategy/${path}?${params}`)
+  const res = await fetch(`${base()}/api/v1/strategy/${path}?${params}`, { signal })
   return parseOrThrow<T>(res)
 }
 
@@ -299,16 +303,18 @@ export async function fetchLapState(
   driver: string,
   lap: number,
   year = YEAR,
+  signal?: AbortSignal,
 ): Promise<LapState> {
-  return getJson<LapState>('lap-state', { gp, driver, lap, year })
+  return getJson<LapState>('lap-state', { gp, driver, lap, year }, signal)
 }
 
 /** Run one sub-agent for a lap state (pure ML — no LLM, no rate limit). */
 export async function runAgent<A extends AgentName>(
   agent: A,
   lapState: LapState,
+  signal?: AbortSignal,
 ): Promise<AgentResultMap[A]> {
-  const data = await postJson<Envelope<AgentResultMap[A]>>(agent, { lap_state: lapState })
+  const data = await postJson<Envelope<AgentResultMap[A]>>(agent, { lap_state: lapState }, signal)
   return data.result
 }
 


### PR DESCRIPTION
## What
Correctness fixes for the Model Lab from an adversarial bug audit (10 bugs, 0 critical). No design changes.

## High
- **Cancel is real now**: an abort signal threads through fetchLapState/runAgent and a run-sequence guard gates onSuccess, so a cancelled or superseded run can no longer land later as a ghost result and overwrite a fresh one.
- **Errors are visible**: all four ML benches toast on failure (tailored rate-limit message) instead of silently reshowing the previous run; user cancels are swallowed.
- **Tyre cliff honesty**: the 'laps to cliff' hint prints the absolute race lap (from the decision lap), and the stint runway reads tyre age, not the L-lap notation it collided with.

## Medium
- Restoring a Situation run from history keeps both lenses in sync (store owns the dual-registration invariant).
- Radio analyses are recorded in the store, so they persist across model switches and light the rail dot.
- The lap seed keys on the Grand Prix, so switching GP with the same driver re-seeds the lap.

## Low
- Prune dangling active-run pointers when the cap evicts a run; reject a half-written lap window ('18-'); gate the radio lap on its driver; suppress the phantom first-lap stint line on the pace chart.

## Checks
- typecheck / build (2926 modules) / oxlint: clean
- browser-verified: tyres cliff hint now reads the real race lap; benches run and render with no regression.