### PR TITLE
feat(chat): Chat #39 C1 — streaming foundation + real token streaming

### DIFF
--- a/backend/api/v1/endpoints/chat.py
+++ b/backend/api/v1/endpoints/chat.py
@@ -306,6 +306,7 @@ async def tool_message_stream(
                 model=request.model,
                 temperature=request.temperature,
                 max_tokens=request.max_tokens,
+                stream_tokens=request.stream_tokens,
             ):
                 yield _sse(event_name, payload)
         except Exception as exc:

--- a/backend/models/tool_schemas.py
+++ b/backend/models/tool_schemas.py
@@ -229,6 +229,16 @@ class ToolMessageRequest(BaseModel):
     model: Optional[str] = Field(None, description="Override LM Studio model.")
     temperature: float = Field(0.7, ge=0.0, le=2.0)
     max_tokens: int = Field(1000, ge=1, le=8192)
+    stream_tokens: bool = Field(
+        False,
+        description=(
+            "Stream the tool-summary reply as live token deltas instead of one "
+            "full-text event. Only changes the second LLM call (the summary of a "
+            "dispatched tool's result) — the first call, which decides whether to "
+            "call a tool at all, always stays non-streaming. Default False keeps "
+            "today's single-token behaviour for callers that never send this flag."
+        ),
+    )
 
 
 class ToolMessageResponse(BaseModel):

--- a/backend/services/chatbot/chat_engine.py
+++ b/backend/services/chatbot/chat_engine.py
@@ -23,12 +23,14 @@ The whole module is async because the FastMCP client is async; the LLM
 provider calls remain blocking ``requests`` calls but run inside the
 event loop without harm at the chat's traffic levels.
 
-Note on streaming: we do NOT chunk the summary text artificially.  An
-earlier version sliced the finished text into 12-char fakes to mimic a
-typing animation, but that was visual only and confused readers about
-where real tokens come from.  When we move to native provider streaming
-(``stream=True``) we will emit live deltas; until then the response
-arrives in a single ``token`` event.
+Note on streaming: by default the summary text still arrives as a single
+``token`` event — we do NOT chunk it artificially just to fake a typing
+animation.  Callers may opt into live deltas by passing
+``stream_tokens=True`` to ``stream_response``; that switches the
+tool-summary call onto the provider's native ``stream=True`` path and
+emits one ``token`` event per delta instead.  The first call (the model
+deciding whether to call a tool) always stays non-streaming — its
+casual-chat replies are short enough that one event is fine.
 """
 
 from __future__ import annotations
@@ -36,11 +38,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Callable, Generator
 
 from backend.core.config import clamp_max_tokens
 from backend.models.tool_schemas import DisplayType, TOOL_DISPLAY_MAP, ToolName, is_tool_allowed
-from backend.services.chatbot.llm_service import build_messages, send_message
+from backend.services.chatbot.llm_service import build_messages, send_message, stream_message
 from backend.services.chatbot.mcp_bridge import (
     call_mcp_tool,
     coerce_tool_arguments,
@@ -56,6 +58,11 @@ logger = logging.getLogger(__name__)
 # single message. ``_first_tool_call`` enforces it by construction — do not widen
 # it to return a list without re-checking this invariant.
 _MAX_TOOLS_PER_TURN = 1
+
+# Sentinel returned by ``next(iterator, default)`` in ``_bridge_sync_stream``
+# once the wrapped generator is exhausted — distinct from any real chunk value
+# (including an empty string), so it can never be mistaken for streamed text.
+_SYNC_STREAM_DONE = object()
 
 
 # Pirelli-style brevity for the chat: short, expert, bilingual.  The model
@@ -136,6 +143,7 @@ async def stream_response(
     model: str | None = None,
     temperature: float = 0.3,
     max_tokens: int = 800,
+    stream_tokens: bool = False,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
     """Stream the chat response as a sequence of (event_name, payload) tuples.
 
