### PR TITLE
fix(webapp): Model Lab chart-tooltip + gauge-card polish, add Run all models

### DIFF
--- a/webapp/src/charts/AgentModelChart.tsx
+++ b/webapp/src/charts/AgentModelChart.tsx
@@ -160,7 +160,17 @@ function buildCompoundScatter(points: AgentModelPoint[]): ScatterSeriesOption {
       value: [p.lap, p.actual] as [number, number | null],
       itemStyle: { color: tireColors[(p.compound ?? '').toLowerCase()] ?? ACTUAL_COLOR },
     }))
-  return { name: 'compound', type: 'scatter', symbolSize: 6, z: 11, silent: true, data }
+  // The dots duplicate the Actual line's value, so keep them out of the axis
+  // tooltip (they would show a redundant "compound" row equal to Actual).
+  return {
+    name: 'compound',
+    type: 'scatter',
+    symbolSize: 6,
+    z: 11,
+    silent: true,
+    tooltip: { show: false },
+    data,
+  }
 }
 
 function buildPredSeries(points: AgentModelPoint[], predLabel: string): LineSeriesOption {
@@ -206,7 +216,15 @@ function buildOption(
   // carry structural names that would clutter it.
   const legendData = [actualLabel, ...(hidePred ? [] : [predLabel])]
   return {
-    tooltip: { trigger: 'axis' },
+    tooltip: {
+      trigger: 'axis',
+      // Round to 3 decimals (+ the unit) so a raw float like 1.2920000000000016
+      // reads as 1.292s. Data points are [lap, value] tuples, so pull the y.
+      valueFormatter: (raw) => {
+        const value = Array.isArray(raw) ? raw[1] : raw
+        return typeof value === 'number' ? `${value.toFixed(3)}${yUnit}` : String(value ?? '')
+      },
+    },
     legend: { top: 0, right: 0, textStyle: { fontSize: 10 }, data: legendData },
     grid: { top: 28, left: 8, right: 12, bottom: 22, containLabel: true },
     xAxis: {

--- a/webapp/src/components/ChartCard.tsx
+++ b/webapp/src/components/ChartCard.tsx
@@ -40,10 +40,14 @@ export interface ChartCardProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode
   /** Optional strip below the body (status / legend). */
   footer?: ReactNode
+  /** Show the maximize control. Defaults to true; pass false for a card whose
+   *  content gains nothing from a full-viewport view (e.g. a single-value
+   *  gauge), where the button is just noise. */
+  maximizable?: boolean
 }
 
 export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function ChartCard(
-  { title, actions, children, footer, className, ...props },
+  { title, actions, children, footer, maximizable = true, className, ...props },
   ref,
 ) {
   const [isMaximized, setIsMaximized] = useState(false)
@@ -65,19 +69,21 @@ export const ChartCard = forwardRef<HTMLDivElement, ChartCardProps>(function Cha
       <h3 className="truncate font-display text-sm font-medium text-fg-1">{title}</h3>
       <div className="flex items-center gap-1">
         {actions}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label={isMaximized ? 'Restore chart' : 'Maximize chart'}
-          onClick={() => setIsMaximized((value) => !value)}
-          className="size-8 px-0 text-fg-3"
-        >
-          {isMaximized ? (
-            <Minimize2 className="size-4" aria-hidden="true" />
-          ) : (
-            <Maximize2 className="size-4" aria-hidden="true" />
-          )}
-        </Button>
+        {maximizable ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={isMaximized ? 'Restore chart' : 'Maximize chart'}
+            onClick={() => setIsMaximized((value) => !value)}
+            className="size-8 px-0 text-fg-3"
+          >
+            {isMaximized ? (
+              <Minimize2 className="size-4" aria-hidden="true" />
+            ) : (
+              <Maximize2 className="size-4" aria-hidden="true" />
+            )}
+          </Button>
+        ) : null}
       </div>
     </div>
   )

--- a/webapp/src/features/lab/LabPage.tsx
+++ b/webapp/src/features/lab/LabPage.tsx
@@ -5,8 +5,9 @@
 
 import { useCallback, useMemo } from 'react'
 import { getRouteApi, Link } from '@tanstack/react-router'
-import { ArrowUpRight } from 'lucide-react'
+import { ArrowUpRight, Play } from 'lucide-react'
 import { Header } from '@/app/Header'
+import { Button } from '@/components/Button'
 import { LabContextBar } from './components/LabContextBar'
 import { ModelRail } from './components/ModelRail'
 import { RunFrame } from './components/RunFrame'
@@ -14,6 +15,7 @@ import { RunHistoryStrip } from './components/RunHistoryStrip'
 import { MODEL_DEFS, MODEL_DEF_BY_ID } from './models/registry'
 import { applyLabPatch, fromRaw, toRaw, type LabSearch, type ModelId } from './search'
 import { useLabStore } from './store'
+import { useRunAll } from './useRunAll'
 
 const routeApi = getRouteApi('/lab')
 
@@ -44,12 +46,29 @@ export function LabPage() {
     [activeRunByModel],
   )
 
+  const { runAll, isRunning, canRunAll } = useRunAll()
+
   const window = strategyWindow(search)
   const canSendToStrategy = !!search.gp && !!search.driver
 
   return (
     <>
       <Header title="Model Lab">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="border border-hairline bg-bg-3 hover:bg-bg-4"
+          onClick={() => runAll(search)}
+          disabled={!canRunAll(search) || isRunning}
+          title={
+            canRunAll(search)
+              ? 'Run every model for this moment'
+              : 'Pick a Grand Prix, driver and lap first'
+          }
+        >
+          <Play className="size-3.5" aria-hidden="true" />
+          {isRunning ? 'Running all…' : 'Run all'}
+        </Button>
         {canSendToStrategy ? (
           <Link
             to="/strategy"

--- a/webapp/src/features/lab/models/PitResultView.tsx
+++ b/webapp/src/features/lab/models/PitResultView.tsx
@@ -176,7 +176,7 @@ export function PitResultView({ gp, driver, lap }: ResultViewProps) {
         />
       </VerdictRow>
 
-      <ChartCard title="Stop duration (s)">
+      <ChartCard title="Stop duration (s)" maximizable={false}>
         <RangeBar
           low={agent.stop_duration_p05}
           mid={agent.stop_duration_p50}
@@ -186,7 +186,7 @@ export function PitResultView({ gp, driver, lap }: ResultViewProps) {
       </ChartCard>
 
       {agent.undercut_prob != null ? (
-        <ChartCard title="Undercut probability">
+        <ChartCard title="Undercut probability" maximizable={false}>
           <div className="flex flex-col items-center gap-3">
             <Gauge
               value={agent.undercut_prob}

--- a/webapp/src/features/lab/models/SituationResultView.tsx
+++ b/webapp/src/features/lab/models/SituationResultView.tsx
@@ -272,7 +272,10 @@ export function SituationResultView({
         <Pill tone={threatTone(agent.threat_level)}>{agent.threat_level} threat</Pill>
       </VerdictRow>
 
-      <ChartCard title={lens === 'overtake' ? 'Overtake probability' : 'SC probability (3 laps)'}>
+      <ChartCard
+        title={lens === 'overtake' ? 'Overtake probability' : 'SC probability (3 laps)'}
+        maximizable={false}
+      >
         <div className="grid gap-4 lg:grid-cols-[minmax(0,20rem)_1fr] lg:items-center">
           <div className="mx-auto w-full max-w-xs">
             <Gauge

--- a/webapp/src/features/lab/useRunAll.ts
+++ b/webapp/src/features/lab/useRunAll.ts
@@ -1,0 +1,117 @@
+// "Run all models" for the Model Lab: fire every model against the current
+// moment in one click, so a user who wants the whole board can skip running six
+// benches by hand. Fetches the shared lap state once, then runs pace, tyres,
+// situation (which fills Overtake + Safety car) and pit in parallel, recording
+// each result in the store exactly like the individual benches do. Radio is
+// left out: it has no single "run this lap" input (it needs a chosen message).
+//
+// Each job is independent (Promise.allSettled), so one model failing (a rate
+// limit, a missing lap) does not stop the others; failures raise one toast.
+
+import { useState } from 'react'
+import { useToast } from '@/components/Toast'
+import {
+  fetchLapRange,
+  fetchLapState,
+  fetchPaceRange,
+  fetchTireRange,
+  runAgent,
+} from '@/lib/api/strategy'
+import { LAB_YEAR, type LabSearch } from './search'
+import { useLabStore, type LabRun } from './store'
+import { runFailureToast } from './models/runError'
+
+const newRun = (run: Omit<LabRun, 'id' | 'ranAt'>): LabRun => ({
+  ...run,
+  id: crypto.randomUUID(),
+  ranAt: Date.now(),
+})
+
+export function useRunAll() {
+  const addRun = useLabStore((s) => s.addRun)
+  const { toast } = useToast()
+  const [isRunning, setIsRunning] = useState(false)
+
+  /** True when the context can run the batch (Radio aside). */
+  const canRunAll = (search: LabSearch): boolean =>
+    !!search.gp && !!search.driver && search.lap != null
+
+  async function runAll(search: LabSearch): Promise<void> {
+    const { gp, driver, lap } = search
+    if (!gp || !driver || lap == null || isRunning) return
+    setIsRunning(true)
+    try {
+      // Shared context: the lap state for the single-lap agents, and the full
+      // lap range for the tyre trajectory (pace uses the picked window if any).
+      const [lapState, range] = await Promise.all([
+        fetchLapState(gp, driver, lap, LAB_YEAR),
+        fetchLapRange(gp, driver, LAB_YEAR),
+      ])
+      const paceWindow = search.laps ?? [range.min_lap, range.max_lap]
+      const lapLabel = `Lap ${lap}`
+
+      const jobs = [
+        fetchPaceRange(gp, driver, paceWindow[0], paceWindow[1], LAB_YEAR).then((r) =>
+          addRun(
+            newRun({
+              model: 'pace',
+              context: { gp, driver, laps: paceWindow },
+              result: { kind: 'pace', range: r },
+              label: `Laps ${paceWindow[0]}-${paceWindow[1]}`,
+            }),
+          ),
+        ),
+        Promise.all([
+          runAgent('tire', lapState),
+          fetchTireRange(gp, driver, range.min_lap, range.max_lap, LAB_YEAR),
+        ]).then(([agent, r]) =>
+          addRun(
+            newRun({
+              model: 'tyres',
+              context: { gp, driver, lap },
+              result: { kind: 'tyres', agent, range: r },
+              label: lapLabel,
+            }),
+          ),
+        ),
+        runAgent('situation', lapState).then((agent) =>
+          addRun(
+            newRun({
+              model: 'overtake',
+              context: { gp, driver, lap },
+              result: { kind: 'situation', agent },
+              label: lapLabel,
+            }),
+          ),
+        ),
+        runAgent('pit', lapState).then((agent) =>
+          addRun(
+            newRun({
+              model: 'pit',
+              context: { gp, driver, lap },
+              result: { kind: 'pit', agent },
+              label: lapLabel,
+            }),
+          ),
+        ),
+      ]
+
+      const settled = await Promise.allSettled(jobs)
+      const failed = settled.filter((s) => s.status === 'rejected')
+      if (failed.length > 0) {
+        runFailureToast(
+          toast,
+          `${failed.length} model${failed.length === 1 ? '' : 's'}`,
+          failed[0].status === 'rejected' ? failed[0].reason : undefined,
+        )
+      }
+    } catch (error) {
+      // A failure fetching the shared lap state / range aborts the whole batch.
+      runFailureToast(toast, 'Run all', error)
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return { runAll, isRunning, canRunAll }
+}


### PR DESCRIPTION
## What
Model Lab polish from live testing.

- **Chart tooltip:** drop the redundant 'compound' row (it just duplicated the Actual value) and round values to 3 decimals + unit (no more 1.2920000000000016). Fixes the pace and tyre charts.
- **Gauge cards:** ChartCard gains an opt-out maximizable flag; the maximize button is turned off on the single-value gauge cards (overtake / safety car / pit undercut / pit stop-duration) where a full-viewport view is meaningless.
- **Run all models:** a header button that runs pace + tyres + situation (fills overtake and safety car) + pit for the current moment in parallel and records each in the store, so the whole bench populates in one click. Radio stays manual (needs a chosen message).

## Checks
- typecheck / build (2927 modules) / oxlint: clean
- browser-verified: tooltip shows no compound row and 3-decimal values, gauge cards have no expand button, Run all lights all five model dots.