### PR TITLE
feat(chat): Chat #39 C2/C3 — tool-result renderers + inline charts

### DIFF
--- a/webapp/src/features/chat/charts/InlineChart.tsx
+++ b/webapp/src/features/chat/charts/InlineChart.tsx
@@ -1,0 +1,112 @@
+// The seam between the chat chart module and the rest of Chat. Whatever
+// renders the `chart` display_type branch of a tool result calls this with
+// the tool's real name and its raw (still-`unknown`) payload — everything
+// else in this folder (payload validation, the 4 option builders, the
+// dispatcher) is an implementation detail behind it.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
+import { ChartCard } from '@/components/ChartCard'
+import { Skeleton } from '@/components/Skeleton'
+import { registerF1Theme, useChartTheme } from '@/charts/registerEcharts'
+import { useFirstPaintAnimation } from '@/charts/useFirstPaintAnimation'
+import { buildToolChartOptions, getChartTitles } from './index'
+
+registerF1Theme()
+
+const CHART_HEIGHT = 340
+const FALLBACK_TITLE = 'Chart'
+// Mounts a pane's ECharts instance a little before it actually enters the
+// viewport, so the canvas is already live by the time a fast scroll reaches it.
+const VISIBILITY_ROOT_MARGIN = '200px'
+
+export interface InlineChartProps {
+  toolName: string
+  data: unknown
+}
+
+/**
+ * Renders the chart(s) for one chat tool result inline in the message
+ * thread. A payload that doesn't match its tool's expected shape (or a tool
+ * name none of the 4 chart builders recognise) degrades to a compact "chart
+ * unavailable" note with a raw-JSON disclosure, never a crash — the same
+ * fallback discipline the rest of Chat's tool-result rendering follows.
+ */
+export function InlineChart({ toolName, data }: InlineChartProps) {
+  const options = useMemo(() => buildToolChartOptions(toolName, data), [toolName, data])
+  const titles = useMemo(() => getChartTitles(toolName, data), [toolName, data])
+
+  if (!options || options.length === 0) {
+    return (
+      <details className="rounded-xl border border-hairline bg-bg-2 p-3 text-xs text-fg-3">
+        <summary className="cursor-pointer select-none">Chart unavailable — raw data</summary>
+        <pre className="mt-2 overflow-auto rounded-lg bg-bg-2 p-2 font-mono">
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      </details>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, index) => (
+        <LazyChartPane key={index} option={option} title={titles[index] ?? FALLBACK_TITLE} />
+      ))}
+    </div>
+  )
+}
+
+/** Mounts `ReactECharts` only once its host has scrolled into view. A chat
+ *  turn can land several chart tool results in one thread, and paying
+ *  ECharts' canvas-init cost for every one of them up front would visibly
+ *  jank the scroll. Stays mounted once visible — scrolling past and back
+ *  doesn't replay the entrance animation or re-pay the init cost. */
+function LazyChartPane({ option, title }: { option: EChartsOption; title: string }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (isVisible) return
+    const node = containerRef.current
+    if (!node) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setIsVisible(true)
+      },
+      { rootMargin: VISIBILITY_ROOT_MARGIN },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [isVisible])
+
+  return (
+    <div ref={containerRef}>
+      {isVisible ? (
+        <ChartedPane option={option} title={title} />
+      ) : (
+        <Skeleton style={{ height: CHART_HEIGHT }} className="w-full rounded-2xl" />
+      )}
+    </div>
+  )
+}
+
+/** The real chart host. Split out from `LazyChartPane` so the theme and
+ *  first-paint-animation hooks only run once a pane is actually visible. */
+function ChartedPane({ option, title }: { option: EChartsOption; title: string }) {
+  const chartTheme = useChartTheme()
+  const paintedOption = useFirstPaintAnimation(option)
+  return (
+    <ChartCard title={title}>
+      <div role="img" aria-label={title}>
+        <ReactECharts
+          theme={chartTheme}
+          key={chartTheme}
+          option={paintedOption}
+          notMerge
+          style={{ height: CHART_HEIGHT }}
+        />
+      </div>
+    </ChartCard>
+  )
+}

--- a/webapp/src/features/chat/charts/buildCompareOption.ts
+++ b/webapp/src/features/chat/charts/buildCompareOption.ts
@@ -1,0 +1,168 @@
+// Pure ECharts option builder for the `compare_drivers` chat tool. Ported
+// from the Streamlit original's `build_compare_drivers_figure`
+// (chart_builders.py) — a speed overlay over a delta curve for two drivers.
+
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import { getDriverColor } from '@/lib/drivers'
+import { alignDeltaX } from '@/lib/lapMarks'
+import { asNumberArray, asNumberOrNull, asRecord, asString } from './payloadGuards'
+
+interface PilotPayload {
+  name: string
+  color: string | null
+  lapTime: number | null
+  distance: number[]
+  speed: number[]
+}
+
+interface ComparePayload {
+  pilot1: PilotPayload
+  pilot2: PilotPayload
+  delta: number[]
+}
+
+const DELTA_COLOR = '#a78bfa'
+const DELTA_FILL = 'rgba(167, 139, 250, 0.15)'
+const ZERO_LINE_COLOR = 'rgba(148, 163, 184, 0.6)'
+
+function parsePilot(raw: unknown, fallbackName: string): PilotPayload | null {
+  const root = asRecord(raw)
+  if (!root) return null
+  return {
+    name: asString(root.name, fallbackName),
+    color: typeof root.color === 'string' && root.color !== '' ? root.color : null,
+    lapTime: asNumberOrNull(root.lap_time),
+    distance: asNumberArray(root.distance),
+    speed: asNumberArray(root.speed),
+  }
+}
+
+function parseComparePayload(data: unknown): ComparePayload | null {
+  const root = asRecord(data)
+  if (!root) return null
+  const pilot1 = parsePilot(root.pilot1, 'Driver 1')
+  const pilot2 = parsePilot(root.pilot2, 'Driver 2')
+  if (!pilot1 || !pilot2) return null
+  return { pilot1, pilot2, delta: asNumberArray(root.delta) }
+}
+
+function formatLapTime(lapTime: number | null): string {
+  return lapTime != null ? `${lapTime.toFixed(3)}s` : '—'
+}
+
+/** "{name1} {time1} vs {name2} {time2}" header, mirroring the Python
+ *  original's dynamic figure title — the one piece of this chart's context
+ *  that can't be a static per-tool label, since it names the two actual
+ *  drivers. Falls back to a generic label when the payload didn't parse. */
+export function compareTitle(data: unknown): string {
+  const payload = parseComparePayload(data)
+  if (!payload) return 'Driver comparison'
+  const { pilot1, pilot2 } = payload
+  return `${pilot1.name} ${formatLapTime(pilot1.lapTime)} vs ${pilot2.name} ${formatLapTime(pilot2.lapTime)}`
+}
+
+/** The payload's own team colour first, `getDriverColor` only as a fallback
+ *  for a missing/empty value — team colours come from the tool result, never
+ *  re-derived when the backend already sent one. */
+function pilotColor(pilot: PilotPayload): string {
+  return pilot.color ?? getDriverColor(pilot.name)
+}
+
+function zip(xs: number[], ys: number[]): Array<[number, number]> {
+  const length = Math.min(xs.length, ys.length)
+  const points: Array<[number, number]> = new Array(length)
+  for (let i = 0; i < length; i++) points[i] = [xs[i], ys[i]]
+  return points
+}
+
+function buildSpeedSeries(pilot: PilotPayload, color: string): LineSeriesOption {
+  return {
+    name: pilot.name,
+    type: 'line',
+    xAxisIndex: 0,
+    yAxisIndex: 0,
+    showSymbol: false,
+    lineStyle: { color, width: 1.8 },
+    itemStyle: { color },
+    data: zip(pilot.distance, pilot.speed),
+  }
+}
+
+function buildDeltaSeries(deltaX: number[], delta: number[], name: string): LineSeriesOption {
+  return {
+    name,
+    type: 'line',
+    xAxisIndex: 1,
+    yAxisIndex: 1,
+    showSymbol: false,
+    lineStyle: { color: DELTA_COLOR, width: 1.6 },
+    itemStyle: { color: DELTA_COLOR },
+    areaStyle: { color: DELTA_FILL, origin: 0 },
+    markLine: {
+      silent: true,
+      symbol: 'none',
+      lineStyle: { color: ZERO_LINE_COLOR, type: 'dashed' },
+      data: [{ yAxis: 0 }],
+    },
+    data: zip(deltaX, delta),
+  }
+}
+
+/**
+ * Speed overlay (top) + delta curve (bottom) for a two-driver comparison.
+ * The delta trace keeps the Python original's single violet fill rather than
+ * the fuller Comparison replay's winner-oriented two-tone treatment: this
+ * payload ships one ready-made `delta` array (pilot1 minus pilot2) with no
+ * "who is faster" signal to orient a two-tone fill around, so a neutral
+ * single-colour fill is the honest rendering of what the tool actually
+ * returned. Returns null when either pilot is missing from the payload.
+ */
+export function buildCompareOption(data: unknown): EChartsOption | null {
+  const payload = parseComparePayload(data)
+  if (!payload) return null
+  const { pilot1, pilot2, delta } = payload
+
+  const color1 = pilotColor(pilot1)
+  const color2 = pilotColor(pilot2)
+  const deltaX = alignDeltaX(pilot1.distance.length > 0 ? pilot1.distance : undefined, delta.length)
+
+  return {
+    axisPointer: { link: [{ xAxisIndex: 'all' }] },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      valueFormatter: (raw) => (typeof raw === 'number' ? raw.toFixed(3) : String(raw ?? '')),
+    },
+    legend: { top: 0, data: [pilot1.name, pilot2.name], textStyle: { fontSize: 10 } },
+    grid: [
+      { top: '10%', height: '46%', left: 8, right: 16, containLabel: true },
+      { top: '66%', height: '28%', left: 8, right: 16, containLabel: true },
+    ],
+    xAxis: [
+      { gridIndex: 0, type: 'value', axisLabel: { show: false }, splitLine: { show: false } },
+      {
+        gridIndex: 1,
+        type: 'value',
+        name: 'Distance (m)',
+        nameLocation: 'middle',
+        nameGap: 24,
+        splitLine: { show: false },
+      },
+    ],
+    yAxis: [
+      { gridIndex: 0, type: 'value', name: 'km/h', scale: true, nameTextStyle: { fontSize: 10 } },
+      {
+        gridIndex: 1,
+        type: 'value',
+        name: `${pilot1.name} − ${pilot2.name} (s)`,
+        nameTextStyle: { fontSize: 9 },
+        scale: true,
+      },
+    ],
+    series: [
+      buildSpeedSeries(pilot1, color1),
+      buildSpeedSeries(pilot2, color2),
+      buildDeltaSeries(deltaX, delta, `${pilot1.name} − ${pilot2.name}`),
+    ],
+  }
+}