@@ -143,10 +151,18 @@ async def stream_response(
     yielded tuple — keeping the engine framework-agnostic so it can also
     feed a future WebSocket / CLI consumer without changes.
 
+    Args:
+        stream_tokens: When True, the tool-summary leg (the second LLM
+            call, made after a tool result comes back) emits live token
+            deltas instead of one full-text event. Default False leaves
+            every existing caller on today's single-``token`` turn.
+
     Yielded events:
         ("stage", {"stage": <name>})           — backend phase advanced
         ("tool_result", {"tool_result": ...})  — structured tool output
-        ("token", {"token": <chunk>})          — LLM text chunk
+        ("token", {"token": <chunk>})          — LLM text chunk (one delta
+                                                   per event when
+                                                   stream_tokens=True)
         ("done", {...})                         — final marker + metadata
     """
     # Cost cap A3 (#224): clamp the client-controlled budget down to the server
@@ -191,6 +207,7 @@ async def stream_response(
         model=model,
         temperature=temperature,
         max_tokens=max_tokens,
+        stream_tokens=stream_tokens,
     ):
         yield event
 
@@ -288,6 +305,7 @@ async def _stream_tool_response(
     model: str | None,
     temperature: float,
     max_tokens: int,
+    stream_tokens: bool = False,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
     """Dispatch the model's tool_call, stream the tool_result + summary."""
     tool_name = tool_call["function"]["name"]
@@ -319,6 +337,14 @@ async def _stream_tool_response(
         tool_data=tool_data,
         tool_error=tool_error,
     )
+
+    if stream_tokens:
+        async for event in _stream_summary_deltas(
+            summary_messages, model, temperature, max_tokens, tool_name, tool_error,
+        ):
+            yield event
+        return
+
     summary_response = await _safe_send(
         summary_messages,
         model=model,
@@ -330,6 +356,56 @@ async def _stream_tool_response(
     yield ("token", {"token": summary_text})
 
     yield ("done", _done_metadata(summary_response))
+
+
+async def _stream_summary_deltas(
+    summary_messages: list[dict[str, Any]],
+    model: str | None,
+    temperature: float,
+    max_tokens: int,
+    tool_name: str,
+    tool_error: str | None,
+) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
+    """Stream the tool-summary LLM call as live token deltas.
+
+    Opt-in counterpart to the single ``token`` event the caller emits by
+    default.  If the provider's stream fails before any text arrives — a
+    model/provider combination that does not honour ``stream=True``, a
+    dropped connection, and so on — we fall back to the ordinary
+    non-streaming call, so turning this flag on can only add live deltas,
+    never turn a turn that used to work into a failed one.
+    """
+    collected = ""
+    try:
+        async for delta in _bridge_sync_stream(
+            lambda: stream_message(
+                messages=summary_messages,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        ):
+            collected += delta
+            yield ("token", {"token": delta})
+    except Exception:
+        logger.exception("Token streaming failed for the summary call")
+        if not collected:
+            summary_response = await _safe_send(
+                summary_messages, model=model, temperature=temperature, max_tokens=max_tokens,
+            )
+            summary_text = _extract_text(summary_response) or _fallback_summary(tool_name, tool_error)
+            yield ("token", {"token": summary_text})
+            yield ("done", _done_metadata(summary_response))
+            return
+        # Some deltas already reached the client — do not replay a fallback
+        # summary on top of them, just close the turn out cleanly.
+        yield ("done", {"llm_model": model, "tokens_used": None})
+        return
+
+    if not collected.strip():
+        yield ("token", {"token": _fallback_summary(tool_name, tool_error)})
+
+    yield ("done", {"llm_model": model, "tokens_used": None})
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +464,25 @@ async def _safe_send(
     except Exception:
         logger.exception("LLM provider call failed")
         return {}
+
+
+async def _bridge_sync_stream(make_generator: Callable[[], Generator[str, None, None]]) -> AsyncGenerator[str, None]:
+    """Turn a blocking text generator into an async one without stalling the loop.
+
+    ``stream_message`` is a plain ``requests``-based generator — there is no
+    async provider client — so every ``next()`` call blocks on network I/O
+    while it waits for the next chunk. Running each ``next()`` through
+    ``asyncio.to_thread`` keeps that wait off the event loop, the same
+    reasoning ``_safe_send`` already applies to the non-streaming call, so
+    concurrent SSE streams (the sim, voice, other chat turns) stay responsive
+    while this one is mid-response.
+    """
+    iterator = iter(make_generator())
+    while True:
+        chunk = await asyncio.to_thread(next, iterator, _SYNC_STREAM_DONE)
+        if chunk is _SYNC_STREAM_DONE:
+            return
+        yield chunk
 
 
 def _extract_message(response: dict[str, Any]) -> dict[str, Any]:

--- a/webapp/src/app/router.tsx
+++ b/webapp/src/app/router.tsx
@@ -4,13 +4,13 @@ import {
   createRouter,
   lazyRouteComponent,
 } from '@tanstack/react-router'
-import { Header } from './Header'
 import { Shell } from './Shell'
 import { validateDashboardSearch } from '@/features/dashboard/search'
 import { validateStrategySearch } from '@/features/strategy/search'
 import { validateComparisonSearch } from '@/features/comparison/search'
 import { validateRaceSearch } from '@/features/race/search'
 import { validateLabSearch } from '@/features/lab/search'
+import { validateChatSearch } from '@/features/chat/search'
 
 // Each feature page is a LAZY route component so the first paint of a light tab
 // (Home) doesn't download every other tab's code — the chart-heavy pages
@@ -33,17 +33,20 @@ const ComparisonPage = lazyRouteComponent(
 )
 const RacePage = lazyRouteComponent(() => import('@/features/race/RacePage'), 'RacePage')
 const LabPage = lazyRouteComponent(() => import('@/features/lab/LabPage'), 'LabPage')
+const ChatPage = lazyRouteComponent(() => import('@/features/chat/ChatPage'), 'ChatPage')
 const ThemePreview = lazyRouteComponent(() => import('@/features/dev/ThemePreview'), 'ThemePreview')
 
 // Route tree wiring (#33). Root renders the app shell (acrylic rail + routed
 // content plane, see Shell.tsx); the shell's <Outlet/> renders whichever leaf
 // route matched below. '/' is the real Home (the Pit Wall launcher hub); the
 // old theme-preview palette moved to the dev-only '/dev/theme' (not in the
-// rail). The feature-less tabs are "coming soon" placeholders until their
-// features ship (one sprint at a time). Each `createRoute` call keeps its
-// `path` a literal string at the call site (not threaded through a prop/array)
-// so TanStack Router's typed route tree infers the exact path union — that's
-// what makes <Link to="..."> in Rail.tsx type-checked.
+// rail). Every rail tab now has a real feature page (Chat/#39 was the last
+// "coming soon" placeholder); only Voice (#40) remains reserved, as a disabled
+// toggle inside the Chat sidebar rather than a separate route. Each
+// `createRoute` call keeps its `path` a literal string at the call site (not
+// threaded through a prop/array) so TanStack Router's typed route tree infers
+// the exact path union — that's what makes <Link to="..."> in Rail.tsx
+// type-checked.
 const rootRoute = createRootRoute({ component: () => <Shell /> })
 
 const indexRoute = createRoute({
@@ -51,18 +54,6 @@ const indexRoute = createRoute({
   path: '/',
   component: HomePage,
 })
-
-/** Shared body for routes without a feature yet. */
-function ComingSoon({ title }: { title: string }) {
-  return (
-    <>
-      <Header title={title} />
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-fg-3">{title} — coming soon</p>
-      </div>
-    </>
-  )
-}
 
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -119,10 +110,15 @@ const comparisonRoute = createRoute({
   component: ComparisonPage,
 })
 
+// Chat (#39) — the MCP-tool-calling assistant: real SSE token streaming, one
+// tool result inline per turn. Its own search shape (active chat id, the
+// text/voice mode toggle reserved for Voice #40, a never-auto-firing `ask`
+// deep-link prefill).
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/chat',
-  component: () => <ComingSoon title="Chat" />,
+  validateSearch: validateChatSearch,
+  component: ChatPage,
 })
 
 const routeTree = rootRoute.addChildren([

--- a/webapp/src/features/chat/ChatPage.tsx
+++ b/webapp/src/features/chat/ChatPage.tsx
@@ -1,0 +1,129 @@
+// Chat page (#39, C1 foundation): assembles the sidebar, message thread and
+// composer around `useChatStream`. Owns the URL (which chat is open, the
+// reserved text/voice mode) and resolves it against the persisted store on
+// mount — everything else (turn content, stage ticker) is either store state
+// or the stream hook's ephemeral `turn`.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import { Header } from '@/app/Header'
+import { Pill } from '@/components/Pill'
+import { fromRaw, toRaw, type ChatMode, type ChatSearch } from './search'
+import { useChatStore, chatList } from './store'
+import { useChatHealth } from './queries'
+import { useChatStream } from './useChatStream'
+import { ChatSidebar } from './components/ChatSidebar'
+import { MessageThread } from './components/MessageThread'
+import { Composer } from './components/Composer'
+import { ExamplePrompts } from './components/ExamplePrompts'
+import { ToolBadge } from './components/ToolBadge'
+
+const routeApi = getRouteApi('/chat')
+const NO_MESSAGES: never[] = []
+
+export function ChatPage() {
+  const raw = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const search = useMemo(() => fromRaw(raw), [raw])
+
+  const chats = useChatStore((s) => s.chats)
+  const storeActiveId = useChatStore((s) => s.activeChatId)
+  const newChat = useChatStore((s) => s.newChat)
+  const setActive = useChatStore((s) => s.setActive)
+
+  /** Apply a search patch and push it into the URL. No key here cascades off
+   *  another (unlike Race/Lab), so a plain merge is enough — no
+   *  `applyChatPatch` needed. */
+  function patch(p: Partial<ChatSearch>) {
+    void navigate({ search: (prev) => toRaw({ ...fromRaw(prev), ...p }) })
+  }
+
+  // Resolve which chat id is active: the URL's `c` wins when it names a real
+  // chat, otherwise fall back to the store's last-active chat, otherwise start
+  // a fresh one — then reflect that choice back into the URL so the tab stays
+  // deep-linkable. Guarded by a ref keyed on `search.c` (NOT on `chats`, which
+  // changes on every appended message) so this only re-runs when the URL's
+  // chat id actually changes, never once per streamed token.
+  const resolvedForRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    const key = search.c ?? '__none__'
+    if (resolvedForRef.current === key) return
+    resolvedForRef.current = key
+
+    const { chats: liveChats, activeChatId: liveActiveId } = useChatStore.getState()
+    if (search.c && liveChats[search.c]) {
+      if (search.c !== liveActiveId) setActive(search.c)
+      return
+    }
+    const fallbackId = liveActiveId && liveChats[liveActiveId] ? liveActiveId : newChat()
+    void navigate({ search: (prev) => toRaw({ ...fromRaw(prev), c: fallbackId }) })
+  }, [search.c, navigate, newChat, setActive])
+
+  const activeChatId = search.c && chats[search.c] ? search.c : storeActiveId
+  const activeChat = activeChatId ? chats[activeChatId] : undefined
+  const messages = activeChat?.messages ?? NO_MESSAGES
+  const chatsList = useMemo(() => chatList(chats), [chats])
+
+  const { turn, isStreaming, send, stop } = useChatStream(activeChatId)
+  const [draft, setDraft] = useState(search.ask ?? '')
+
+  const health = useChatHealth()
+
+  function handleSend() {
+    if (!draft.trim()) return
+    send(draft)
+    setDraft('')
+  }
+
+  const streamingFooter =
+    turn && turn.status === 'streaming' ? (
+      <div className="flex items-center gap-2 px-1 py-2">
+        <span className="size-1.5 animate-pulse rounded-full bg-purple-400" aria-hidden="true" />
+        <span className="text-xs text-fg-3">{turn.stageLabel}</span>
+        {turn.toolBadge ? (
+          <ToolBadge toolName={turn.toolBadge.toolName} status={turn.toolBadge.status} />
+        ) : null}
+      </div>
+    ) : undefined
+
+  return (
+    <>
+      <Header title="Chat">
+        {health.data ? (
+          <Pill tone={health.data.lmStudioReachable ? 'success' : 'danger'}>
+            {health.data.lmStudioReachable ? 'LLM online' : 'LLM offline'}
+          </Pill>
+        ) : null}
+      </Header>
+
+      <div className="flex min-h-0 flex-1">
+        <ChatSidebar
+          chats={chatsList}
+          activeChatId={activeChatId}
+          mode={search.mode}
+          onSelectChat={(id) => patch({ c: id })}
+          onNewChat={() => patch({ c: newChat() })}
+          onModeChange={(mode: ChatMode) => patch({ mode })}
+        />
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          {messages.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center">
+              <ExamplePrompts onSelect={(prompt) => send(prompt)} />
+            </div>
+          ) : (
+            <MessageThread messages={messages} streamingFooter={streamingFooter} />
+          )}
+
+          <Composer
+            value={draft}
+            onChange={setDraft}
+            onSend={handleSend}
+            isStreaming={isStreaming}
+            onStop={stop}
+          />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/webapp/src/features/chat/components/ChatSidebar.tsx
+++ b/webapp/src/features/chat/components/ChatSidebar.tsx
@@ -1,0 +1,86 @@
+import { Plus } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { Tabs, TabsList, TabsTrigger } from '@/components/Tabs'
+import { cn } from '@/lib/cn'
+import type { ChatMode } from '../search'
+import type { ChatSession } from '../store'
+
+export interface ChatSidebarProps {
+  chats: ChatSession[]
+  activeChatId?: string
+  mode: ChatMode
+  onSelectChat: (id: string) => void
+  onNewChat: () => void
+  onModeChange: (mode: ChatMode) => void
+}
+
+/**
+ * Chat history rail: the new-chat action, the conversation list, and the
+ * text/voice mode toggle. Voice (#40) is reserved but disabled here — the
+ * toggle exists from day one so the seam is visible in the UI, not so it does
+ * anything yet. A reports panel belongs here too; it is built in C4, this
+ * sprint just leaves the space for it.
+ */
+export function ChatSidebar({
+  chats,
+  activeChatId,
+  mode,
+  onSelectChat,
+  onNewChat,
+  onModeChange,
+}: ChatSidebarProps) {
+  return (
+    <aside className="flex w-64 shrink-0 flex-col gap-3 border-r border-hairline bg-bg-1 p-3">
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={onNewChat}
+        className="justify-start gap-2 border border-hairline bg-bg-3"
+      >
+        <Plus className="size-4" aria-hidden="true" />
+        New chat
+      </Button>
+
+      <Tabs value={mode} onValueChange={(value) => onModeChange(value as ChatMode)}>
+        <TabsList variant="segmented" className="w-full">
+          <TabsTrigger value="text" className="flex-1 justify-center">
+            Text
+          </TabsTrigger>
+          <TabsTrigger
+            value="voice"
+            disabled
+            title="Voice chat is coming soon"
+            className="flex-1 justify-center"
+          >
+            Voice
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
+        {chats.length === 0 ? (
+          <p className="px-3 py-2 text-xs text-fg-4">No conversations yet.</p>
+        ) : (
+          chats.map((chat) => (
+            <button
+              key={chat.id}
+              type="button"
+              onClick={() => onSelectChat(chat.id)}
+              title={chat.title}
+              className={cn(
+                'truncate rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                chat.id === activeChatId
+                  ? 'bg-bg-4 text-fg-1'
+                  : 'text-fg-3 hover:bg-bg-3 hover:text-fg-2',
+              )}
+            >
+              {chat.title}
+            </button>
+          ))
+        )}
+      </div>
+
+      {/* TODO(C4): ReportsPanel — one-click report generation + history. */}
+    </aside>
+  )
+}

--- a/webapp/src/features/chat/components/Composer.tsx
+++ b/webapp/src/features/chat/components/Composer.tsx
@@ -21,7 +21,14 @@ export interface ComposerProps {
  * than disabling the whole composer, since the user can keep typing the next
  * message while the current reply finishes.
  */
-export function Composer({ value, onChange, onSend, isStreaming, onStop, disabled }: ComposerProps) {
+export function Composer({
+  value,
+  onChange,
+  onSend,
+  isStreaming,
+  onStop,
+  disabled,
+}: ComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   function autosize() {

--- a/webapp/src/features/chat/components/Composer.tsx
+++ b/webapp/src/features/chat/components/Composer.tsx
@@ -1,0 +1,85 @@
+import { useRef, type KeyboardEvent } from 'react'
+import { Paperclip, Send, Square } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { cn } from '@/lib/cn'
+
+const MAX_HEIGHT_PX = 160
+
+export interface ComposerProps {
+  value: string
+  onChange: (value: string) => void
+  onSend: () => void
+  isStreaming: boolean
+  onStop: () => void
+  disabled?: boolean
+}
+
+/**
+ * Autosizing single-line-to-multiline input. Enter sends, Shift+Enter inserts
+ * a newline (parity: `st.chat_input`'s Enter-to-send, `chat_input.py:31-34`).
+ * While a turn is streaming the Send button swaps for a Stop button rather
+ * than disabling the whole composer, since the user can keep typing the next
+ * message while the current reply finishes.
+ */
+export function Composer({ value, onChange, onSend, isStreaming, onStop, disabled }: ComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  function autosize() {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT_PX)}px`
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      if (value.trim()) onSend()
+    }
+  }
+
+  return (
+    <div className="flex items-end gap-2 border-t border-hairline bg-bg-1 p-3">
+      <button
+        type="button"
+        disabled
+        title="Attach an image (coming soon)"
+        // TODO(C4): wire FileDrop image attach here — client-side downscale to
+        // <=768px JPEG, and thread it through the `image` field / the
+        // `_last_user_image` port so it never rides the text history instead
+        // (see the wire-history discipline in lib/api/chat.ts).
+        className="flex size-9 shrink-0 items-center justify-center rounded-lg text-fg-4 opacity-50"
+      >
+        <Paperclip className="size-4" aria-hidden="true" />
+      </button>
+
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value)
+          autosize()
+        }}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        rows={1}
+        placeholder="Ask me anything about F1..."
+        className={cn(
+          'max-h-40 flex-1 resize-none rounded-xl border border-hairline bg-bg-2 px-3 py-2 text-sm text-fg-1',
+          'placeholder:text-fg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none',
+          disabled && 'opacity-50',
+        )}
+      />
+
+      {isStreaming ? (
+        <Button variant="danger" onClick={onStop} aria-label="Stop the response">
+          <Square className="size-4" aria-hidden="true" />
+        </Button>
+      ) : (
+        <Button onClick={onSend} disabled={disabled || !value.trim()} aria-label="Send message">
+          <Send className="size-4" aria-hidden="true" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/ExamplePrompts.tsx
+++ b/webapp/src/features/chat/components/ExamplePrompts.tsx
@@ -19,7 +19,11 @@ const EXAMPLE_PROMPTS: ExamplePrompt[] = [
     label: 'FIA regulation',
     prompt: 'What do articles 55 and 57 say about safety car procedures?',
   },
-  { Icon: Route, label: 'Full strategy', prompt: 'Full strategy for NOR lap 40 Australia risk 0.7' },
+  {
+    Icon: Route,
+    label: 'Full strategy',
+    prompt: 'Full strategy for NOR lap 40 Australia risk 0.7',
+  },
 ]
 
 export interface ExamplePromptsProps {
@@ -37,8 +41,8 @@ export function ExamplePrompts({ onSelect }: ExamplePromptsProps) {
       <p className="max-w-sm text-sm text-fg-3">
         Mention a <span className="font-medium text-fg-2">driver</span>,{' '}
         <span className="font-medium text-fg-2">GP</span>, and{' '}
-        <span className="font-medium text-fg-2">lap</span> to trigger an analysis, or try an
-        example below.
+        <span className="font-medium text-fg-2">lap</span> to trigger an analysis, or try an example
+        below.
       </p>
       <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
         {EXAMPLE_PROMPTS.map(({ Icon, label, prompt }) => (

--- a/webapp/src/features/chat/components/ExamplePrompts.tsx
+++ b/webapp/src/features/chat/components/ExamplePrompts.tsx
@@ -1,0 +1,66 @@
+import { CircleGauge, Disc3, Gavel, Route, type LucideIcon } from 'lucide-react'
+import { Card } from '@/components/Card'
+
+interface ExamplePrompt {
+  Icon: LucideIcon
+  label: string
+  prompt: string
+}
+
+// Byte-identical to the Streamlit example cards (`frontend/components/chatbot/
+// chat_history.py:199-224`) so a user moving between the old and new chat
+// sees the same four starting points, in the same 2x2 order (tyres, pace,
+// regs, strategy).
+const EXAMPLE_PROMPTS: ExamplePrompt[] = [
+  { Icon: Disc3, label: 'Tyre status', prompt: 'Tyre status for VER at lap 30 in Bahrain' },
+  { Icon: CircleGauge, label: 'Pace prediction', prompt: 'Predict pace for LEC lap 25 Monaco' },
+  {
+    Icon: Gavel,
+    label: 'FIA regulation',
+    prompt: 'What do articles 55 and 57 say about safety car procedures?',
+  },
+  { Icon: Route, label: 'Full strategy', prompt: 'Full strategy for NOR lap 40 Australia risk 0.7' },
+]
+
+export interface ExamplePromptsProps {
+  onSelect: (prompt: string) => void
+}
+
+/**
+ * The empty-chat starting point: a hint line plus four example prompts.
+ * Clicking one sends it immediately — the same behaviour as the Streamlit
+ * example cards (parity, `chat_history.py:229-236`), not just a prefill.
+ */
+export function ExamplePrompts({ onSelect }: ExamplePromptsProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
+      <p className="max-w-sm text-sm text-fg-3">
+        Mention a <span className="font-medium text-fg-2">driver</span>,{' '}
+        <span className="font-medium text-fg-2">GP</span>, and{' '}
+        <span className="font-medium text-fg-2">lap</span> to trigger an analysis, or try an
+        example below.
+      </p>
+      <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
+        {EXAMPLE_PROMPTS.map(({ Icon, label, prompt }) => (
+          <Card
+            key={label}
+            role="button"
+            tabIndex={0}
+            title={prompt}
+            onClick={() => onSelect(prompt)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                onSelect(prompt)
+              }
+            }}
+            className="flex cursor-pointer items-center gap-2 p-3 text-left transition-colors hover:bg-bg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none"
+          >
+            <Icon className="size-4 shrink-0 text-purple-300" aria-hidden="true" />
+            <span className="text-sm font-medium text-fg-1">{label}</span>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/MessageThread.tsx
+++ b/webapp/src/features/chat/components/MessageThread.tsx
@@ -92,7 +92,10 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 
   return (
     <div
-      className={cn('flex flex-col gap-1 [content-visibility:auto]', isUser ? 'items-end' : 'items-start')}
+      className={cn(
+        'flex flex-col gap-1 [content-visibility:auto]',
+        isUser ? 'items-end' : 'items-start',
+      )}
     >
       <div
         className={cn(

--- a/webapp/src/features/chat/components/MessageThread.tsx
+++ b/webapp/src/features/chat/components/MessageThread.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { ArrowDown } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { Markdown } from '@/components/Markdown'
+import { cn } from '@/lib/cn'
+import type { ChatMessage } from '../store'
+import { ToolResultCard } from './ToolResultCard'
+
+const BOTTOM_THRESHOLD_PX = 48
+
+export interface MessageThreadProps {
+  messages: ChatMessage[]
+  /** Trailing content rendered after the message list while a turn is in
+   *  flight — the stage line / tool badge the page composes from `turn`. Kept
+   *  as a prop rather than this component reading the stream hook itself, so
+   *  the thread only ever needs a message array + a slot. */
+  streamingFooter?: ReactNode
+}
+
+/**
+ * Scrolling message log: auto-follows new content while the reader is at the
+ * bottom, and offers a "Jump to latest" button instead of yanking the
+ * viewport when they have scrolled up to read an earlier turn.
+ */
+export function MessageThread({ messages, streamingFooter }: MessageThreadProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+
+  function handleScroll() {
+    const el = scrollRef.current
+    if (!el) return
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    setIsAtBottom(distanceFromBottom <= BOTTOM_THRESHOLD_PX)
+  }
+
+  function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior })
+  }
+
+  useEffect(() => {
+    if (isAtBottom) scrollToBottom('auto')
+    // Only a NEW message (or the footer appearing/disappearing) should trigger
+    // auto-follow. A streaming message's own content grows on every token —
+    // re-running this on every character would fight the reader's scroll
+    // position mid-turn far too often, so `messages.length` is the real
+    // dependency, not `messages` itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages.length, streamingFooter != null])
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+        className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-4"
+      >
+        {messages.map((message) => (
+          <MessageBubble key={message.id} message={message} />
+        ))}
+        {streamingFooter}
+      </div>
+
+      {!isAtBottom && (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => scrollToBottom()}
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 border border-hairline bg-bg-3 shadow-[var(--shadow-elev)]"
+        >
+          <ArrowDown className="size-3.5" aria-hidden="true" />
+          Jump to latest
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  if (message.type === 'tool_result' && message.toolResult) {
+    return <ToolResultCard toolResult={message.toolResult} />
+  }
+
+  const isUser = message.role === 'user'
+  const footnote = [message.model, message.tokens != null ? `${message.tokens} tok` : null]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div
+      className={cn('flex flex-col gap-1 [content-visibility:auto]', isUser ? 'items-end' : 'items-start')}
+    >
+      <div
+        className={cn(
+          'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm',
+          isUser ? 'bg-purple-600/90 text-fg-1' : 'border border-hairline bg-bg-3',
+        )}
+      >
+        {isUser ? (
+          <p className="text-pretty">{message.content}</p>
+        ) : (
+          <Markdown>{message.content}</Markdown>
+        )}
+      </div>
+      {!isUser && footnote ? (
+        <span className="px-1 font-mono text-[11px] text-fg-4">{footnote}</span>
+      ) : null}
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/ToolBadge.tsx
+++ b/webapp/src/features/chat/components/ToolBadge.tsx
@@ -1,0 +1,48 @@
+import { Wrench } from 'lucide-react'
+import { Pill } from '@/components/Pill'
+import { cn } from '@/lib/cn'
+
+export type ToolBadgeStatus = 'running' | 'done' | 'error'
+
+export interface ToolBadgeProps {
+  toolName: string
+  status: ToolBadgeStatus
+}
+
+const STATUS_TONE: Record<ToolBadgeStatus, 'purple' | 'success' | 'danger'> = {
+  running: 'purple',
+  done: 'success',
+  error: 'danger',
+}
+
+/** "predict_pace" -> "Predict pace". Tool names are already readable
+ *  snake_case; this borrows the same sentence-case rendering the stage-label
+ *  fallback uses (`../stageLabels.ts`) so a badge and its ticker line never
+ *  disagree in tone. */
+function humanize(toolName: string): string {
+  const words = toolName.split('_').join(' ')
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`
+}
+
+/**
+ * A small chip narrating which tool is running / just finished / just failed
+ * during a turn. Deliberately generic — one icon for every tool family — so a
+ * later sprint can specialise per-tool icons without changing this
+ * component's contract (`display_type` renderers already carry their own
+ * iconography once C2 lands).
+ */
+export function ToolBadge({ toolName, status }: ToolBadgeProps) {
+  return (
+    <Pill
+      tone={STATUS_TONE[status]}
+      className={cn(
+        'inline-flex items-center gap-1.5',
+        status === 'running' && 'motion-safe:animate-pulse',
+      )}
+    >
+      <Wrench className="size-3" aria-hidden="true" />
+      {humanize(toolName)}
+      <span className="sr-only"> ({status})</span>
+    </Pill>
+  )
+}

--- a/webapp/src/features/chat/components/ToolResultCard.tsx
+++ b/webapp/src/features/chat/components/ToolResultCard.tsx
@@ -1,0 +1,35 @@
+import { Card } from '@/components/Card'
+import { Pill } from '@/components/Pill'
+import type { ToolResult } from '@/lib/api/chat'
+
+export interface ToolResultCardProps {
+  toolResult: ToolResult
+}
+
+/**
+ * Placeholder tool-result renderer for the foundation sprint: every tool
+ * result lands as its natural-language summary plus a raw JSON disclosure, no
+ * matter which `display_type` the backend tagged it with. A later sprint
+ * replaces the body below with a switch over `display_type` (metrics /
+ * strategy_card / table / chart / text) that reuses the cards already built
+ * for Race and Lab (StatCard, Gauge, CompoundPill, ScenarioScoresChart, …) —
+ * this component's props and export stay the same, only the body changes.
+ */
+export function ToolResultCard({ toolResult }: ToolResultCardProps) {
+  return (
+    <Card className="flex flex-col gap-2 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-xs text-fg-3">{toolResult.tool_name}</span>
+        <Pill tone="neutral">{toolResult.display_type}</Pill>
+      </div>
+      {toolResult.summary ? <p className="text-sm text-fg-2">{toolResult.summary}</p> : null}
+      <details className="text-xs text-fg-3">
+        <summary className="cursor-pointer select-none">Raw data</summary>
+        <pre className="mt-2 overflow-auto rounded-lg bg-bg-2 p-2 font-mono">
+          {JSON.stringify(toolResult.data, null, 2)}
+        </pre>
+      </details>
+      {/* C2 replaces this with the display_type switch */}
+    </Card>
+  )
+}

--- a/webapp/src/features/chat/queries.ts
+++ b/webapp/src/features/chat/queries.ts
@@ -1,0 +1,57 @@
+// TanStack Query data layer for the Chat tab. Only the health check goes
+// through the generated OpenAPI client (`api.GET`, typed against schema.ts) —
+// the SSE turn itself (`sendChatTurn`, lib/api/chat.ts) is driven imperatively
+// by `useChatStream`, not as a query/mutation, since its "result" is a stream
+// of events rather than one response value.
+
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api/client'
+import { queryKeys } from '@/lib/queryKeys'
+
+export interface ChatHealth {
+  status: string
+  lmStudioReachable: boolean
+  message: string
+  modelsAvailable: number | null
+}
+
+function toChatHealth(raw: {
+  status: string
+  lm_studio_reachable: boolean
+  message: string
+  models_available?: number | null
+}): ChatHealth {
+  return {
+    status: raw.status,
+    lmStudioReachable: raw.lm_studio_reachable,
+    message: raw.message,
+    modelsAvailable: raw.models_available ?? null,
+  }
+}
+
+/**
+ * LLM-provider health for the header pill. A downed provider does not usually
+ * flip mid-session, so this polls lightly rather than on every keystroke; the
+ * composer stays usable either way (parity: `frontend/pages/chat.py:450-455`)
+ * — a red pill only sets expectations, it never blocks sending.
+ */
+export function useChatHealth() {
+  return useQuery({
+    queryKey: queryKeys.chat.health(),
+    queryFn: async (): Promise<ChatHealth> => {
+      // `/chat/health`'s generated schema documents only a 200 response (the
+      // handler's 500 path, `chat.py:54-56`, is a real runtime possibility the
+      // OpenAPI types do not model) — checking `response.ok` instead of the
+      // `error`/`data` pair avoids TypeScript narrowing this branch away as
+      // unreachable when the schema claims failure is impossible.
+      const { data, response } = await api.GET('/api/v1/chat/health')
+      if (!response.ok || !data) {
+        throw new Error(`Chat health check failed (${response.status})`)
+      }
+      return toChatHealth(data)
+    },
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  })
+}

--- a/webapp/src/features/chat/search.ts
+++ b/webapp/src/features/chat/search.ts
@@ -1,0 +1,68 @@
+// URL search-param contract for the Chat tab. `c` is the active chat id so a
+// link reproduces which conversation is open; `mode` reserves the text/voice
+// toggle for Voice (#40) — Chat only ever runs `text` today, but the sidebar
+// shows the toggle with Voice disabled so the seam exists from day one; `ask`
+// is a deep-link prefill (another tab handing the user off to the assistant
+// with a question already typed) that NEVER auto-fires, same grammar as
+// Race's `q` (features/race/search.ts:14-15, RegulationsPanel's
+// `initialQuestion`) — the composer is seeded with the text, the user still
+// presses Send.
+//
+// Unlike Race/Lab, none of these three keys cascade off each other, so there
+// is no `applyChatPatch` helper here — a plain object patch is enough.
+
+export const CHAT_MODES = ['text', 'voice'] as const
+export type ChatMode = (typeof CHAT_MODES)[number]
+const DEFAULT_MODE: ChatMode = 'text'
+
+/** Component-facing selection. */
+export interface ChatSearch {
+  c?: string
+  mode: ChatMode
+  ask?: string
+}
+
+/** URL / validated selection. */
+export interface RawChatSearch {
+  c?: string
+  mode?: ChatMode
+  ask?: string
+}
+
+function coerceStr(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined
+}
+
+function coerceMode(raw: unknown): ChatMode {
+  return CHAT_MODES.includes(raw as ChatMode) ? (raw as ChatMode) : DEFAULT_MODE
+}
+
+/** `validateSearch` for /chat: coerce the raw router search. */
+export function validateChatSearch(raw: Record<string, unknown>): RawChatSearch {
+  const c = coerceStr(raw.c)
+  const mode = coerceMode(raw.mode)
+  const ask = coerceStr(raw.ask)
+  return {
+    ...(c ? { c } : {}),
+    ...(mode !== DEFAULT_MODE ? { mode } : {}),
+    ...(ask ? { ask } : {}),
+  }
+}
+
+/** URL shape → component shape. */
+export function fromRaw(raw: RawChatSearch): ChatSearch {
+  return {
+    c: raw.c,
+    mode: coerceMode(raw.mode),
+    ask: raw.ask,
+  }
+}
+
+/** Component shape → URL shape (empty fields + the default mode dropped). */
+export function toRaw(search: ChatSearch): RawChatSearch {
+  return {
+    ...(search.c ? { c: search.c } : {}),
+    ...(search.mode !== DEFAULT_MODE ? { mode: search.mode } : {}),
+    ...(search.ask ? { ask: search.ask } : {}),
+  }
+}

--- a/webapp/src/features/chat/stageLabels.ts
+++ b/webapp/src/features/chat/stageLabels.ts
@@ -1,0 +1,52 @@
+// Re-keyed stage-label map for the chat SSE ticker (design-audit #39, finding
+// 4.2). Streamlit's `_STAGE_LABELS` (frontend/pages/chat.py:33-52) has drifted
+// from what `chat_engine.stream_response` actually emits: it carries three
+// dead keys from the retired regex router (`extracting_intent`,
+// `classifying_query`, `loading_models`), two wrong tool names
+// (`calling_list_gps` / `calling_list_drivers` instead of the real dispatched
+// `calling_list_available_gps` / `calling_list_available_drivers`), and is
+// missing three real stages (`preparing_tools`, `model_choosing_tool`,
+// `composing_response`). This map is keyed against the ACTUAL emissions
+// (`chat_engine.py:173-333`) instead of copied verbatim.
+
+const STAGE_LABELS: Record<string, string> = {
+  preparing_tools: 'Preparing tools…',
+  model_choosing_tool: 'Choosing the right tool…',
+  composing_response: 'Composing the response…',
+  summarizing_with_llm: 'Summarizing the result…',
+  calling_predict_pace: 'Predicting lap pace…',
+  calling_predict_tire: 'Predicting tire degradation…',
+  calling_predict_situation: 'Predicting overtake / safety car risk…',
+  calling_predict_pit: 'Predicting the pit stop…',
+  calling_analyze_radio: 'Analyzing team radio…',
+  calling_query_regulations: 'Searching FIA regulations…',
+  calling_recommend_strategy: 'Running the full strategy council…',
+  calling_list_available_gps: 'Listing available Grand Prix…',
+  calling_list_available_drivers: 'Listing available drivers…',
+  calling_get_lap_range: 'Checking the lap range…',
+  calling_compare_drivers: 'Comparing drivers…',
+  calling_get_lap_times: 'Fetching lap times…',
+  calling_get_telemetry: 'Fetching telemetry…',
+  calling_get_race_data: 'Fetching race data…',
+}
+
+const CALLING_PREFIX = 'calling_'
+
+/** The tool name a `calling_<name>` stage names, or undefined for any other
+ *  stage. Shared by the label lookup below and the reducer's tool-badge
+ *  derivation (`useChatStream.ts`), so both agree on how a stage names its
+ *  tool. */
+export function toolNameFromStage(stage: string): string | undefined {
+  return stage.startsWith(CALLING_PREFIX) ? stage.slice(CALLING_PREFIX.length) : undefined
+}
+
+/** Human label for a backend stage name. Falls back to a sentence-cased
+ *  rendering of the raw stage (still stripping the `calling_` prefix) for any
+ *  stage this map does not know about yet, so a newly added tool never shows a
+ *  raw snake_case string in the ticker. */
+export function stageLabel(stage: string): string {
+  const known = STAGE_LABELS[stage]
+  if (known) return known
+  const words = (toolNameFromStage(stage) ?? stage).split('_').join(' ')
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}…`
+}

--- a/webapp/src/features/chat/store.ts
+++ b/webapp/src/features/chat/store.ts
@@ -1,0 +1,177 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { ToolResult } from '@/lib/api/chat'
+
+// Persisted chat store: id-keyed chats (not name-keyed) so two conversations
+// that happen to start with the same words never silently overwrite each
+// other — a real bug in the Streamlit chat, which keys saved chats by an
+// auto-generated NAME (design-audit #39 finding 4.8, `frontend/utils/
+// chat_state.py:159-197`). `useChatStream` (the SSE reducer) is the only
+// writer of message content; this module only shapes what gets stored and how
+// it is looked up.
+
+export type ChatMessageRole = 'user' | 'assistant'
+export type ChatMessageType = 'text' | 'tool_result'
+
+export interface ChatMessage {
+  id: string
+  role: ChatMessageRole
+  type: ChatMessageType
+  content: string
+  toolResult?: ToolResult
+  /** Set once the turn's `done` event lands — only ever present on the
+   *  streaming assistant text message, never on a tool_result message. */
+  model?: string
+  tokens?: number
+  ts: number
+}
+
+export interface ChatSession {
+  id: string
+  title: string
+  messages: ChatMessage[]
+  createdAt: number
+}
+
+export interface ChatReport {
+  id: string
+  chatId: string
+  title: string
+  content: string
+  createdAt: number
+}
+
+const REPORT_CAP = 20
+const TITLE_MAX_CHARS = 30
+const PLACEHOLDER_TITLE = 'New chat'
+
+/** First 30 chars of the user's opening message, with an ellipsis if it was
+ *  longer — the exact rule Streamlit uses to name a saved chat
+ *  (`chat_state.py:176-180`), so titles read the same across both UIs. */
+function autoTitle(userText: string): string {
+  const trimmed = userText.trim()
+  return trimmed.length > TITLE_MAX_CHARS ? `${trimmed.slice(0, TITLE_MAX_CHARS)}...` : trimmed
+}
+
+/** Patch applied to a message as a turn streams: `delta` appends to `content`
+ *  (the normal per-token case); `model`/`tokens` land once, from the turn's
+ *  `done` event. All three may arrive together only for a single-token turn
+ *  (no B2 streaming) — never mutually exclusive by design. */
+export interface StreamingPatch {
+  delta?: string
+  model?: string
+  tokens?: number
+}
+
+interface ChatState {
+  chats: Record<string, ChatSession>
+  activeChatId?: string
+  reports: ChatReport[]
+  /** Create a fresh, empty chat, make it active, and return its id. */
+  newChat: () => string
+  setActive: (id: string) => void
+  /** Append a fully-formed message (the optimistic user bubble, a tool_result
+   *  card, or the first token of a new assistant reply). Also auto-titles the
+   *  chat from the FIRST user text message while it still carries the
+   *  placeholder title. */
+  appendMessage: (chatId: string, message: ChatMessage) => void
+  /** Apply a streaming patch to an already-appended message — the token-by-
+   *  token content growth, plus the final model/tokens footnote. */
+  updateStreaming: (chatId: string, messageId: string, patch: StreamingPatch) => void
+  renameChat: (chatId: string, title: string) => void
+  deleteChat: (chatId: string) => void
+  addReport: (report: ChatReport) => void
+}
+
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set) => ({
+      chats: {},
+      activeChatId: undefined,
+      reports: [],
+
+      newChat: () => {
+        const id = crypto.randomUUID()
+        const chat: ChatSession = {
+          id,
+          title: PLACEHOLDER_TITLE,
+          messages: [],
+          createdAt: Date.now(),
+        }
+        set((s) => ({ chats: { ...s.chats, [id]: chat }, activeChatId: id }))
+        return id
+      },
+
+      setActive: (id) => set({ activeChatId: id }),
+
+      appendMessage: (chatId, message) =>
+        set((s) => {
+          const chat = s.chats[chatId]
+          if (!chat) return s
+          const messages = [...chat.messages, message]
+          const title =
+            chat.title === PLACEHOLDER_TITLE && message.role === 'user' && message.type === 'text'
+              ? autoTitle(message.content)
+              : chat.title
+          return { chats: { ...s.chats, [chatId]: { ...chat, messages, title } } }
+        }),
+
+      updateStreaming: (chatId, messageId, patch) =>
+        set((s) => {
+          const chat = s.chats[chatId]
+          if (!chat) return s
+          const messages = chat.messages.map((m) =>
+            m.id === messageId
+              ? {
+                  ...m,
+                  content: patch.delta != null ? m.content + patch.delta : m.content,
+                  model: patch.model ?? m.model,
+                  tokens: patch.tokens ?? m.tokens,
+                }
+              : m,
+          )
+          return { chats: { ...s.chats, [chatId]: { ...chat, messages } } }
+        }),
+
+      renameChat: (chatId, title) =>
+        set((s) => {
+          const chat = s.chats[chatId]
+          if (!chat) return s
+          return { chats: { ...s.chats, [chatId]: { ...chat, title } } }
+        }),
+
+      deleteChat: (chatId) =>
+        set((s) => {
+          const rest = { ...s.chats }
+          delete rest[chatId]
+          const activeChatId = s.activeChatId === chatId ? undefined : s.activeChatId
+          return { chats: rest, activeChatId }
+        }),
+
+      addReport: (report) => set((s) => ({ reports: [report, ...s.reports].slice(0, REPORT_CAP) })),
+    }),
+    {
+      name: 'f1sl.chat',
+      // TODO(C4): swap to an idb-keyval storage adapter once image attachments
+      // land — a data-URI image (~100-250 kB) risks blowing the ~5 MB
+      // localStorage quota across many saved chats. Text-only chats are fine
+      // on the default adapter.
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ chats: s.chats, activeChatId: s.activeChatId, reports: s.reports }),
+    },
+  ),
+)
+
+/** The last-activity timestamp for a chat: its newest message, or its creation
+ *  time for a chat with none yet. */
+function lastActivity(chat: ChatSession): number {
+  return chat.messages.length > 0 ? chat.messages[chat.messages.length - 1].ts : chat.createdAt
+}
+
+/** Ordered chat list for the sidebar, most recently active first. Pure over
+ *  the chats record (not a zustand selector) so callers memoize it themselves
+ *  — same pattern as `runsForModel` in the Lab store: sorting inside a
+ *  selector returns a fresh array every call and loops the render. */
+export function chatList(chats: Record<string, ChatSession>): ChatSession[] {
+  return Object.values(chats).sort((a, b) => lastActivity(b) - lastActivity(a))
+}

--- a/webapp/src/features/chat/useChatStream.test.ts
+++ b/webapp/src/features/chat/useChatStream.test.ts
@@ -110,7 +110,10 @@ describe('applyStreamEvent', () => {
   })
 
   it('re-keys an unknown stage to a sentence-cased fallback instead of raw snake_case', () => {
-    const turn = applyStreamEvent(createActiveTurn(), { event: 'stage', stage: 'calling_a_future_tool' })
+    const turn = applyStreamEvent(createActiveTurn(), {
+      event: 'stage',
+      stage: 'calling_a_future_tool',
+    })
     expect(turn.stageLabel).toBe('A future tool…')
   })
 })

--- a/webapp/src/features/chat/useChatStream.test.ts
+++ b/webapp/src/features/chat/useChatStream.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatStreamEvent } from '@/lib/api/chat'
+import { applyStreamEvent, createActiveTurn, isEmptyTurn, markStopped } from './useChatStream'
+
+// Captured-SSE fixtures: each `events` array is the exact (event, payload)
+// sequence `chat_engine.stream_response` yields for that branch
+// (design-audit #39 §3.2), already parsed into `ChatStreamEvent`s — the frame
+// PARSING itself is covered by `lib/api/chat.test.ts`. This file is the
+// regression test for the reducer's understanding of the wire contract.
+
+function reduceAll(events: ChatStreamEvent[]) {
+  return events.reduce(applyStreamEvent, createActiveTurn())
+}
+
+describe('applyStreamEvent', () => {
+  it('folds a full tool-call turn: stage(s) -> tool_result -> token(s) -> done', () => {
+    const events: ChatStreamEvent[] = [
+      { event: 'stage', stage: 'preparing_tools' },
+      { event: 'stage', stage: 'model_choosing_tool' },
+      { event: 'stage', stage: 'calling_predict_pace' },
+      {
+        event: 'tool_result',
+        toolResult: {
+          tool_name: 'predict_pace',
+          display_type: 'metrics',
+          data: { lap_time_pred: 91.2 },
+          summary: 'Pace holds around 91.2s.',
+        },
+      },
+      { event: 'stage', stage: 'summarizing_with_llm' },
+      { event: 'token', token: 'Looking ' },
+      { event: 'token', token: 'strong.' },
+      { event: 'done', llmModel: 'gpt-4.1-mini', tokensUsed: 128 },
+    ]
+
+    const turn = reduceAll(events)
+
+    expect(turn.status).toBe('done')
+    expect(turn.toolBadge).toEqual({ toolName: 'predict_pace', status: 'done' })
+    expect(turn.toolResultMessage?.toolResult?.tool_name).toBe('predict_pace')
+    expect(turn.toolResultMessage?.content).toBe('Pace holds around 91.2s.')
+    expect(turn.assistantMessage?.content).toBe('Looking strong.')
+    expect(turn.assistantMessage?.model).toBe('gpt-4.1-mini')
+    expect(turn.assistantMessage?.tokens).toBe(128)
+  })
+
+  it('folds the no-tool shortcut: stage(composing_response) -> token -> done', () => {
+    const events: ChatStreamEvent[] = [
+      { event: 'stage', stage: 'preparing_tools' },
+      { event: 'stage', stage: 'model_choosing_tool' },
+      { event: 'stage', stage: 'composing_response' },
+      { event: 'token', token: 'Hello! How can I help?' },
+      { event: 'done' },
+    ]
+
+    const turn = reduceAll(events)
+
+    expect(turn.status).toBe('done')
+    expect(turn.toolBadge).toBeUndefined()
+    expect(turn.toolResultMessage).toBeUndefined()
+    expect(turn.assistantMessage?.content).toBe('Hello! How can I help?')
+    expect(turn.stageLabel).toBe('Composing the response…')
+  })
+
+  it('folds a refused (non-allowlisted) tool call the same way as a plain reply', () => {
+    const events: ChatStreamEvent[] = [
+      { event: 'stage', stage: 'model_choosing_tool' },
+      { event: 'stage', stage: 'composing_response' },
+      { event: 'token', token: '_The `mutate_data` tool is not available in this chat._' },
+      { event: 'done' },
+    ]
+
+    const turn = reduceAll(events)
+
+    expect(turn.status).toBe('done')
+    expect(turn.assistantMessage?.content).toContain('not available in this chat')
+  })
+
+  it('marks the turn as error when the endpoint error envelope arrives', () => {
+    const events: ChatStreamEvent[] = [
+      { event: 'stage', stage: 'calling_get_race_data' },
+      { event: 'token', token: '\n\nError: backend exploded' },
+      { event: 'done', error: 'backend exploded' },
+    ]
+
+    const turn = reduceAll(events)
+
+    expect(turn.status).toBe('error')
+    expect(turn.error).toBe('backend exploded')
+    expect(turn.assistantMessage?.content).toContain('backend exploded')
+  })
+
+  it('marks the tool badge as errored when the tool_result payload carries an error', () => {
+    const events: ChatStreamEvent[] = [
+      { event: 'stage', stage: 'calling_predict_tire' },
+      {
+        event: 'tool_result',
+        toolResult: {
+          tool_name: 'predict_tire',
+          display_type: 'text',
+          data: { error: 'lap 1 has no data' },
+          summary: 'lap 1 has no data',
+        },
+      },
+    ]
+
+    const turn = reduceAll(events)
+
+    expect(turn.toolBadge).toEqual({ toolName: 'predict_tire', status: 'error' })
+  })
+
+  it('re-keys an unknown stage to a sentence-cased fallback instead of raw snake_case', () => {
+    const turn = applyStreamEvent(createActiveTurn(), { event: 'stage', stage: 'calling_a_future_tool' })
+    expect(turn.stageLabel).toBe('A future tool…')
+  })
+})
+
+describe('isEmptyTurn / markStopped', () => {
+  it('flags a fresh turn (no tool result, no assistant text) as empty', () => {
+    expect(isEmptyTurn(createActiveTurn())).toBe(true)
+  })
+
+  it('does not flag a turn that produced only a tool result as empty', () => {
+    const turn = applyStreamEvent(createActiveTurn(), {
+      event: 'tool_result',
+      toolResult: { tool_name: 'list_available_gps', display_type: 'text', data: {}, summary: 'x' },
+    })
+    expect(isEmptyTurn(turn)).toBe(false)
+  })
+
+  it('does not flag a turn that produced only assistant text as empty', () => {
+    const turn = applyStreamEvent(createActiveTurn(), { event: 'token', token: 'hi' })
+    expect(isEmptyTurn(turn)).toBe(false)
+  })
+
+  it('appends the verbatim stopped marker to whatever text had already streamed', () => {
+    const turn = applyStreamEvent(createActiveTurn(), { event: 'token', token: 'Partial answer' })
+    const stopped = markStopped(turn)
+    expect(stopped.assistantMessage?.content).toBe('Partial answer\n\n_[Response stopped by user]_')
+    expect(stopped.status).toBe('done')
+  })
+
+  it('starts a message that is JUST the marker when nothing had streamed yet', () => {
+    const stopped = markStopped(createActiveTurn())
+    expect(stopped.assistantMessage?.content).toBe('\n\n_[Response stopped by user]_')
+  })
+})

--- a/webapp/src/features/chat/useChatStream.ts
+++ b/webapp/src/features/chat/useChatStream.ts
@@ -99,7 +99,12 @@ export function applyStreamEvent(turn: ActiveTurn, event: ChatStreamEvent): Acti
       const assistantMessage = turn.assistantMessage
         ? { ...turn.assistantMessage, model: event.llmModel, tokens: event.tokensUsed }
         : turn.assistantMessage
-      return { ...turn, status: event.error ? 'error' : 'done', error: event.error, assistantMessage }
+      return {
+        ...turn,
+        status: event.error ? 'error' : 'done',
+        error: event.error,
+        assistantMessage,
+      }
     }
   }
 }
@@ -115,13 +120,20 @@ const EMPTY_STREAM_NOTICE =
  *  token had landed yet. */
 export function markStopped(turn: ActiveTurn): ActiveTurn {
   const base = turn.assistantMessage ?? newAssistantMessage()
-  return { ...turn, status: 'done', assistantMessage: { ...base, content: base.content + STOPPED_MARKER } }
+  return {
+    ...turn,
+    status: 'done',
+    assistantMessage: { ...base, content: base.content + STOPPED_MARKER },
+  }
 }
 
 /** True once a turn produced NEITHER a tool result NOR any assistant text — a
  *  200 OK with a silently empty SSE stream (parity: `chat.py:358-363`). */
 export function isEmptyTurn(turn: ActiveTurn): boolean {
-  return !turn.toolResultMessage && (!turn.assistantMessage || turn.assistantMessage.content.trim() === '')
+  return (
+    !turn.toolResultMessage &&
+    (!turn.assistantMessage || turn.assistantMessage.content.trim() === '')
+  )
 }
 
 // ── The hook ─────────────────────────────────────────────────────────────

--- a/webapp/src/features/chat/useChatStream.ts
+++ b/webapp/src/features/chat/useChatStream.ts
@@ -1,0 +1,266 @@
+import { useCallback, useRef, useState } from 'react'
+import { SseError } from '@/lib/api/sse'
+import {
+  buildWireHistory,
+  sendChatTurn,
+  type ChatStreamEvent,
+  type ToolMessageRequestBody,
+  type ToolResult,
+} from '@/lib/api/chat'
+import { useToast } from '@/components/Toast'
+import { stageLabel, toolNameFromStage } from './stageLabels'
+import { useChatStore, type ChatMessage } from './store'
+
+// The SSE-turn reducer. Split in two layers on purpose:
+//   - `applyStreamEvent` (+ `markStopped` / `isEmptyTurn`) is a PURE fold over
+//     one turn's events into an `ActiveTurn` — no network, no store, no React.
+//     This is what `useChatStream.test.ts` exercises with captured event
+//     sequences (stage -> tool_result -> token -> done, no-tool, refused-tool,
+//     error-envelope): the regression test for the wire contract lives here.
+//   - `useChatStream` is the thin React/side-effect shell: it drives
+//     `sendChatTurn`, mirrors `applyStreamEvent`'s ticker state into a
+//     `useState` for the UI, and commits the DURABLE parts (the tool-result
+//     card, the streaming assistant text) into the persisted chat store as
+//     they land, so a reload never loses a turn that was mid-flight.
+
+export interface ToolBadgeState {
+  toolName: string
+  status: 'running' | 'done' | 'error'
+}
+
+export type ActiveTurnStatus = 'streaming' | 'done' | 'error'
+
+/** Everything known about the turn currently in flight (or just finished).
+ *  `assistantMessage`/`toolResultMessage` here are DRAFTS the reducer builds
+ *  as events arrive — the hook is what actually appends/updates them in the
+ *  persisted store, keyed off the same object identity. */
+export interface ActiveTurn {
+  status: ActiveTurnStatus
+  stage?: string
+  stageLabel: string
+  toolBadge?: ToolBadgeState
+  toolResultMessage?: ChatMessage
+  assistantMessage?: ChatMessage
+  error?: string
+}
+
+export function createActiveTurn(): ActiveTurn {
+  return { status: 'streaming', stageLabel: 'Starting…' }
+}
+
+function newAssistantMessage(content = ''): ChatMessage {
+  return { id: crypto.randomUUID(), role: 'assistant', type: 'text', content, ts: Date.now() }
+}
+
+function newToolResultMessage(toolResult: ToolResult): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    type: 'tool_result',
+    content: toolResult.summary,
+    toolResult,
+    ts: Date.now(),
+  }
+}
+
+/**
+ * Fold one parsed SSE event into the in-flight turn. Pure and exported so the
+ * captured-SSE fixtures in `useChatStream.test.ts` exercise it directly.
+ */
+export function applyStreamEvent(turn: ActiveTurn, event: ChatStreamEvent): ActiveTurn {
+  switch (event.event) {
+    case 'stage': {
+      const toolName = toolNameFromStage(event.stage)
+      return {
+        ...turn,
+        stage: event.stage,
+        stageLabel: stageLabel(event.stage),
+        toolBadge: toolName ? { toolName, status: 'running' } : turn.toolBadge,
+      }
+    }
+    case 'tool_result': {
+      const hasError = 'error' in event.toolResult.data
+      return {
+        ...turn,
+        toolResultMessage: newToolResultMessage(event.toolResult),
+        toolBadge: turn.toolBadge
+          ? { ...turn.toolBadge, status: hasError ? 'error' : 'done' }
+          : turn.toolBadge,
+      }
+    }
+    case 'token': {
+      const assistantMessage = turn.assistantMessage ?? newAssistantMessage()
+      return {
+        ...turn,
+        assistantMessage: { ...assistantMessage, content: assistantMessage.content + event.token },
+      }
+    }
+    case 'done': {
+      const assistantMessage = turn.assistantMessage
+        ? { ...turn.assistantMessage, model: event.llmModel, tokens: event.tokensUsed }
+        : turn.assistantMessage
+      return { ...turn, status: event.error ? 'error' : 'done', error: event.error, assistantMessage }
+    }
+  }
+}
+
+const STOPPED_MARKER = '\n\n_[Response stopped by user]_'
+const EMPTY_STREAM_NOTICE =
+  '_(No response received from the backend. Check the docker logs for the ' +
+  'chat container — the request returned 200 but the SSE stream was empty.)_'
+
+/** Finalize a turn the user aborted mid-stream: append the verbatim "stopped"
+ *  marker Streamlit uses (`frontend/pages/chat.py:350`) to whatever text had
+ *  already arrived, or start a fresh message that is just the marker if no
+ *  token had landed yet. */
+export function markStopped(turn: ActiveTurn): ActiveTurn {
+  const base = turn.assistantMessage ?? newAssistantMessage()
+  return { ...turn, status: 'done', assistantMessage: { ...base, content: base.content + STOPPED_MARKER } }
+}
+
+/** True once a turn produced NEITHER a tool result NOR any assistant text — a
+ *  200 OK with a silently empty SSE stream (parity: `chat.py:358-363`). */
+export function isEmptyTurn(turn: ActiveTurn): boolean {
+  return !turn.toolResultMessage && (!turn.assistantMessage || turn.assistantMessage.content.trim() === '')
+}
+
+// ── The hook ─────────────────────────────────────────────────────────────
+
+export interface UseChatStreamResult {
+  /** The turn in flight, or the last finished one; null before the chat's
+   *  first message. Drives the ticker (stage label + tool badge) — message
+   *  CONTENT itself lives in the store and needs no separate draft to render. */
+  turn: ActiveTurn | null
+  isStreaming: boolean
+  send: (text: string) => void
+  stop: () => void
+}
+
+/**
+ * Drive one chat's SSE turns: appends the optimistic user message, builds the
+ * wire request from the store's own history, streams it through
+ * `sendChatTurn`, and folds every event through `applyStreamEvent` —
+ * committing each durable piece (the tool-result card, the growing assistant
+ * reply) into the persisted store as it lands.
+ */
+export function useChatStream(chatId: string | undefined): UseChatStreamResult {
+  const [turn, setTurn] = useState<ActiveTurn | null>(null)
+  const turnRef = useRef<ActiveTurn>(createActiveTurn())
+  const assistantMessageIdRef = useRef<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const { toast } = useToast()
+
+  const appendMessage = useChatStore((s) => s.appendMessage)
+  const updateStreaming = useChatStore((s) => s.updateStreaming)
+
+  /** Append the assistant text message on its first chunk, or append a further
+   *  delta once it already exists in the store — the one place that decides
+   *  "create vs update" so normal streaming, the Stop marker, and the
+   *  empty-stream fallback all go through the same path. */
+  const commitAssistantDelta = useCallback(
+    (delta: string) => {
+      if (!chatId) return
+      if (assistantMessageIdRef.current == null) {
+        const message = newAssistantMessage(delta)
+        assistantMessageIdRef.current = message.id
+        appendMessage(chatId, message)
+      } else {
+        updateStreaming(chatId, assistantMessageIdRef.current, { delta })
+      }
+    },
+    [chatId, appendMessage, updateStreaming],
+  )
+
+  const handleEvent = useCallback(
+    (event: ChatStreamEvent) => {
+      turnRef.current = applyStreamEvent(turnRef.current, event)
+      setTurn(turnRef.current)
+
+      if (event.event === 'tool_result' && chatId && turnRef.current.toolResultMessage) {
+        appendMessage(chatId, turnRef.current.toolResultMessage)
+      }
+      if (event.event === 'token') {
+        commitAssistantDelta(event.token)
+      }
+      if (event.event === 'done' && chatId && assistantMessageIdRef.current) {
+        updateStreaming(chatId, assistantMessageIdRef.current, {
+          model: event.llmModel,
+          tokens: event.tokensUsed,
+        })
+      }
+    },
+    [chatId, appendMessage, updateStreaming, commitAssistantDelta],
+  )
+
+  /** Resolve the turn once `sendChatTurn`'s promise settles successfully — a
+   *  natural finish (a `done` event already set `status`) or a user-initiated
+   *  Stop (the promise resolves without one, since `postStream` swallows an
+   *  abort rather than rejecting). */
+  const finishTurn = useCallback(
+    (aborted: boolean) => {
+      if (aborted && turnRef.current.status === 'streaming') {
+        turnRef.current = { ...turnRef.current, status: 'done' }
+        commitAssistantDelta(STOPPED_MARKER)
+      } else if (turnRef.current.status !== 'error' && isEmptyTurn(turnRef.current)) {
+        turnRef.current = { ...turnRef.current, status: 'error' }
+        commitAssistantDelta(EMPTY_STREAM_NOTICE)
+      }
+      setTurn(turnRef.current)
+      abortRef.current = null
+    },
+    [commitAssistantDelta],
+  )
+
+  const send = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed || !chatId || turn?.status === 'streaming') return
+
+      const priorMessages = useChatStore.getState().chats[chatId]?.messages ?? []
+      appendMessage(chatId, {
+        id: crypto.randomUUID(),
+        role: 'user',
+        type: 'text',
+        content: trimmed,
+        ts: Date.now(),
+      })
+
+      turnRef.current = createActiveTurn()
+      assistantMessageIdRef.current = null
+      setTurn(turnRef.current)
+
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      const body: ToolMessageRequestBody = {
+        text: trimmed,
+        chat_history: buildWireHistory(priorMessages),
+      }
+
+      sendChatTurn(body, { onEvent: handleEvent, signal: controller.signal })
+        .then(() => finishTurn(controller.signal.aborted))
+        .catch((error: unknown) => {
+          turnRef.current = { ...turnRef.current, status: 'error' }
+          setTurn(turnRef.current)
+          abortRef.current = null
+          const rateLimited = error instanceof SseError && error.status === 429
+          toast({
+            title: rateLimited ? 'Rate limit reached' : 'Chat request failed',
+            description: rateLimited
+              ? 'Chat is limited to 20 requests/min. Wait a moment and try again.'
+              : error instanceof Error
+                ? error.message
+                : 'Could not reach the backend.',
+            tone: 'danger',
+          })
+        })
+    },
+    [chatId, turn?.status, appendMessage, handleEvent, finishTurn, toast],
+  )
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort()
+  }, [])
+
+  return { turn, isStreaming: turn?.status === 'streaming', send, stop }
+}

--- a/webapp/src/lib/api/chat.test.ts
+++ b/webapp/src/lib/api/chat.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { sendChatTurn, buildWireHistory, type ChatStreamEvent, type HistorySourceMessage } from './chat'
+import {
+  sendChatTurn,
+  buildWireHistory,
+  type ChatStreamEvent,
+  type HistorySourceMessage,
+} from './chat'
 
 // Captured-SSE fixtures: real wire text (not pre-parsed JS objects), so this
 // also exercises `parseChatFrame` (module-private) end to end through
@@ -60,7 +65,9 @@ describe('sendChatTurn', () => {
     const events: ChatStreamEvent[] = []
     await sendChatTurn({ text: 'hi' }, { onEvent: (e) => events.push(e) })
 
-    expect(events).toEqual([{ event: 'done', llmModel: undefined, tokensUsed: undefined, error: undefined }])
+    expect(events).toEqual([
+      { event: 'done', llmModel: undefined, tokensUsed: undefined, error: undefined },
+    ])
   })
 
   it('always asks the backend for real token streaming by default', async () => {

--- a/webapp/src/lib/api/chat.test.ts
+++ b/webapp/src/lib/api/chat.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { sendChatTurn, buildWireHistory, type ChatStreamEvent, type HistorySourceMessage } from './chat'
+
+// Captured-SSE fixtures: real wire text (not pre-parsed JS objects), so this
+// also exercises `parseChatFrame` (module-private) end to end through
+// `sendChatTurn`. `useChatStream.test.ts` covers the reducer that consumes the
+// already-parsed `ChatStreamEvent`s these tests produce.
+
+function sseResponse(rawFrames: string): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(rawFrames))
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('sendChatTurn', () => {
+  it('parses a full tool-call turn into typed events, in order', async () => {
+    const frames = [
+      'event: stage\ndata: {"stage":"preparing_tools"}\n\n',
+      'event: stage\ndata: {"stage":"calling_predict_pace"}\n\n',
+      'event: tool_result\ndata: {"tool_result":{"tool_name":"predict_pace","display_type":"metrics","data":{"lap_time_pred":91.2},"summary":"Pace holds."}}\n\n',
+      'event: token\ndata: {"token":"Looking strong."}\n\n',
+      'event: done\ndata: {"llm_model":"gpt-4.1-mini","tokens_used":128}\n\n',
+    ].join('')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(frames)))
+
+    const events: ChatStreamEvent[] = []
+    await sendChatTurn({ text: 'predict pace' }, { onEvent: (e) => events.push(e) })
+
+    expect(events).toEqual([
+      { event: 'stage', stage: 'preparing_tools' },
+      { event: 'stage', stage: 'calling_predict_pace' },
+      {
+        event: 'tool_result',
+        toolResult: {
+          tool_name: 'predict_pace',
+          display_type: 'metrics',
+          data: { lap_time_pred: 91.2 },
+          summary: 'Pace holds.',
+        },
+      },
+      { event: 'token', token: 'Looking strong.' },
+      { event: 'done', llmModel: 'gpt-4.1-mini', tokensUsed: 128, error: undefined },
+    ])
+  })
+
+  it('drops an unrecognised event name instead of throwing', async () => {
+    const frames = [
+      'event: legacy_stage\ndata: {"stage":"extracting_intent"}\n\n',
+      'event: done\ndata: {}\n\n',
+    ].join('')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse(frames)))
+
+    const events: ChatStreamEvent[] = []
+    await sendChatTurn({ text: 'hi' }, { onEvent: (e) => events.push(e) })
+
+    expect(events).toEqual([{ event: 'done', llmModel: undefined, tokensUsed: undefined, error: undefined }])
+  })
+
+  it('always asks the backend for real token streaming by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse('event: done\ndata: {}\n\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await sendChatTurn({ text: 'hi' }, { onEvent: () => {} })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.stream_tokens).toBe(true)
+  })
+
+  it('lets an explicit stream_tokens override the default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse('event: done\ndata: {}\n\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await sendChatTurn({ text: 'hi', stream_tokens: false }, { onEvent: () => {} })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string).stream_tokens).toBe(false)
+  })
+})
+
+describe('buildWireHistory', () => {
+  const textMessage = (i: number): HistorySourceMessage => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    type: 'text',
+    content: `msg ${i}`,
+  })
+
+  it('drops tool_result entries and caps the message count at 40', () => {
+    const messages: HistorySourceMessage[] = Array.from({ length: 45 }, (_, i) => textMessage(i))
+    messages.push({ role: 'assistant', type: 'tool_result', content: 'ignored' })
+
+    const wire = buildWireHistory(messages)
+
+    expect(wire).toHaveLength(40)
+    expect(wire.some((m) => m.content === 'ignored')).toBe(false)
+    // The cap keeps the MOST RECENT 40, so the oldest text messages are the
+    // ones dropped, not the newest.
+    expect(wire[0].content).toBe('msg 5')
+    expect(wire.at(-1)?.content).toBe('msg 44')
+  })
+
+  it('truncates an oversized message to the 12,000-char cap', () => {
+    const huge = 'x'.repeat(20_000)
+    const wire = buildWireHistory([{ role: 'user', type: 'text', content: huge }])
+    expect(wire[0].content).toHaveLength(12_000)
+  })
+
+  it('drops empty/whitespace-only text messages', () => {
+    const wire = buildWireHistory([{ role: 'user', type: 'text', content: '   ' }])
+    expect(wire).toHaveLength(0)
+  })
+})