--- a/webapp/src/features/chat/charts/buildLapTimesOption.ts
+++ b/webapp/src/features/chat/charts/buildLapTimesOption.ts
@@ -1,0 +1,168 @@
+// Pure ECharts option builder for the `get_lap_times` chat tool. Ported from
+// the Streamlit original's `build_lap_times_figure` (chart_builders.py) — one
+// line per driver, invalid laps rendered as hollow dots, dashed pit markers
+// inferred from compound changes (this payload carries no Stint column, so
+// only the compound-change signal ever fires).
+
+import type {
+  EChartsOption,
+  LineSeriesOption,
+  TooltipComponentFormatterCallbackParams,
+} from 'echarts'
+import { getDriverColor } from '@/lib/drivers'
+import { detectPitLaps, type PitEvent } from '@/lib/lapMarks'
+import { compoundColor } from './compoundColor'
+import { asArray, asBoolean, asNumberOrNull, asRecord, asString } from './payloadGuards'
+
+interface LapTimeRecord {
+  driver: string
+  lapNumber: number
+  lapTime: number | null
+  isValid: boolean
+  compound: string
+}
+
+function parseLapTimeRecords(data: unknown): LapTimeRecord[] | null {
+  const root = asRecord(data)
+  const rows = root ? asArray(root.lap_times) : null
+  if (!rows) return null
+
+  const records: LapTimeRecord[] = []
+  for (const raw of rows) {
+    const row = asRecord(raw)
+    const lapNumber = row ? asNumberOrNull(row.lap_number) : null
+    if (!row || lapNumber == null) continue
+    records.push({
+      driver: asString(row.driver, '?').toUpperCase(),
+      lapNumber,
+      lapTime: asNumberOrNull(row.lap_time),
+      isValid: asBoolean(row.is_valid, true),
+      compound: asString(row.compound, '').toUpperCase() || 'UNK',
+    })
+  }
+  return records
+}
+
+function groupByDriver(records: LapTimeRecord[]): Map<string, LapTimeRecord[]> {
+  const byDriver = new Map<string, LapTimeRecord[]>()
+  for (const record of records) {
+    const list = byDriver.get(record.driver) ?? []
+    list.push(record)
+    byDriver.set(record.driver, list)
+  }
+  for (const list of byDriver.values()) list.sort((a, b) => a.lapNumber - b.lapNumber)
+  return byDriver
+}
+
+/** One line per driver. Laps FastF1 flagged unrepresentative (`is_valid:
+ *  false` — an in/out lap, a red-flag lap) render as a hollow, team-bordered
+ *  dot instead of a filled one, so a strategist can spot which points not to
+ *  read as pace evidence. `transparent` (rather than the Streamlit original's
+ *  hardcoded dark-purple background) keeps the knockout effect correct on
+ *  either theme's card colour. */
+function buildDriverLineSeries(driver: string, rows: LapTimeRecord[]): LineSeriesOption {
+  const color = getDriverColor(driver)
+  return {
+    name: driver,
+    type: 'line',
+    showSymbol: true,
+    symbolSize: 6,
+    lineStyle: { color, width: 2 },
+    itemStyle: { color },
+    data: rows.map((row) => ({
+      value: [row.lapNumber, row.lapTime] as [number, number | null],
+      itemStyle: row.isValid
+        ? undefined
+        : { color: 'transparent', borderColor: color, borderWidth: 1.5 },
+    })),
+  }
+}
+
+/** Ghost series hosting one dashed vertical marker per detected pit stop,
+ *  coloured by the compound fitted after the stop and labelled with the
+ *  driver code so overlapping pits stay distinguishable. */
+function buildPitMarkLineSeries(pitEvents: PitEvent[]): LineSeriesOption {
+  return {
+    name: 'pit-stops',
+    type: 'line',
+    data: [],
+    silent: true,
+    symbol: 'none',
+    tooltip: { show: false },
+    markLine: {
+      silent: true,
+      symbol: 'none',
+      data: pitEvents.map((event) => ({
+        xAxis: event.lap,
+        lineStyle: { color: compoundColor(event.compound), width: 1, type: 'dashed' as const },
+        label: {
+          show: true,
+          formatter: `${event.driver} - ${event.compound.slice(0, 3)}`,
+          position: 'insideEndTop' as const,
+          fontSize: 9,
+          color: compoundColor(event.compound),
+        },
+      })),
+    },
+  }
+}
+
+function buildTooltipFormatter() {
+  return (params: TooltipComponentFormatterCallbackParams): string => {
+    const items = Array.isArray(params) ? params : [params]
+    // `axisValue` is present at runtime on an axis-triggered tooltip's first
+    // item but isn't part of the strict callback-params type — same cast
+    // gapSeries.ts's own axis tooltip formatter uses.
+    const lap = (items[0] as { axisValue?: number | string } | undefined)?.axisValue
+    const rows = items
+      .filter((item) => item.seriesName && item.seriesName !== 'pit-stops')
+      .map((item) => {
+        const value = Array.isArray(item.value) ? item.value : []
+        const time = typeof value[1] === 'number' ? `${value[1].toFixed(3)}s` : '—'
+        return `<div style="display:flex;justify-content:space-between;gap:16px;">
+  <span>${item.seriesName}</span>
+  <span style="font-family:'JetBrains Mono Variable',monospace">${time}</span>
+</div>`
+      })
+    return `<div style="margin-bottom:4px;opacity:0.7">Lap ${lap ?? '—'}</div>${rows.join('')}`
+  }
+}
+
+/**
+ * Lap-time-vs-lap-number line chart, one trace per driver. Returns null when
+ * the payload doesn't carry a usable `lap_times` array.
+ */
+export function buildLapTimesOption(data: unknown): EChartsOption | null {
+  const records = parseLapTimeRecords(data)
+  if (!records || records.length === 0) return null
+
+  const byDriver = groupByDriver(records)
+  const series: LineSeriesOption[] = []
+  const pitEvents: PitEvent[] = []
+
+  for (const [driver, rows] of byDriver) {
+    series.push(buildDriverLineSeries(driver, rows))
+    pitEvents.push(
+      ...detectPitLaps(
+        rows.map((row) => ({ lap: row.lapNumber, compound: row.compound })),
+        driver,
+      ),
+    )
+  }
+  series.push(buildPitMarkLineSeries(pitEvents))
+
+  return {
+    tooltip: { trigger: 'axis', axisPointer: { type: 'line' }, formatter: buildTooltipFormatter() },
+    legend: { top: 0, textStyle: { fontSize: 10 } },
+    grid: { top: 40, left: 8, right: 16, bottom: 28, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap',
+      nameLocation: 'middle',
+      nameGap: 24,
+      splitLine: { show: false },
+    },
+    yAxis: { type: 'value', scale: true },
+    series,
+  }
+}

--- a/webapp/src/features/chat/charts/buildRaceDataOptions.ts
+++ b/webapp/src/features/chat/charts/buildRaceDataOptions.ts
@@ -1,0 +1,184 @@
+// Pure ECharts option builder for the `get_race_data` chat tool. Ported from
+// the Streamlit original's `build_race_data_figure` (chart_builders.py) —
+// TWO independent charts (positions, lap times with pit laps masked) rather
+// than one stacked pair, so the lap-time panel doesn't get cramped once 10+
+// drivers share a legend.
+
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import { getDriverColor } from '@/lib/drivers'
+import { detectPitLaps, maskPitLapOutliers, type PitEvent } from '@/lib/lapMarks'
+import { compoundColor } from './compoundColor'
+import { asArray, asNumberOrNull, asRecord, asString } from './payloadGuards'
+
+interface RaceDataRow {
+  driver: string
+  lapNumber: number
+  position: number | null
+  lapTime: number | null
+  compound: string
+  /** Raw stint index, kept nullable — `detectPitLaps` treats a missing stint
+   *  as "fall back to the compound-change signal", so this must not be
+   *  coerced to 0 before reaching it. */
+  stint: number | null
+}
+
+export const RACE_DATA_TITLES = ['Race positions', 'Lap times (pit laps masked)'] as const
+
+function parseRaceDataRows(data: unknown): RaceDataRow[] | null {
+  const root = asRecord(data)
+  const rows = root ? asArray(root.race_data) : null
+  if (!rows) return null
+
+  const records: RaceDataRow[] = []
+  for (const raw of rows) {
+    const row = asRecord(raw)
+    const lapNumber = row ? asNumberOrNull(row.LapNumber) : null
+    if (!row || lapNumber == null) continue
+    records.push({
+      driver: asString(row.Driver, '?').toUpperCase(),
+      lapNumber,
+      position: asNumberOrNull(row.Position),
+      lapTime: asNumberOrNull(row.LapTime_s),
+      compound: asString(row.Compound, '').toUpperCase() || 'UNK',
+      stint: asNumberOrNull(row.Stint),
+    })
+  }
+  return records
+}
+
+function groupByDriver(rows: RaceDataRow[]): Map<string, RaceDataRow[]> {
+  const byDriver = new Map<string, RaceDataRow[]>()
+  for (const row of rows) {
+    const list = byDriver.get(row.driver) ?? []
+    list.push(row)
+    byDriver.set(row.driver, list)
+  }
+  for (const list of byDriver.values()) list.sort((a, b) => a.lapNumber - b.lapNumber)
+  return byDriver
+}
+
+/** Ghost series hosting one dashed vertical marker per detected pit stop,
+ *  coloured by the compound fitted after the stop — shared shape between the
+ *  positions and lap-times charts so both draw the exact same pit lines. */
+function buildPitMarkLineSeries(pitEvents: PitEvent[]): LineSeriesOption {
+  return {
+    name: 'pit-stops',
+    type: 'line',
+    data: [],
+    silent: true,
+    symbol: 'none',
+    tooltip: { show: false },
+    markLine: {
+      silent: true,
+      symbol: 'none',
+      data: pitEvents.map((event) => ({
+        xAxis: event.lap,
+        lineStyle: { color: compoundColor(event.compound), width: 1, type: 'dashed' as const },
+        label: {
+          show: true,
+          formatter: `${event.driver} - ${event.compound.slice(0, 3)}`,
+          position: 'insideEndTop' as const,
+          fontSize: 9,
+          color: compoundColor(event.compound),
+        },
+      })),
+    },
+  }
+}
+
+function buildPositionsOption(
+  byDriver: Map<string, RaceDataRow[]>,
+  pitEvents: PitEvent[],
+): EChartsOption {
+  const series: LineSeriesOption[] = [...byDriver.entries()].map(([driver, rows]) => {
+    const color = getDriverColor(driver)
+    return {
+      name: driver,
+      type: 'line',
+      showSymbol: true,
+      symbolSize: 5,
+      lineStyle: { color, width: 2 },
+      itemStyle: { color },
+      data: rows.map((row): [number, number | null] => [row.lapNumber, row.position]),
+    }
+  })
+  series.push(buildPitMarkLineSeries(pitEvents))
+
+  return {
+    tooltip: { trigger: 'axis', axisPointer: { type: 'line' } },
+    legend: { top: 0, textStyle: { fontSize: 10 } },
+    grid: { top: 40, left: 8, right: 16, bottom: 28, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap',
+      nameLocation: 'middle',
+      nameGap: 24,
+      splitLine: { show: false },
+    },
+    yAxis: { type: 'value', name: 'Position', inverse: true, nameTextStyle: { fontSize: 10 } },
+    series,
+  }
+}
+
+function buildMaskedLapTimesOption(
+  byDriver: Map<string, RaceDataRow[]>,
+  pitEvents: PitEvent[],
+): EChartsOption {
+  const series: LineSeriesOption[] = [...byDriver.entries()].map(([driver, rows]) => {
+    const color = getDriverColor(driver)
+    const masked = maskPitLapOutliers(rows.map((row) => row.lapTime))
+    return {
+      name: driver,
+      type: 'line',
+      showSymbol: true,
+      symbolSize: 4,
+      lineStyle: { color, width: 1.6 },
+      itemStyle: { color },
+      data: rows.map((row, i): [number, number | null | undefined] => [row.lapNumber, masked[i]]),
+    }
+  })
+  series.push(buildPitMarkLineSeries(pitEvents))
+
+  return {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      valueFormatter: (raw) => (typeof raw === 'number' ? `${raw.toFixed(3)}s` : String(raw ?? '')),
+    },
+    legend: { top: 0, textStyle: { fontSize: 10 } },
+    grid: { top: 40, left: 8, right: 16, bottom: 28, containLabel: true },
+    xAxis: {
+      type: 'value',
+      name: 'Lap',
+      nameLocation: 'middle',
+      nameGap: 24,
+      splitLine: { show: false },
+    },
+    yAxis: { type: 'value', scale: true },
+    series,
+  }
+}
+
+/**
+ * Two independent charts — race positions and lap times with pit-lap
+ * outliers masked to a gap — for the full field or whichever drivers the
+ * tool scoped its payload to. Returns null when the payload doesn't carry a
+ * usable `race_data` array.
+ */
+export function buildRaceDataOptions(data: unknown): EChartsOption[] | null {
+  const rows = parseRaceDataRows(data)
+  if (!rows || rows.length === 0) return null
+
+  const byDriver = groupByDriver(rows)
+  const pitEvents: PitEvent[] = []
+  for (const [driver, driverRows] of byDriver) {
+    pitEvents.push(
+      ...detectPitLaps(
+        driverRows.map((row) => ({ lap: row.lapNumber, stint: row.stint, compound: row.compound })),
+        driver,
+      ),
+    )
+  }
+
+  return [buildPositionsOption(byDriver, pitEvents), buildMaskedLapTimesOption(byDriver, pitEvents)]
+}