--- a/webapp/src/lib/api/chat.ts
+++ b/webapp/src/lib/api/chat.ts
@@ -1,0 +1,207 @@
+// Chat API types + the SSE-turn sender. The backend has no typed OpenAPI shape
+// for the SSE frames themselves (they are `event: X\ndata: {...}\n\n` text, not
+// a JSON response body), so this module hand-writes the wire contract exactly
+// like lib/api/race.ts hand-writes the strategy endpoints' real shapes — the
+// generated schema.ts only covers the non-streaming chat endpoints.
+//
+// --- WHERE TO CHANGE IF THE BACKEND CONTRACT CHANGES ---
+// POST /chat/tool-message-stream   backend/api/v1/endpoints/chat.py (SSE framing)
+// Event sequence + stream_tokens   backend/services/chatbot/chat_engine.py (stream_response)
+// ToolMessageRequest fields        backend/models/tool_schemas.py
+// Wire-history / context pruning   backend/services/chatbot/llm_service.py (build_messages)
+//   (only reads chat_history text entries + context.{year,grand_prix,session,drivers})
+
+import type { EventSourceMessage } from 'eventsource-parser'
+import { postStream } from './sse'
+
+export type DisplayType = 'metrics' | 'strategy_card' | 'table' | 'chart' | 'text'
+
+/** One tool's structured output, exactly as chat_engine._build_tool_result_payload
+ *  builds it. `data` is tool-shaped, not schema'd (ToolResultData.data is a bare
+ *  dict server-side) — a display_type-specific renderer narrows it per
+ *  `tool_name`; this foundation sprint only needs to carry it opaquely through
+ *  to a thin JSON-disclosure placeholder. */
+export interface ToolResult {
+  tool_name: string
+  display_type: DisplayType
+  data: Record<string, unknown>
+  summary: string
+}
+
+/** The only context keys `build_messages` reads (llm_service.py:474-483) — the
+ *  backend silently ignores anything else, so widening this shape would just
+ *  be dead weight on the wire. */
+export interface ChatContextPayload {
+  year?: number
+  grand_prix?: string
+  session?: string
+  drivers?: string[]
+}
+
+/**
+ * One wire-history entry. TEXT ONLY by construction (design-audit #39 finding
+ * 4.3): Streamlit's history also carries `tool_result` and `image` entries, and
+ * the image one LEAKS raw base64 into the LLM prompt because `build_messages`
+ * only filters on `type != 'tool_result'`, never on `type == 'image'` — and
+ * `ToolMessageRequest` has no server-side history validator to catch it
+ * (unlike `ChatRequest`, `chat_models.py:43-63`). Since this shape cannot
+ * represent an image or a tool result at all, that leak cannot be
+ * reintroduced by accident on the client side either.
+ */
+export interface WireChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface ToolMessageRequestBody {
+  text: string
+  image?: string
+  chat_history?: WireChatMessage[]
+  context?: ChatContextPayload
+  model?: string
+  temperature?: number
+  max_tokens?: number
+  /** Stream the tool-summary reply as live token deltas instead of one
+   *  full-text event (backend B2, default False server-side so Streamlit stays
+   *  on today's behaviour). `sendChatTurn` always requests it — real streaming
+   *  is the whole point of the Chat tab's SSE migration (see the module
+   *  docstring on `chat_engine.py`). */
+  stream_tokens?: boolean
+}
+
+/** One parsed SSE frame, tagged by the wire `event` name. Mirrors the raw
+ *  `{event, data}` frame shape so a consumer switches on `.event` the same way
+ *  it would read the wire, just with `data` already parsed and narrowed. */
+export type ChatStreamEvent =
+  | { event: 'stage'; stage: string }
+  | { event: 'tool_result'; toolResult: ToolResult }
+  | { event: 'token'; token: string }
+  | { event: 'done'; llmModel?: string; tokensUsed?: number; error?: string }
+
+export interface ChatStreamHandlers {
+  onEvent: (event: ChatStreamEvent) => void
+  onError?: (error: unknown) => void
+  signal?: AbortSignal
+}
+
+// ── Narrowing helpers ────────────────────────────────────────────────────────
+
+function asRecord(raw: unknown): Record<string, unknown> {
+  return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+}
+function str(raw: unknown): string {
+  return typeof raw === 'string' ? raw : ''
+}
+function strOrUndef(raw: unknown): string | undefined {
+  return typeof raw === 'string' ? raw : undefined
+}
+function numOrUndef(raw: unknown): number | undefined {
+  return typeof raw === 'number' && !Number.isNaN(raw) ? raw : undefined
+}
+
+const DISPLAY_TYPES: readonly DisplayType[] = [
+  'metrics',
+  'strategy_card',
+  'table',
+  'chart',
+  'text',
+]
+
+function toToolResult(raw: unknown): ToolResult | null {
+  const d = asRecord(raw)
+  const displayType = DISPLAY_TYPES.includes(d.display_type as DisplayType)
+    ? (d.display_type as DisplayType)
+    : null
+  if (!displayType || typeof d.tool_name !== 'string') return null
+  return {
+    tool_name: d.tool_name,
+    display_type: displayType,
+    data: asRecord(d.data),
+    summary: str(d.summary),
+  }
+}
+
+/** Parse one raw SSE frame into a typed `ChatStreamEvent`, or null for a frame
+ *  this client does not understand (an unrecognised event name, or a payload
+ *  missing its required fields) — dropped rather than thrown, so one bad frame
+ *  cannot tear down an otherwise-good turn. */
+function parseChatFrame(message: EventSourceMessage): ChatStreamEvent | null {
+  let payload: Record<string, unknown>
+  try {
+    payload = asRecord(JSON.parse(message.data))
+  } catch {
+    return null
+  }
+  switch (message.event) {
+    case 'stage':
+      return typeof payload.stage === 'string' ? { event: 'stage', stage: payload.stage } : null
+    case 'tool_result': {
+      const toolResult = toToolResult(payload.tool_result)
+      return toolResult ? { event: 'tool_result', toolResult } : null
+    }
+    case 'token':
+      return typeof payload.token === 'string' ? { event: 'token', token: payload.token } : null
+    case 'done':
+      return {
+        event: 'done',
+        llmModel: strOrUndef(payload.llm_model),
+        tokensUsed: numOrUndef(payload.tokens_used),
+        error: strOrUndef(payload.error),
+      }
+    default:
+      return null
+  }
+}
+
+/**
+ * Send one chat turn and stream its `stage` / `tool_result` / `token` / `done`
+ * events. Thin wrapper over `postStream`: the only chat-specific work is frame
+ * parsing (`parseChatFrame`) and always asking the backend for real token
+ * streaming — `stream_tokens: true` unless the caller explicitly overrides it.
+ */
+export async function sendChatTurn(
+  body: ToolMessageRequestBody,
+  { onEvent, onError, signal }: ChatStreamHandlers,
+): Promise<void> {
+  const wireBody: ToolMessageRequestBody = { stream_tokens: true, ...body }
+  return postStream('/api/v1/chat/tool-message-stream', wireBody, {
+    onEvent: (message) => {
+      const parsed = parseChatFrame(message)
+      if (parsed) onEvent(parsed)
+    },
+    onError,
+    signal,
+  })
+}
+
+// ── Wire-history discipline (design-audit #39 finding 4.3) ──────────────────
+
+const MAX_HISTORY_MESSAGES = 40
+const MAX_MESSAGE_CHARS = 12_000
+
+/** A minimal shape any store message satisfies — decoupled from the feature
+ *  store's richer `ChatMessage` (which also carries an id, a timestamp, and an
+ *  optional `toolResult`) so this module does not need to import the store's
+ *  type just to describe what it reads from it. */
+export interface HistorySourceMessage {
+  role: 'user' | 'assistant'
+  type: 'text' | 'tool_result'
+  content: string
+}
+
+/**
+ * Build the `chat_history` wire payload from the store's message list. TEXT
+ * ONLY: `tool_result` entries are dropped (dead weight server-side anyway —
+ * `build_messages` already filters them out, `llm_service.py:499`) and there is
+ * no `image` variant in `WireChatMessage` to leak in the first place. Also
+ * self-caps to the bounds `ChatRequest` enforces server-side but
+ * `ToolMessageRequest` does not (`chat_models.py:20-21,43-63` vs
+ * `tool_schemas.py:216-231`) — the SPA cannot rely on a validator that is not
+ * actually wired up for this endpoint.
+ */
+export function buildWireHistory(messages: HistorySourceMessage[]): WireChatMessage[] {
+  const textOnly = messages
+    .filter((m) => m.type === 'text' && m.content.trim() !== '')
+    .map((m): WireChatMessage => ({ role: m.role, content: m.content.slice(0, MAX_MESSAGE_CHARS) }))
+  return textOnly.slice(-MAX_HISTORY_MESSAGES)
+}