--- a/webapp/src/features/chat/charts/buildTelemetryOption.ts
+++ b/webapp/src/features/chat/charts/buildTelemetryOption.ts
@@ -1,0 +1,164 @@
+// Pure ECharts option builder for the `get_telemetry` chat tool. Ported from
+// the Streamlit original's `build_telemetry_figure` (chart_builders.py) — a
+// 3-panel stack (speed / throttle / brake) over one lap's distance, one
+// driver at a time. Speed keeps the driver's team colour; throttle/brake use
+// the fixed green/red convention cockpit telemetry displays use everywhere,
+// same as the Python original. The distance-axis km-compaction below mirrors
+// the dashboard telemetry grid's own axis formatter (channels.ts / dashboard
+// ChannelChart.tsx), so a chat telemetry chart reads the same as the
+// full-page one.
+
+import type {
+  EChartsOption,
+  LineSeriesOption,
+  XAXisComponentOption,
+  YAXisComponentOption,
+} from 'echarts'
+import { getDriverColor } from '@/lib/drivers'
+import { asNumberArray, asNumberOrNull, asRecord, asString } from './payloadGuards'
+
+interface TelemetryPayload {
+  driver: string
+  lapNumber: number | null
+  distance: number[]
+  speed: number[]
+  throttle: number[]
+  brake: number[]
+}
+
+const THROTTLE_COLOR = '#10b981'
+const BRAKE_COLOR = '#ef4444'
+const THROTTLE_FILL = 'rgba(16, 185, 129, 0.2)'
+const BRAKE_FILL = 'rgba(239, 68, 68, 0.25)'
+const PANEL_COUNT = 3
+const PANEL_HEIGHT_PCT = 24
+const PANEL_TOP_START_PCT = 6
+const PANEL_GAP_PCT = 34
+
+function parseTelemetryPayload(data: unknown): TelemetryPayload | null {
+  const root = asRecord(data)
+  if (!root) return null
+  const distance = asNumberArray(root.distance)
+  if (distance.length === 0) return null
+  return {
+    driver: asString(root.driver, '?').toUpperCase(),
+    lapNumber: asNumberOrNull(root.lap_number),
+    distance,
+    speed: asNumberArray(root.speed),
+    throttle: asNumberArray(root.throttle),
+    brake: asNumberArray(root.brake),
+  }
+}
+
+/** "VER - lap 34 telemetry", or a generic fallback when the payload didn't
+ *  parse — the dynamic per-turn label InlineChart shows as the chart's title,
+ *  mirroring the Python original's in-figure title. */
+export function telemetryTitle(data: unknown): string {
+  const payload = parseTelemetryPayload(data)
+  if (!payload) return 'Telemetry'
+  const lap = payload.lapNumber != null ? payload.lapNumber : '?'
+  return `${payload.driver} - lap ${lap} telemetry`
+}
+
+/** Compacts large metre values to "1.2k" — same formatter the Comparison
+ *  replay's channel panes use, so a chat telemetry chart's axis reads the
+ *  same as the rest of the app once distances run into the thousands. */
+function distanceAxisLabel(value: string | number): string {
+  const n = Number(value)
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`
+}
+
+function zip(distance: number[], values: number[]): Array<[number, number]> {
+  const length = Math.min(distance.length, values.length)
+  const points: Array<[number, number]> = new Array(length)
+  for (let i = 0; i < length; i++) points[i] = [distance[i], values[i]]
+  return points
+}
+
+interface Panel {
+  name: string
+  values: number[]
+  color: string
+  fill?: string
+}
+
+function buildGrids(): NonNullable<EChartsOption['grid']> {
+  return Array.from({ length: PANEL_COUNT }, (_, i) => ({
+    top: `${PANEL_TOP_START_PCT + i * PANEL_GAP_PCT}%`,
+    height: `${PANEL_HEIGHT_PCT}%`,
+    left: 8,
+    right: 16,
+    containLabel: true,
+  }))
+}
+
+function buildXAxes(): XAXisComponentOption[] {
+  const lastIndex = PANEL_COUNT - 1
+  return Array.from({ length: PANEL_COUNT }, (_, i) => ({
+    gridIndex: i,
+    type: 'value',
+    splitLine: { show: false },
+    axisLabel: i === lastIndex ? { formatter: distanceAxisLabel, fontSize: 10 } : { show: false },
+    axisTick: i === lastIndex ? undefined : { show: false },
+    name: i === lastIndex ? 'Distance (m)' : undefined,
+    nameLocation: 'middle',
+    nameGap: 24,
+  }))
+}
+
+function buildYAxes(panels: Panel[]): YAXisComponentOption[] {
+  return panels.map((panel, i) => ({
+    gridIndex: i,
+    type: 'value',
+    scale: true,
+    name: panel.name,
+    nameTextStyle: { fontSize: 10 },
+    axisLabel: { fontSize: 10 },
+  }))
+}
+
+function buildPanelSeries(panels: Panel[], distance: number[]): LineSeriesOption[] {
+  return panels.map((panel, i) => ({
+    name: panel.name,
+    type: 'line',
+    gridIndex: i,
+    xAxisIndex: i,
+    yAxisIndex: i,
+    showSymbol: false,
+    lineStyle: { color: panel.color, width: 1.8 },
+    itemStyle: { color: panel.color },
+    areaStyle: panel.fill ? { color: panel.fill } : undefined,
+    data: zip(distance, panel.values),
+  }))
+}
+
+/**
+ * 3-panel telemetry stack (speed / throttle / brake) vs distance for one
+ * driver's lap. Returns null when the payload doesn't carry a usable
+ * `distance` array.
+ */
+export function buildTelemetryOption(data: unknown): EChartsOption | null {
+  const payload = parseTelemetryPayload(data)
+  if (!payload) return null
+
+  const panels: Panel[] = [
+    { name: 'Speed (km/h)', values: payload.speed, color: getDriverColor(payload.driver) },
+    { name: 'Throttle (%)', values: payload.throttle, color: THROTTLE_COLOR, fill: THROTTLE_FILL },
+    { name: 'Brake (%)', values: payload.brake, color: BRAKE_COLOR, fill: BRAKE_FILL },
+  ]
+
+  return {
+    // Links the vertical crosshair across all 3 stacked grids, mirroring the
+    // Python original's `shared_xaxes` subplot hover behaviour.
+    axisPointer: { link: [{ xAxisIndex: 'all' }] },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'line' },
+      valueFormatter: (raw) => (typeof raw === 'number' ? raw.toFixed(1) : String(raw ?? '')),
+    },
+    grid: buildGrids(),
+    xAxis: buildXAxes(),
+    yAxis: buildYAxes(panels),
+    series: buildPanelSeries(panels, payload.distance),
+  }
+}

--- a/webapp/src/features/chat/charts/compoundColor.ts
+++ b/webapp/src/features/chat/charts/compoundColor.ts
@@ -1,0 +1,22 @@
+// Shared compound-to-colour lookup for the two chart builders that draw pit
+// markers (lap times and race data) — both need to tint a dashed vline by
+// the tyre compound fitted after the stop, so it lives once here rather than
+// twice.
+
+import { tireColors } from '@/charts/echartsTheme'
+
+const INTERMEDIATE_ALIAS = 'INT'
+// Violet accent, matching the Streamlit original's fallback for an unknown or
+// missing compound label (chart_builders.py's `_COMPOUND_FALLBACK`).
+const FALLBACK_COLOR = '#a78bfa'
+
+/**
+ * Resolve an already-uppercased compound label to its themed hex colour,
+ * folding the `INT` shorthand FastF1 payloads sometimes ship into
+ * `INTERMEDIATE` first. Anything else unrecognised falls back to a violet
+ * accent so a pit marker never renders with an undefined colour.
+ */
+export function compoundColor(compound: string): string {
+  const key = compound === INTERMEDIATE_ALIAS ? 'INTERMEDIATE' : compound
+  return tireColors[key] ?? FALLBACK_COLOR
+}

--- a/webapp/src/features/chat/charts/index.ts
+++ b/webapp/src/features/chat/charts/index.ts
@@ -1,0 +1,62 @@
+// Dispatcher for the 4 chart-shaped chat tools. `InlineChart` is the only
+// caller — it needs one option array + one title per tool result, and
+// everything upstream of that (payload validation, the actual builders) is
+// this folder's private detail.
+
+import type { EChartsOption } from 'echarts'
+import { buildCompareOption, compareTitle } from './buildCompareOption'
+import { buildLapTimesOption } from './buildLapTimesOption'
+import { buildRaceDataOptions, RACE_DATA_TITLES } from './buildRaceDataOptions'
+import { buildTelemetryOption, telemetryTitle } from './buildTelemetryOption'
+
+const LAP_TIMES_TITLE = 'Lap times'
+
+/**
+ * Dispatches a chat tool result to its chart-option builder(s). Each of the
+ * four chart-shaped tools (`get_lap_times`, `get_telemetry`,
+ * `compare_drivers`, `get_race_data`) maps to one builder above; any other
+ * tool name, or a builder that rejects its own payload shape, returns null so
+ * `InlineChart` can fall back to its "chart unavailable" note instead of
+ * rendering nothing or crashing.
+ */
+export function buildToolChartOptions(toolName: string, data: unknown): EChartsOption[] | null {
+  switch (toolName) {
+    case 'get_lap_times': {
+      const option = buildLapTimesOption(data)
+      return option ? [option] : null
+    }
+    case 'get_telemetry': {
+      const option = buildTelemetryOption(data)
+      return option ? [option] : null
+    }
+    case 'compare_drivers': {
+      const option = buildCompareOption(data)
+      return option ? [option] : null
+    }
+    case 'get_race_data':
+      return buildRaceDataOptions(data)
+    default:
+      return null
+  }
+}
+
+/**
+ * Chart title(s) for the given tool, one per option `buildToolChartOptions`
+ * returns for it. Static per tool except `compare_drivers` (and, once it
+ * ships, `get_telemetry`'s driver/lap label), whose title names the actual
+ * data in the turn rather than the tool that produced it.
+ */
+export function getChartTitles(toolName: string, data: unknown): string[] {
+  switch (toolName) {
+    case 'get_lap_times':
+      return [LAP_TIMES_TITLE]
+    case 'get_telemetry':
+      return [telemetryTitle(data)]
+    case 'compare_drivers':
+      return [compareTitle(data)]
+    case 'get_race_data':
+      return [...RACE_DATA_TITLES]
+    default:
+      return []
+  }
+}

--- a/webapp/src/features/chat/charts/payloadGuards.ts
+++ b/webapp/src/features/chat/charts/payloadGuards.ts
@@ -1,0 +1,39 @@
+// Minimal, shared type-narrowing helpers for the four chart-tool payloads.
+// Every MCP tool result arrives as `unknown` on the wire (the backend does
+// not schema its `data` field — see lib/api/chat.ts's own note on
+// `ToolResult.data`), so each builder in this folder validates its own shape
+// before touching it and returns null on any mismatch rather than throwing —
+// a malformed payload degrades to InlineChart's "chart unavailable" note,
+// never a crash.
+
+/** Narrows to a plain object (excluding arrays and null), or null. */
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+/** Narrows to an array, or null. */
+export function asArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null
+}
+
+/** Numeric entries of an array field, dropping anything non-numeric rather
+ *  than failing the whole series over one bad sample. */
+export function asNumberArray(value: unknown): number[] {
+  const arr = asArray(value)
+  if (!arr) return []
+  return arr.filter((entry): entry is number => typeof entry === 'number')
+}
+
+export function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+export function asNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' ? value : null
+}
+
+export function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}

--- a/webapp/src/features/chat/components/MetricsResult.tsx
+++ b/webapp/src/features/chat/components/MetricsResult.tsx
@@ -1,0 +1,125 @@
+import { Gauge } from '@/charts/Gauge'
+import { Card } from '@/components/Card'
+import { Pill } from '@/components/Pill'
+import { RangeBar } from '@/components/RangeBar'
+import { StatCard } from '@/components/StatCard'
+import type { ToolResult } from '@/lib/api/chat'
+import { RawDataDisclosure } from './RawDataDisclosure'
+import { toPaceMetrics, toSituationMetrics } from './toolResultParsing'
+
+// The `metrics` display_type: N25 pace and N27 overtake/safety-car, the two
+// tools the chat allowlist tags this way. Both reuse the exact viz the Model
+// Lab benches already ship for the same models, just for a single lap
+// instead of a window/lens toggle.
+
+const THREAT_TONE: Record<string, 'danger' | 'warning' | 'success'> = {
+  HIGH: 'danger',
+  MEDIUM: 'warning',
+  LOW: 'success',
+}
+
+const formatSeconds = (value: number): string => `${value.toFixed(3)}s`
+
+/** N25's pace prediction for one lap: the three headline deltas plus the
+ *  P10-P90 bootstrap band, the same fields the Model Lab pace bench plots
+ *  (`features/lab/models/PaceResultView.tsx`) for a whole lap window. */
+function PaceMetrics({ data }: { data: ToolResult['data'] }) {
+  const metrics = toPaceMetrics(data)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-stretch gap-3">
+        <StatCard
+          eyebrow="Predicted lap time"
+          value={metrics.lapTimePred != null ? formatSeconds(metrics.lapTimePred) : '—'}
+        />
+        <StatCard
+          eyebrow="Delta vs previous"
+          value={metrics.deltaVsPrev != null ? formatSeconds(metrics.deltaVsPrev) : '—'}
+        />
+        <StatCard
+          eyebrow="Delta vs median"
+          value={metrics.deltaVsMedian != null ? formatSeconds(metrics.deltaVsMedian) : '—'}
+        />
+      </div>
+      <RangeBar
+        low={metrics.ciP10}
+        mid={metrics.lapTimePred}
+        high={metrics.ciP90}
+        format={formatSeconds}
+      />
+    </div>
+  )
+}
+
+/** N27's overtake + safety-car read for one lap. Same gauge operating points
+ *  the Model Lab situation bench uses — 0.80 action threshold for overtake,
+ *  0.30 alert threshold for a safety car within 3 laps
+ *  (`features/lab/models/SituationResultView.tsx`) — so a probability reads
+ *  against the same line everywhere in the app. */
+function SituationMetrics({ data }: { data: ToolResult['data'] }) {
+  const metrics = toSituationMetrics(data)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-4">
+        {metrics.overtakeProb != null ? (
+          <div className="min-w-40 flex-1">
+            <Gauge
+              value={metrics.overtakeProb}
+              label="Overtake"
+              threshold={0.8}
+              thresholdLabel="Action threshold 80%"
+              height={170}
+            />
+          </div>
+        ) : null}
+        {metrics.scProb3Lap != null ? (
+          <div className="min-w-40 flex-1">
+            <Gauge
+              value={metrics.scProb3Lap}
+              label="SC in 3 laps"
+              threshold={0.3}
+              thresholdLabel="Alert threshold 30%"
+              height={170}
+            />
+          </div>
+        ) : null}
+      </div>
+      {metrics.threatLevel ? (
+        <Pill tone={THREAT_TONE[metrics.threatLevel] ?? 'success'} className="self-start">
+          {metrics.threatLevel} threat
+        </Pill>
+      ) : null}
+    </div>
+  )
+}
+
+const METRICS_TITLE: Record<string, string> = {
+  predict_pace: 'Pace prediction',
+  predict_situation: 'Overtake / safety car',
+}
+
+export interface MetricsResultProps {
+  toolResult: ToolResult
+}
+
+/** Dispatches the `metrics` display_type by tool name inside the shared card
+ *  shell every tool-result family uses. Falls back to a raw JSON disclosure
+ *  for any tool this chat build has no specific renderer for yet, so a
+ *  future addition to the backend allowlist never renders blank. */
+export function MetricsResult({ toolResult }: MetricsResultProps) {
+  const title = METRICS_TITLE[toolResult.tool_name]
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      {title ? (
+        <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">{title}</span>
+      ) : null}
+      {toolResult.tool_name === 'predict_pace' ? (
+        <PaceMetrics data={toolResult.data} />
+      ) : toolResult.tool_name === 'predict_situation' ? (
+        <SituationMetrics data={toolResult.data} />
+      ) : (
+        <RawDataDisclosure data={toolResult.data} />
+      )}
+    </Card>
+  )
+}

--- a/webapp/src/features/chat/components/RawDataDisclosure.tsx
+++ b/webapp/src/features/chat/components/RawDataDisclosure.tsx
@@ -1,0 +1,20 @@
+// Collapsible raw-JSON fallback, shared by every tool-result family renderer
+// for the shapes it does not recognise (an unexpected tool, a field that
+// failed to narrow). Keeps an unknown payload inspectable instead of
+// rendering nothing, the same fallback the C1 placeholder used for every
+// result before this sprint gave each family its own renderer.
+
+export interface RawDataDisclosureProps {
+  data: Record<string, unknown>
+}
+
+export function RawDataDisclosure({ data }: RawDataDisclosureProps) {
+  return (
+    <details className="text-xs text-fg-3">
+      <summary className="cursor-pointer select-none">Raw data</summary>
+      <pre className="mt-2 overflow-auto rounded-lg bg-bg-2 p-2 font-mono">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </details>
+  )
+}

--- a/webapp/src/features/chat/components/StrategyCardResult.tsx
+++ b/webapp/src/features/chat/components/StrategyCardResult.tsx
@@ -1,0 +1,167 @@
+import { Gauge } from '@/charts/Gauge'
+import { ScoresPlot } from '@/charts/ScenarioScoresChart'
+import { ActionBadge } from '@/components/ActionBadge'
+import { Card } from '@/components/Card'
+import { CompoundPill } from '@/components/CompoundPill'
+import { ConfidenceDial } from '@/components/ConfidenceDial'
+import { Pill } from '@/components/Pill'
+import { StatCard } from '@/components/StatCard'
+import type { ToolResult } from '@/lib/api/chat'
+import type { StrategyAction } from '@/lib/api/strategy'
+import { RawDataDisclosure } from './RawDataDisclosure'
+import { toPitCard, toRecommendationCard, toTireCard } from './toolResultParsing'
+
+// The `strategy_card` display_type: N26 tyres, N28+N16 pit, and N31's full
+// recommendation, the three tools the chat allowlist tags this way. Each
+// reuses the exact viz its Model Lab bench (or, for the recommendation, the
+// Strategy tab's Decision Banner) already ships for the same model.
+
+const WARNING_TONE: Record<string, 'danger' | 'warning' | 'success'> = {
+  PIT_SOON: 'danger',
+  MONITOR: 'warning',
+  OK: 'success',
+}
+
+const formatSeconds = (value: number): string => `${value.toFixed(2)}s`
+
+/** The LLM/sub-agent's narrative reasoning, collapsed by default so it never
+ *  competes with the structured verdict above it — same pattern as
+ *  `RadioResultCard`'s own reasoning disclosure. */
+function ReasoningDisclosure({ reasoning }: { reasoning: string | undefined }) {
+  if (!reasoning) return null
+  return (
+    <details className="group">
+      <summary className="cursor-pointer text-xs font-medium tracking-wide text-fg-3 uppercase marker:content-none">
+        Reasoning
+      </summary>
+      <p className="mt-2 rounded-lg bg-bg-2 px-3 py-2 text-sm leading-relaxed text-fg-2">
+        {reasoning}
+      </p>
+    </details>
+  )
+}
+
+/** N26's tyre-degradation verdict: compound, degradation rate, the median
+ *  laps-to-cliff estimate, and the categorical warning level — matching the
+ *  Model Lab tyre bench (`features/lab/models/TyreResultView.tsx`). */
+function TireCard({ data }: { data: ToolResult['data'] }) {
+  const card = toTireCard(data)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {card.compound ? <CompoundPill compound={card.compound} /> : null}
+        {card.warningLevel ? (
+          <Pill tone={WARNING_TONE[card.warningLevel] ?? 'success'}>{card.warningLevel}</Pill>
+        ) : null}
+        {/* Not a field of TireOutput today (src/agents/tire_agent.py) — renders
+         *  automatically the moment the backend starts sending one. */}
+        {card.confidence != null ? <ConfidenceDial value={card.confidence} size={40} /> : null}
+      </div>
+      <div className="flex flex-wrap items-stretch gap-3">
+        <StatCard
+          eyebrow="Deg rate"
+          value={card.degRate != null ? `${card.degRate.toFixed(4)} s/lap` : '—'}
+        />
+        <StatCard
+          eyebrow="Cliff P50"
+          value={card.lapsToCliffP50 != null ? `+${Math.round(card.lapsToCliffP50)} laps` : '—'}
+        />
+      </div>
+      <ReasoningDisclosure reasoning={card.reasoning} />
+    </div>
+  )
+}
+
+/** N28 + N16's pit-stop verdict: median stop duration, the recommended lap,
+ *  and the undercut probability at the same 0.522 operating point the Model
+ *  Lab pit bench gauges against (`features/lab/models/PitResultView.tsx`). */
+function PitCard({ data }: { data: ToolResult['data'] }) {
+  const card = toPitCard(data)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-stretch gap-3">
+        <StatCard
+          eyebrow="Stop P50"
+          value={card.stopDurationP50 != null ? formatSeconds(card.stopDurationP50) : '—'}
+        />
+        <StatCard
+          eyebrow="Recommended lap"
+          value={card.recommendedLap != null ? `L${card.recommendedLap}` : '—'}
+        />
+      </div>
+      {card.undercutProb != null ? (
+        <Gauge
+          value={card.undercutProb}
+          label="Undercut"
+          threshold={0.522}
+          thresholdLabel="Operating point 52%"
+          height={170}
+        />
+      ) : null}
+      <ReasoningDisclosure reasoning={card.reasoning} />
+    </div>
+  )
+}
+
+/** N31's full recommendation: the hero action badge + the LLM's
+ *  self-assessed confidence, the Monte-Carlo scenario-scores plot backing
+ *  it, and the narrative reasoning — the same trio the Strategy tab's
+ *  Decision Banner leads with (`features/strategy/components/
+ *  DecisionBanner.tsx`), condensed for a chat bubble. */
+function RecommendationCard({ data }: { data: ToolResult['data'] }) {
+  const card = toRecommendationCard(data)
+  const hasScores = Object.keys(card.scenarioScores).length > 0
+  const action = card.action ?? 'UNKNOWN'
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <ActionBadge action={action} size="hero" />
+        {card.confidence != null ? (
+          <div className="flex flex-col items-center gap-1">
+            <ConfidenceDial value={card.confidence} />
+            <span className="text-[10px] tracking-widest text-fg-4 uppercase">self-assessed</span>
+          </div>
+        ) : null}
+      </div>
+      {hasScores ? (
+        <ScoresPlot scores={card.scenarioScores} chosenAction={action as StrategyAction} />
+      ) : null}
+      <ReasoningDisclosure reasoning={card.reasoning} />
+    </div>
+  )
+}
+
+const STRATEGY_TITLE: Record<string, string> = {
+  predict_tire: 'Tyre degradation',
+  predict_pit: 'Pit strategy',
+  recommend_strategy: 'Strategy recommendation',
+}
+
+export interface StrategyCardResultProps {
+  toolResult: ToolResult
+}
+
+/** Dispatches the `strategy_card` display_type by tool name inside the
+ *  shared card shell every tool-result family uses. Falls back to a raw
+ *  JSON disclosure for any tool this chat build has no specific renderer
+ *  for yet. */
+export function StrategyCardResult({ toolResult }: StrategyCardResultProps) {
+  const title = STRATEGY_TITLE[toolResult.tool_name]
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      {title ? (
+        <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">{title}</span>
+      ) : null}
+      {toolResult.tool_name === 'predict_tire' ? (
+        <TireCard data={toolResult.data} />
+      ) : toolResult.tool_name === 'predict_pit' ? (
+        <PitCard data={toolResult.data} />
+      ) : toolResult.tool_name === 'recommend_strategy' ? (
+        <RecommendationCard data={toolResult.data} />
+      ) : (
+        <RawDataDisclosure data={toolResult.data} />
+      )}
+    </Card>
+  )
+}

--- a/webapp/src/features/chat/components/TableResult.tsx
+++ b/webapp/src/features/chat/components/TableResult.tsx
@@ -1,0 +1,64 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import { Card } from '@/components/Card'
+import { DataTable } from '@/components/DataTable'
+import { RadioResultCard } from '@/components/radio/RadioResultCard'
+import type { ToolResult } from '@/lib/api/chat'
+import { RawDataDisclosure } from './RawDataDisclosure'
+import { asRecord, toRadioResultData } from './toolResultParsing'
+
+// The `table` display_type: `analyze_radio` is the only tool the chat
+// allowlist tags this way today, reusing the exact `RadioResultCard` Race
+// and Lab already ship. A generic fallback covers any future `table` tool
+// whose shape is not fixed beyond "some list of records somewhere" — mirrors
+// the Streamlit renderer's own fallback (`tool_result_renderer.py`'s
+// `_render_table`, which builds a `pd.DataFrame` from the first
+// list-of-dicts value it finds).
+
+type GenericRow = Record<string, unknown>
+
+/** Build tanstack column defs from the keys of the first row, since a
+ *  generic-fallback table has no fixed schema to declare columns from. */
+function genericColumns(rows: GenericRow[]): ColumnDef<GenericRow, unknown>[] {
+  if (rows.length === 0) return []
+  return Object.keys(rows[0]).map((key) => ({
+    id: key,
+    header: key.replace(/_/g, ' '),
+    accessorFn: (row: GenericRow) => row[key],
+  }))
+}
+
+/** The first array-of-objects value found anywhere in the payload. */
+function firstRowList(data: ToolResult['data']): GenericRow[] {
+  for (const value of Object.values(data)) {
+    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'object') {
+      return value.map(asRecord)
+    }
+  }
+  return []
+}
+
+export interface TableResultProps {
+  toolResult: ToolResult
+}
+
+/** Dispatches the `table` display_type. */
+export function TableResult({ toolResult }: TableResultProps) {
+  if (toolResult.tool_name === 'analyze_radio') {
+    return <RadioResultCard result={toRadioResultData(toolResult.data)} />
+  }
+
+  const rows = firstRowList(toolResult.data)
+  if (rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <RawDataDisclosure data={toolResult.data} />
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="p-4">
+      <DataTable columns={genericColumns(rows)} data={rows} height={280} />
+    </Card>
+  )
+}

--- a/webapp/src/features/chat/components/TextResult.tsx
+++ b/webapp/src/features/chat/components/TextResult.tsx
@@ -1,0 +1,87 @@
+import { Card } from '@/components/Card'
+import { Pill } from '@/components/Pill'
+import { RagAnswerCard } from '@/components/rag/RagAnswerCard'
+import type { ToolResult } from '@/lib/api/chat'
+import { RawDataDisclosure } from './RawDataDisclosure'
+import { toLapRange, toRagResultData, toStringChips } from './toolResultParsing'
+
+// The `text` display_type: `query_regulations` renders the full RAG answer
+// card (citations + source passages); the three listing/lookup tools get a
+// small chip list or one-liner instead of the raw JSON a fallback would show.
+
+/** A chip per entry — `list_available_gps` / `list_available_drivers`. */
+function ChipList({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">{label}</span>
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((item) => (
+          <Pill key={item} tone="neutral">
+            {item}
+          </Pill>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** `get_lap_range`: a one-line lap-window readout instead of the raw
+ *  `{min_lap, max_lap}` dict a JSON fallback would show. */
+function LapRangeLine({ data }: { data: ToolResult['data'] }) {
+  const range = toLapRange(data)
+  if (range.minLap == null || range.maxLap == null) return <RawDataDisclosure data={data} />
+  return (
+    <p className="text-sm text-fg-2">
+      Lap window <span className="font-mono text-fg-1">{range.minLap}</span> to{' '}
+      <span className="font-mono text-fg-1">{range.maxLap}</span>
+    </p>
+  )
+}
+
+export interface TextResultProps {
+  toolResult: ToolResult
+}
+
+/**
+ * Dispatches the `text` display_type. `query_regulations` reuses the
+ * promoted `RagAnswerCard` with `stream={false}` — the answer never types
+ * itself out here, since the surrounding chat is already streaming the
+ * real prose for this turn, unlike the Race tab's synchronous ask.
+ */
+export function TextResult({ toolResult }: TextResultProps) {
+  if (toolResult.tool_name === 'query_regulations') {
+    return <RagAnswerCard result={toRagResultData(toolResult.data)} stream={false} />
+  }
+
+  const gps = toStringChips(toolResult.data, 'gps')
+  if (toolResult.tool_name === 'list_available_gps' && gps.length > 0) {
+    return (
+      <Card className="p-4">
+        <ChipList label="Available Grand Prix" items={gps} />
+      </Card>
+    )
+  }
+
+  const drivers = toStringChips(toolResult.data, 'drivers')
+  if (toolResult.tool_name === 'list_available_drivers' && drivers.length > 0) {
+    return (
+      <Card className="p-4">
+        <ChipList label="Drivers" items={drivers} />
+      </Card>
+    )
+  }
+
+  if (toolResult.tool_name === 'get_lap_range') {
+    return (
+      <Card className="p-4">
+        <LapRangeLine data={toolResult.data} />
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="p-4">
+      <RawDataDisclosure data={toolResult.data} />
+    </Card>
+  )
+}

--- a/webapp/src/features/chat/components/ToolErrorCard.tsx
+++ b/webapp/src/features/chat/components/ToolErrorCard.tsx
@@ -1,0 +1,38 @@
+import { TriangleAlert } from 'lucide-react'
+import type { ToolResult } from '@/lib/api/chat'
+import { toolErrorMessage } from './toolResultParsing'
+
+export interface ToolErrorCardProps {
+  toolResult: ToolResult
+}
+
+/**
+ * Danger-tinted banner for a failed tool call — the chat engine catches MCP
+ * exceptions (timeouts, missing data, validation failures) and packs them as
+ * `{"error": "..."}`, forcing `display_type` to `'text'` (see
+ * `toolResultParsing.ts`'s `isToolError` for the detector). The engine always
+ * follows a tool error by streaming an LLM explanation of what went wrong and
+ * what to try instead (it appends a recovery nudge to the summary prompt
+ * before streaming), and that explanation lands as the very next assistant
+ * message in the thread — so this card is deliberately self-contained rather
+ * than trying to embed that prose itself; the two simply render one after
+ * the other in message order.
+ *
+ * Styled as a plain tinted banner (hairline border, tinted background) rather
+ * than a colored-border `Card`, matching the failure banner already used on
+ * the Strategy and Comparison tabs instead of introducing a new treatment.
+ */
+export function ToolErrorCard({ toolResult }: ToolErrorCardProps) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-2xl border border-hairline bg-danger/8 px-4 py-3"
+    >
+      <TriangleAlert className="mt-0.5 size-4 shrink-0 text-danger" aria-hidden="true" />
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-xs text-fg-3">{toolResult.tool_name}</span>
+        <p className="text-sm text-fg-1">{toolErrorMessage(toolResult.data)}</p>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/ToolResultCard.tsx
+++ b/webapp/src/features/chat/components/ToolResultCard.tsx
@@ -1,35 +1,48 @@
-import { Card } from '@/components/Card'
-import { Pill } from '@/components/Pill'
+// The `chart` family is delegated to a sibling module built separately (see
+// the import below) so this switch never needs its own ECharts option
+// builders — it only routes.
+import { InlineChart } from '@/features/chat/charts/InlineChart'
 import type { ToolResult } from '@/lib/api/chat'
+import { MetricsResult } from './MetricsResult'
+import { RawDataDisclosure } from './RawDataDisclosure'
+import { StrategyCardResult } from './StrategyCardResult'
+import { TableResult } from './TableResult'
+import { TextResult } from './TextResult'
+import { ToolErrorCard } from './ToolErrorCard'
+import { isToolError } from './toolResultParsing'
 
 export interface ToolResultCardProps {
   toolResult: ToolResult
 }
 
 /**
- * Placeholder tool-result renderer for the foundation sprint: every tool
- * result lands as its natural-language summary plus a raw JSON disclosure, no
- * matter which `display_type` the backend tagged it with. A later sprint
- * replaces the body below with a switch over `display_type` (metrics /
- * strategy_card / table / chart / text) that reuses the cards already built
- * for Race and Lab (StatCard, Gauge, CompoundPill, ScenarioScoresChart, …) —
- * this component's props and export stay the same, only the body changes.
+ * Renders one `tool_result` event. A failed call always short-circuits to
+ * the danger-tinted `ToolErrorCard` — the backend forces `display_type:
+ * 'text'` and collapses `data` to just `{error}` on failure, so `isToolError`
+ * runs ahead of the `display_type` switch below rather than letting a text
+ * renderer try to make sense of an error envelope. Otherwise the result is
+ * dispatched to its family renderer by `display_type`, each of which reuses
+ * the cards already shipped for Race and Lab (StatCard, Gauge, CompoundPill,
+ * ScenarioScoresChart, RadioResultCard, RagAnswerCard, ...) instead of
+ * inventing new visual language for the chat tab.
  */
 export function ToolResultCard({ toolResult }: ToolResultCardProps) {
-  return (
-    <Card className="flex flex-col gap-2 p-4">
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-mono text-xs text-fg-3">{toolResult.tool_name}</span>
-        <Pill tone="neutral">{toolResult.display_type}</Pill>
-      </div>
-      {toolResult.summary ? <p className="text-sm text-fg-2">{toolResult.summary}</p> : null}
-      <details className="text-xs text-fg-3">
-        <summary className="cursor-pointer select-none">Raw data</summary>
-        <pre className="mt-2 overflow-auto rounded-lg bg-bg-2 p-2 font-mono">
-          {JSON.stringify(toolResult.data, null, 2)}
-        </pre>
-      </details>
-      {/* C2 replaces this with the display_type switch */}
-    </Card>
-  )
+  if (isToolError(toolResult.data)) {
+    return <ToolErrorCard toolResult={toolResult} />
+  }
+
+  switch (toolResult.display_type) {
+    case 'metrics':
+      return <MetricsResult toolResult={toolResult} />
+    case 'strategy_card':
+      return <StrategyCardResult toolResult={toolResult} />
+    case 'table':
+      return <TableResult toolResult={toolResult} />
+    case 'text':
+      return <TextResult toolResult={toolResult} />
+    case 'chart':
+      return <InlineChart toolName={toolResult.tool_name} data={toolResult.data} />
+    default:
+      return <RawDataDisclosure data={toolResult.data} />
+  }
 }

--- a/webapp/src/features/chat/components/toolResultParsing.ts
+++ b/webapp/src/features/chat/components/toolResultParsing.ts
@@ -1,0 +1,293 @@
+import type {
+  RadioAlert,
+  RadioCorrection,
+  RadioEntity,
+  RadioEvent,
+  RadioResult,
+  RagChunk,
+  RagResult,
+  RcmEvent,
+} from '@/lib/api/race'
+import type { ScenarioScore, StrategyAction } from '@/lib/api/strategy'
+
+// Narrowing helpers for chat tool-result payloads. The backend does not
+// schema `data` per tool (`ToolResultData.data: dict[str, Any]`, verified
+// against `backend/mcp_tools.py` and the agent output dataclasses it
+// serializes) — every renderer below reads only the fields it needs and
+// tolerates a missing or mistyped key instead of throwing. Several of these
+// tools return the exact same backend model an existing HTTP endpoint
+// already narrows (`lib/api/race.ts`'s `toRadioResult` / `toRagResult`), but
+// those helpers are not exported from that module, so the narrowing is
+// duplicated here rather than reaching into a file outside this feature.
+
+export function asRecord(raw: unknown): Record<string, unknown> {
+  return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+}
+
+function numOrUndef(raw: unknown): number | undefined {
+  return typeof raw === 'number' && !Number.isNaN(raw) ? raw : undefined
+}
+
+function strOrEmpty(raw: unknown): string {
+  return typeof raw === 'string' ? raw : ''
+}
+
+function strOrUndef(raw: unknown): string | undefined {
+  return typeof raw === 'string' ? raw : undefined
+}
+
+function stringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((value): value is string => typeof value === 'string') : []
+}
+
+/** True for the error envelope the chat engine builds on a failed tool call:
+ *  `display_type` is forced to `'text'` and `data` collapses to just
+ *  `{error}` (`chat_engine.py`'s failure branch) — the same detector the
+ *  Streamlit renderer uses (`tool_result_renderer.py`'s `_looks_like_error`),
+ *  checked ahead of the `display_type` switch so an error never reaches a
+ *  family renderer expecting real fields. */
+export function isToolError(data: Record<string, unknown>): boolean {
+  return 'error' in data && Object.keys(data).length <= 2
+}
+
+export function toolErrorMessage(data: Record<string, unknown>): string {
+  return strOrEmpty(data.error) || 'The tool call failed.'
+}
+
+// ── predict_pace (metrics) ──────────────────────────────────────────────────
+
+export interface PaceMetrics {
+  lapTimePred?: number
+  deltaVsPrev?: number
+  deltaVsMedian?: number
+  ciP10?: number
+  ciP90?: number
+}
+
+/** Fields of `PaceOutput` (`src/agents/pace_agent.py`), serialized as-is. */
+export function toPaceMetrics(data: Record<string, unknown>): PaceMetrics {
+  return {
+    lapTimePred: numOrUndef(data.lap_time_pred),
+    deltaVsPrev: numOrUndef(data.delta_vs_prev),
+    deltaVsMedian: numOrUndef(data.delta_vs_median),
+    ciP10: numOrUndef(data.ci_p10),
+    ciP90: numOrUndef(data.ci_p90),
+  }
+}
+
+// ── predict_situation (metrics) ─────────────────────────────────────────────
+
+export interface SituationMetrics {
+  overtakeProb?: number
+  scProb3Lap?: number
+  threatLevel?: string
+}
+
+/** Fields of `RaceSituationOutput` (`src/agents/race_situation_agent.py`). */
+export function toSituationMetrics(data: Record<string, unknown>): SituationMetrics {
+  return {
+    overtakeProb: numOrUndef(data.overtake_prob),
+    scProb3Lap: numOrUndef(data.sc_prob_3lap),
+    threatLevel: strOrUndef(data.threat_level),
+  }
+}
+
+// ── predict_tire (strategy_card) ────────────────────────────────────────────
+
+export interface TireCard {
+  compound?: string
+  degRate?: number
+  lapsToCliffP50?: number
+  warningLevel?: string
+  confidence?: number
+  reasoning?: string
+}
+
+/** Fields of `TireOutput` (`src/agents/tire_agent.py`). `confidence` is NOT
+ *  one of that dataclass's fields today — it is read defensively so the dial
+ *  appears automatically the moment the backend starts sending one, instead
+ *  of assuming a field that does not exist yet. */
+export function toTireCard(data: Record<string, unknown>): TireCard {
+  return {
+    compound: strOrUndef(data.compound),
+    degRate: numOrUndef(data.deg_rate),
+    lapsToCliffP50: numOrUndef(data.laps_to_cliff_p50),
+    warningLevel: strOrUndef(data.warning_level),
+    confidence: numOrUndef(data.confidence),
+    reasoning: strOrUndef(data.reasoning),
+  }
+}
+
+// ── predict_pit (strategy_card) ─────────────────────────────────────────────
+
+export interface PitCard {
+  stopDurationP50?: number
+  undercutProb?: number
+  recommendedLap?: number
+  reasoning?: string
+}
+
+/** Fields of `PitStrategyOutput` (`src/agents/pit_strategy_agent.py`). */
+export function toPitCard(data: Record<string, unknown>): PitCard {
+  return {
+    stopDurationP50: numOrUndef(data.stop_duration_p50),
+    undercutProb: numOrUndef(data.undercut_prob),
+    recommendedLap: numOrUndef(data.recommended_lap),
+    reasoning: strOrUndef(data.reasoning),
+  }
+}
+
+// ── recommend_strategy (strategy_card) ──────────────────────────────────────
+
+function toScenarioScores(raw: unknown): Record<string, ScenarioScore> {
+  const scores: Record<string, ScenarioScore> = {}
+  for (const [action, value] of Object.entries(asRecord(raw))) {
+    const row = asRecord(value)
+    const e = numOrUndef(row.E)
+    const p10 = numOrUndef(row.P10)
+    const p90 = numOrUndef(row.P90)
+    const score = numOrUndef(row.score)
+    if (e != null && p10 != null && p90 != null && score != null) {
+      scores[action] = { E: e, P10: p10, P90: p90, score }
+    }
+  }
+  return scores
+}
+
+export interface RecommendationCard {
+  action?: StrategyAction
+  confidence?: number
+  scenarioScores: Record<string, ScenarioScore>
+  reasoning?: string
+}
+
+/** Fields of `StrategyRecommendation` (`src/agents/strategy_orchestrator.py`)
+ *  this chat card actually renders — the other 10 v2 fields (pit plan,
+ *  pace mode, contingencies, ...) are left for a future pass, same scope the
+ *  design audit's tool mapping calls for. */
+export function toRecommendationCard(data: Record<string, unknown>): RecommendationCard {
+  return {
+    action: strOrUndef(data.action) as StrategyAction | undefined,
+    confidence: numOrUndef(data.confidence),
+    scenarioScores: toScenarioScores(data.scenario_scores),
+    reasoning: strOrUndef(data.reasoning),
+  }
+}
+
+// ── analyze_radio (table) ───────────────────────────────────────────────────
+
+function toRadioEntity(raw: unknown): RadioEntity {
+  const r = asRecord(raw)
+  return { text: strOrEmpty(r.text), label: strOrEmpty(r.label) }
+}
+
+function toRadioEvent(raw: unknown): RadioEvent {
+  const r = asRecord(raw)
+  const a = asRecord(r.analysis)
+  const entities = Array.isArray(a.entities) ? a.entities.map(toRadioEntity) : []
+  return {
+    message: strOrEmpty(r.message),
+    timestamp: strOrUndef(r.timestamp) ?? null,
+    analysis: {
+      sentiment: strOrEmpty(a.sentiment),
+      sentiment_score: numOrUndef(a.sentiment_score) ?? null,
+      intent: strOrEmpty(a.intent),
+      intent_confidence: numOrUndef(a.intent_confidence) ?? null,
+      entities,
+    },
+  }
+}
+
+function toRadioAlert(raw: unknown): RadioAlert {
+  const r = asRecord(raw)
+  return {
+    source: strOrEmpty(r.source),
+    intent: strOrEmpty(r.intent),
+    message: strOrEmpty(r.message),
+    driver: strOrEmpty(r.driver),
+  }
+}
+
+function toRadioCorrection(raw: unknown): RadioCorrection {
+  const r = asRecord(raw)
+  return {
+    driver: strOrEmpty(r.driver),
+    original_intent: strOrEmpty(r.original_intent),
+    suggested_intent: strOrEmpty(r.suggested_intent),
+    span: strOrEmpty(r.span),
+    reason: strOrEmpty(r.reason),
+  }
+}
+
+function toRcmEvent(raw: unknown): RcmEvent {
+  const r = asRecord(raw)
+  return {
+    message: strOrEmpty(r.message),
+    flag: strOrEmpty(r.flag),
+    category: strOrEmpty(r.category),
+    lap: numOrUndef(r.lap) ?? null,
+  }
+}
+
+/** Narrows a chat tool-result payload into the same `RadioResult` shape the
+ *  `/strategy/radio` HTTP endpoint returns — `analyze_radio` serializes the
+ *  identical `RadioOutput` dataclass (`src/agents/radio_agent.py`), so the
+ *  chat tab can render it with the exact card Race and Lab already ship. */
+export function toRadioResultData(data: Record<string, unknown>): RadioResult {
+  return {
+    radio_events: Array.isArray(data.radio_events) ? data.radio_events.map(toRadioEvent) : [],
+    alerts: Array.isArray(data.alerts) ? data.alerts.map(toRadioAlert) : [],
+    reasoning: strOrEmpty(data.reasoning),
+    corrections: Array.isArray(data.corrections) ? data.corrections.map(toRadioCorrection) : [],
+    rcm_events: Array.isArray(data.rcm_events) ? data.rcm_events.map(toRcmEvent) : [],
+  }
+}
+
+// ── query_regulations (text) ────────────────────────────────────────────────
+
+function toRagChunk(raw: unknown): RagChunk {
+  const r = asRecord(raw)
+  return {
+    text: strOrEmpty(r.text),
+    article: strOrEmpty(r.article),
+    doc_type: strOrEmpty(r.doc_type),
+    year: numOrUndef(r.year) ?? null,
+    score: numOrUndef(r.score) ?? null,
+  }
+}
+
+/** Narrows a chat tool-result payload into `RagResult` — `query_regulations`
+ *  serializes the same `RegulationContext` dataclass the `/strategy/rag`
+ *  endpoint returns (`src/agents/rag_agent.py`), minus the `question` field
+ *  (the tool never echoes the question back; it defaults to an empty
+ *  string, which `RagAnswerCard` never reads anyway). */
+export function toRagResultData(data: Record<string, unknown>): RagResult {
+  return {
+    question: strOrEmpty(data.question),
+    answer: strOrEmpty(data.answer),
+    articles: stringArray(data.articles),
+    chunks: Array.isArray(data.chunks) ? data.chunks.map(toRagChunk) : [],
+  }
+}
+
+// ── list_available_gps / list_available_drivers (text) ─────────────────────
+
+/** `{"gps": [...]}` or `{"drivers": [...]}` — the exact shape
+ *  `available_gps` / `available_drivers` return (`backend/api/v1/endpoints/
+ *  strategy.py`). */
+export function toStringChips(data: Record<string, unknown>, key: 'gps' | 'drivers'): string[] {
+  return stringArray(data[key])
+}
+
+// ── get_lap_range (text) ────────────────────────────────────────────────────
+
+export interface LapRange {
+  minLap?: number
+  maxLap?: number
+}
+
+/** `{"min_lap": n, "max_lap": n}` — the exact shape `lap_range` returns
+ *  (`backend/api/v1/endpoints/strategy.py`); there is no `total_laps` key. */
+export function toLapRange(data: Record<string, unknown>): LapRange {
+  return { minLap: numOrUndef(data.min_lap), maxLap: numOrUndef(data.max_lap) }
+}

--- a/webapp/src/lib/lapMarks.test.ts
+++ b/webapp/src/lib/lapMarks.test.ts
@@ -1,0 +1,82 @@
+// Fixture tests pinning parity with the Streamlit original's pit-detection
+// and outlier-masking helpers (chart_builders.py's `_detect_pit_laps` /
+// `_mask_pit_lap_outliers`), plus the delta-x alignment rule. Small captured
+// input arrays, one behaviour per test — no ECharts, no React.
+
+import { describe, expect, it } from 'vitest'
+import { alignDeltaX, detectPitLaps, maskPitLapOutliers } from './lapMarks'
+
+describe('detectPitLaps', () => {
+  it('detects a pit stop from a stint increment', () => {
+    const rows = [
+      { lap: 1, stint: 1, compound: 'MEDIUM' },
+      { lap: 2, stint: 1, compound: 'MEDIUM' },
+      { lap: 3, stint: 2, compound: 'HARD' },
+      { lap: 4, stint: 2, compound: 'HARD' },
+    ]
+    expect(detectPitLaps(rows, 'VER')).toEqual([{ lap: 3, compound: 'HARD', driver: 'VER' }])
+  })
+
+  it('falls back to a compound change when no stint field is present', () => {
+    const rows = [
+      { lap: 1, compound: 'SOFT' },
+      { lap: 2, compound: 'SOFT' },
+      { lap: 3, compound: 'MEDIUM' },
+    ]
+    expect(detectPitLaps(rows, 'HAM')).toEqual([{ lap: 3, compound: 'MEDIUM', driver: 'HAM' }])
+  })
+
+  it('never flags the first lap, and ignores a compound relabel while a stint is tracked', () => {
+    const rows = [
+      { lap: 1, stint: 1, compound: 'SOFT' },
+      { lap: 2, stint: 1, compound: 'SOFT' },
+    ]
+    expect(detectPitLaps(rows, 'NOR')).toEqual([])
+  })
+
+  it('skips a row with a missing lap without letting it update the running state', () => {
+    // Lap 2 is dropped from the payload entirely (e.g. a Safety Car lap), and
+    // its Stint=5 must NOT become the new "previous stint" — otherwise lap 3's
+    // Stint=2 would read as a decrease, not an increment, and the pit would be
+    // missed.
+    const rows = [
+      { lap: 1, stint: 1, compound: 'SOFT' },
+      { lap: null, stint: 5, compound: 'HARD' },
+      { lap: 3, stint: 2, compound: 'MEDIUM' },
+    ]
+    expect(detectPitLaps(rows, 'PIA')).toEqual([{ lap: 3, compound: 'MEDIUM', driver: 'PIA' }])
+  })
+})
+
+describe('maskPitLapOutliers', () => {
+  it('leaves the input unchanged with fewer than 3 valid samples', () => {
+    const lapTimes = [90.1, 95.4]
+    expect(maskPitLapOutliers(lapTimes)).toEqual(lapTimes)
+  })
+
+  it('masks a lap exceeding 1.15x the median to null', () => {
+    // sorted [89, 90, 91, 130] -> median (90+91)/2 = 90.5 -> cutoff 104.075
+    const lapTimes = [90, 91, 89, 130]
+    expect(maskPitLapOutliers(lapTimes)).toEqual([90, 91, 89, null])
+  })
+
+  it('respects a custom threshold ratio', () => {
+    const lapTimes = [90, 90, 90, 100]
+    expect(maskPitLapOutliers(lapTimes, 1.05)).toEqual([90, 90, 90, null])
+    expect(maskPitLapOutliers(lapTimes, 1.2)).toEqual([90, 90, 90, 100])
+  })
+})
+
+describe('alignDeltaX', () => {
+  it('slices the reference distance array to the delta length', () => {
+    expect(alignDeltaX([0, 10, 20, 30, 40], 3)).toEqual([0, 10, 20])
+  })
+
+  it('falls back to a 0..n-1 range only when distance is truly absent', () => {
+    expect(alignDeltaX(undefined, 4)).toEqual([0, 1, 2, 3])
+  })
+
+  it('does not pad a distance array shorter than the delta series', () => {
+    expect(alignDeltaX([0, 10], 5)).toEqual([0, 10])
+  })
+})

--- a/webapp/src/lib/lapMarks.ts
+++ b/webapp/src/lib/lapMarks.ts
@@ -1,0 +1,115 @@
+// Pure derivations the chat charts need that the tool payloads themselves do
+// not carry: where a pit stop happened, which lap times are pit-lap outliers
+// that would otherwise wreck a chart's y-axis, and how to align a ready-made
+// delta series onto a reference distance array of possibly different length.
+// Ported 1:1 from the Streamlit original's chart_builders.py
+// (`_detect_pit_laps`, `_mask_pit_lap_outliers`, the `delta_x` slicing in
+// `build_compare_drivers_figure`) so a chat chart never silently drifts from
+// what the equivalent Streamlit chart already draws — see lapMarks.test.ts
+// for fixtures pinning the exact edge cases the Python original handles.
+
+/** One driver-lap row as `detectPitLaps` needs it — already normalised by the
+ *  caller from whichever payload shape it read (`lap_number`/`compound` for
+ *  lap-times, `LapNumber`/`Stint`/`Compound` for race-data), so this module
+ *  stays payload-agnostic. */
+export interface PitLapInput {
+  lap: number | null | undefined
+  /** Stint index, when the payload carries one. `null`/`undefined` triggers
+   *  the compound-change fallback signal below. */
+  stint?: number | null
+  /** Tyre compound label, any case — normalised to uppercase internally. */
+  compound?: string | null
+}
+
+/** One detected pit stop: the first lap of the new stint, the compound fitted
+ *  for it, and the driver code the caller passed in (carried through so a
+ *  chart combining several drivers' events can still tell them apart). */
+export interface PitEvent {
+  lap: number
+  compound: string
+  driver: string
+}
+
+/**
+ * Walk a driver's laps (already sorted by lap ascending) and return the laps
+ * where a pit stop happened, using two signals in order of reliability:
+ *
+ * 1. The `stint` field incrementing — race-data payloads carry it and it
+ *    ticks up once per stop regardless of compound choice.
+ * 2. A `compound` change between consecutive laps — the fallback for
+ *    lap-times payloads that carry no stint, where a compound switch is the
+ *    only observable pit-stop boundary.
+ *
+ * A row whose `lap` is missing is skipped entirely, including for the
+ * purpose of updating the running "previous stint/compound" state — the
+ * Python original's `continue` has the same effect, so a gap in the data
+ * cannot itself manufacture a spurious pit event once real rows resume.
+ */
+export function detectPitLaps(rows: PitLapInput[], driver = ''): PitEvent[] {
+  const events: PitEvent[] = []
+  let prevStint: number | null = null
+  let prevCompound = ''
+
+  for (const row of rows) {
+    if (row.lap == null) continue
+    const stint = row.stint ?? null
+    const compound = (row.compound ?? '').toUpperCase()
+
+    const stintIncremented = stint !== null && prevStint !== null && stint > prevStint
+    const compoundChangedNoStint =
+      stint === null && prevCompound !== '' && compound !== '' && compound !== prevCompound
+
+    if ((stintIncremented || compoundChangedNoStint) && compound !== '') {
+      events.push({ lap: row.lap, compound, driver })
+    }
+
+    if (stint !== null) prevStint = stint
+    if (compound !== '') prevCompound = compound
+  }
+
+  return events
+}
+
+const DEFAULT_OUTLIER_RATIO = 1.15
+const MIN_SAMPLES_TO_MASK = 3
+
+/** Middle value of a numeric array (average of the two middle values on an
+ *  even-length array), matching Python's `statistics.median`. */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/**
+ * Replace pit-lap spikes with `null` so a chart draws a gap instead of
+ * squashing every racing lap into a sliver near the x-axis. A pit lap runs
+ * ~20s slower than a racing lap; any lap exceeding the driver's own median by
+ * more than `thresholdRatio` is treated as non-racing and masked. Below
+ * `MIN_SAMPLES_TO_MASK` valid samples the median itself would be unreliable,
+ * so the input is returned unchanged.
+ */
+export function maskPitLapOutliers(
+  lapTimes: Array<number | null | undefined>,
+  thresholdRatio = DEFAULT_OUTLIER_RATIO,
+): Array<number | null | undefined> {
+  const valid = lapTimes.filter((t): t is number => typeof t === 'number')
+  if (valid.length < MIN_SAMPLES_TO_MASK) return lapTimes
+
+  const cutoff = median(valid) * thresholdRatio
+  return lapTimes.map((t) => (typeof t === 'number' && t > cutoff ? null : t))
+}
+
+/**
+ * Align a delta series (e.g. pilot1 minus pilot2 lap time) onto an x-axis,
+ * borrowing the reference driver's own distance samples when present. Mirrors
+ * the Python original's `p1.get("distance", list(range(len(delta))))[:
+ * len(delta)]`: the range fallback only applies when `distance` is truly
+ * absent (`undefined`), never merely empty, and the result is never padded —
+ * a `distance` shorter than `delta` yields an x-axis shorter than the delta
+ * series itself, exactly as the Python slice does.
+ */
+export function alignDeltaX(distance: number[] | undefined, deltaLength: number): number[] {
+  const base = distance !== undefined ? distance : Array.from({ length: deltaLength }, (_, i) => i)
+  return base.slice(0, deltaLength)
+}


### PR DESCRIPTION
Closes #168

Renders each MCP tool's output INLINE in the chat thread (the spine of Chat).
- **C2 (renderers):** ToolResultCard is now a display_type + tool_name switch reusing the Race/Lab primitives — StatCard/RangeBar/Gauge (metrics), CompoundPill/ConfidenceDial/ActionBadge/ScenarioScoresChart (strategy_card), RadioResultCard (table), RagAnswerCard (text) — plus a tool-error card and tolerant payload parsing verified field-by-field against the real backend agent dataclasses (found predict_tire has no `confidence` today — read as optional/forward-compatible).
- **C3 (charts):** `features/chat/charts/` — an InlineChart host + four pure ECharts builders (get_lap_times / get_telemetry / compare_drivers / get_race_data) dispatched by tool name, lazily rendered on visibility; `lib/lapMarks.ts` ports pit-detection + outlier masking with parity tests vs the Python.

## Checks (central, Opus)
- `tsc -b` clean (fixed 2 `gridIndex`-on-series type errors in the compare builder — series bind to grids via xAxisIndex/yAxisIndex) · `npm run build` green (ChatPage 42 kB) · vitest 21/21 (incl. lapMarks parity) · prettier@3.9.5 (CI's pinned version) clean · oxlint clean · the C2→C3 InlineChart seam typechecks.
- Deferred: live-stream browser verify → C5.

Part of #39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rich chat result displays for metrics, strategies, tables, text responses, and charts.
  * Added interactive charts for lap times, telemetry, driver comparisons, race positions, and pit-stop insights.
  * Added specialized cards for pace predictions, situation analysis, tyre and pit strategies, recommendations, radio analysis, and regulations.
* **Bug Fixes**
  * Improved handling of malformed or unsupported results with safe raw-data fallbacks.
  * Added clear error cards for failed tool requests.
  * Improved chart loading performance with viewport-based rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->