--- a/webapp/src/lib/api/chat.ts
+++ b/webapp/src/lib/api/chat.ts
@@ -99,13 +99,7 @@ function numOrUndef(raw: unknown): number | undefined {
   return typeof raw === 'number' && !Number.isNaN(raw) ? raw : undefined
 }
 
-const DISPLAY_TYPES: readonly DisplayType[] = [
-  'metrics',
-  'strategy_card',
-  'table',
-  'chart',
-  'text',
-]
+const DISPLAY_TYPES: readonly DisplayType[] = ['metrics', 'strategy_card', 'table', 'chart', 'text']
 
 function toToolResult(raw: unknown): ToolResult | null {
   const d = asRecord(raw)

--- a/webapp/src/lib/api/sse.test.ts
+++ b/webapp/src/lib/api/sse.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import type { EventSourceMessage } from 'eventsource-parser'
-import { postStream } from './sse'
+import { postStream, SseError } from './sse'
 
 // Builds a streamed SSE Response from raw chunks (chunk boundaries deliberately
 // fall mid-frame to prove the parser reassembles across reads).
@@ -52,6 +52,19 @@ describe('postStream', () => {
     const onError = vi.fn()
     await expect(postStream('/api/v1/x', {}, { onEvent: () => {}, onError })).rejects.toThrow(/500/)
     expect(onError).toHaveBeenCalledOnce()
+  })
+
+  it('rejects with a typed SseError carrying the real status code', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('too many requests', { status: 429, statusText: 'Too Many Requests' })),
+    )
+
+    await expect(postStream('/api/v1/x', {}, { onEvent: () => {} })).rejects.toMatchObject({
+      name: 'SseError',
+      status: 429,
+    })
+    await expect(postStream('/api/v1/x', {}, { onEvent: () => {} })).rejects.toBeInstanceOf(SseError)
   })
 
   it('swallows an aborted stream (Stop button) without erroring', async () => {

--- a/webapp/src/lib/api/sse.test.ts
+++ b/webapp/src/lib/api/sse.test.ts
@@ -57,14 +57,20 @@ describe('postStream', () => {
   it('rejects with a typed SseError carrying the real status code', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(new Response('too many requests', { status: 429, statusText: 'Too Many Requests' })),
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('too many requests', { status: 429, statusText: 'Too Many Requests' }),
+        ),
     )
 
     await expect(postStream('/api/v1/x', {}, { onEvent: () => {} })).rejects.toMatchObject({
       name: 'SseError',
       status: 429,
     })
-    await expect(postStream('/api/v1/x', {}, { onEvent: () => {} })).rejects.toBeInstanceOf(SseError)
+    await expect(postStream('/api/v1/x', {}, { onEvent: () => {} })).rejects.toBeInstanceOf(
+      SseError,
+    )
   })
 
   it('swallows an aborted stream (Stop button) without erroring', async () => {

--- a/webapp/src/lib/api/sse.ts
+++ b/webapp/src/lib/api/sse.ts
@@ -16,6 +16,18 @@ export interface SseHandlers {
   signal?: AbortSignal
 }
 
+/** A non-ok HTTP response from an SSE POST, carrying the real status code so a
+ *  caller can special-case it (e.g. a 429 rate-limit Toast) instead of parsing
+ *  it back out of the error message string. */
+export class SseError extends Error {
+  readonly status: number
+  constructor(status: number, statusText: string) {
+    super(`SSE request failed: ${status} ${statusText}`)
+    this.name = 'SseError'
+    this.status = status
+  }
+}
+
 /**
  * POST a JSON body and stream the Server-Sent-Events response.
  *
@@ -37,7 +49,7 @@ export async function postStream(
       signal,
     })
     if (!response.ok || !response.body) {
-      throw new Error(`SSE request failed: ${response.status} ${response.statusText}`)
+      throw new SseError(response.status, response.statusText)
     }
 
     const parser = createParser({ onEvent })


### PR DESCRIPTION
Closes #166

## What
Chat tab foundation (turn machinery + UI shell) with **real SSE token streaming** end-to-end.
- `features/chat/`: id-keyed sessions (fixes the name-collision bug), MessageThread, Composer, ExamplePrompts, ChatSidebar, ToolBadge, stage ticker (labels re-keyed to the engine's real emissions).
- `useChatStream` reducer over the SSE frames (stage/tool_result/token/done) + fixture tests; tool_result renders BEFORE prose; Stop via AbortController; 429 + empty-stream handling.
- `sse.ts`: typed `SseError.status` for the 429 path.
- **Backend (additive, default-off):** `stream_tokens` flag on `ToolMessageRequest` + `chat_engine` summary leg streams via `stream_message`; the webapp sends it `true` → live token deltas. Streamlit (never sends it) is byte-unchanged.
- Route flip `/chat` → `ChatPage`; dropped the now-dead `ComingSoon`.
- `ToolResultCard` is a thin summary+JSON placeholder — the display_type renderers are C2/C3.

## Checks (central, Opus)
- webapp: `tsc -b` clean · `npm run build` green (ChatPage 21 kB lazy) · chat vitest 22/22 · oxlint clean.
- backend: default-off intact — `test_security_tool_allowlist`/`test_security_cost_cap` 11/11 pass; the `stream_tokens=False` branch is byte-identical to the prior code.
- **Deferred:** live-stream browser verify (needs the running backend) → C5 / next window.

Gate A (real streaming) approved by Víctor. Plan: `~/.claude/plans/chat-migration-39/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fully functional Chat page with persistent conversations, chat history, mode selection, example prompts, and deep-linkable chats.
  * Added real-time token streaming, tool status indicators, tool results, stop controls, and automatic message updates.
  * Added chat service health monitoring and improved handling of rate limits and connection errors.
* **Bug Fixes**
  * Improved recovery from interrupted or malformed streaming responses.
* **Tests**
  * Expanded coverage for streaming events, history handling, and server-sent event errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->