### PR TITLE
feat(chat): Chat #39 C4 — sessions, reports, image attachments

### DIFF
--- a/webapp/src/features/chat/ChatPage.tsx
+++ b/webapp/src/features/chat/ChatPage.tsx
@@ -21,6 +21,10 @@ import { ToolBadge } from './components/ToolBadge'
 const routeApi = getRouteApi('/chat')
 const NO_MESSAGES: never[] = []
 
+/** Cmd/Ctrl+Shift+O — the "new chat" shortcut noted in the sidebar's own New
+ *  Chat button tooltip. */
+const NEW_CHAT_SHORTCUT_KEY = 'o'
+
 export function ChatPage() {
   const raw = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
@@ -30,6 +34,7 @@ export function ChatPage() {
   const storeActiveId = useChatStore((s) => s.activeChatId)
   const newChat = useChatStore((s) => s.newChat)
   const setActive = useChatStore((s) => s.setActive)
+  const deleteChat = useChatStore((s) => s.deleteChat)
 
   /** Apply a search patch and push it into the URL. No key here cascades off
    *  another (unlike Race/Lab), so a plain merge is enough — no
@@ -65,14 +70,53 @@ export function ChatPage() {
   const chatsList = useMemo(() => chatList(chats), [chats])
 
   const { turn, isStreaming, send, stop } = useChatStream(activeChatId)
-  const [draft, setDraft] = useState(search.ask ?? '')
+  const [draft, setDraft] = useState(() => search.ask ?? '')
+  const [attachment, setAttachment] = useState<string | null>(null)
 
   const health = useChatHealth()
 
+  // ?ask= deep-link prefill: the lazy initializer above already seeded
+  // `draft` from whatever `ask` was present on the FIRST render (no flash),
+  // so this mount-once effect only has to strip the param back out of the
+  // URL — a deep link never auto-sends, the user still presses Send once the
+  // composer is prefilled (same "never auto-fire" grammar as Race's `q`).
+  useEffect(() => {
+    if (search.ask != null) patch({ ask: undefined })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // New-chat keyboard shortcut, advertised on the sidebar's own button.
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const isShortcut =
+        event.shiftKey &&
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === NEW_CHAT_SHORTCUT_KEY
+      if (!isShortcut) return
+      event.preventDefault()
+      patch({ c: newChat() })
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   function handleSend() {
     if (!draft.trim()) return
-    send(draft)
+    send(draft, attachment ?? undefined)
     setDraft('')
+    setAttachment(null)
+  }
+
+  /** Delete a chat once the sidebar's undo window has elapsed. Reads the
+   *  store's LIVE `activeChatId` rather than closing over this render's
+   *  `activeChatId` — the sidebar's timer can fire seconds after the click,
+   *  by which point the user may have switched chats, and a stale check here
+   *  would navigate away from the wrong (still-open) chat. */
+  function handleDeleteChat(id: string) {
+    const wasActive = useChatStore.getState().activeChatId === id
+    deleteChat(id)
+    if (wasActive) patch({ c: newChat() })
   }
 
   const streamingFooter =
@@ -104,6 +148,7 @@ export function ChatPage() {
           onSelectChat={(id) => patch({ c: id })}
           onNewChat={() => patch({ c: newChat() })}
           onModeChange={(mode: ChatMode) => patch({ mode })}
+          onDeleteChat={handleDeleteChat}
         />
 
         <div className="flex min-h-0 flex-1 flex-col">
@@ -121,6 +166,8 @@ export function ChatPage() {
             onSend={handleSend}
             isStreaming={isStreaming}
             onStop={stop}
+            attachment={attachment}
+            onAttachmentChange={setAttachment}
           />
         </div>
       </div>

--- a/webapp/src/features/chat/components/AttachmentChip.tsx
+++ b/webapp/src/features/chat/components/AttachmentChip.tsx
@@ -1,0 +1,27 @@
+import { X } from 'lucide-react'
+
+export interface AttachmentChipProps {
+  src: string
+  onRemove: () => void
+}
+
+/**
+ * Removable thumbnail for the image queued on the composer's NEXT message.
+ * Shown only while composing — the image itself never re-appears on later
+ * turns once sent, since wire history stays text-only.
+ */
+export function AttachmentChip({ src, onRemove }: AttachmentChipProps) {
+  return (
+    <div className="flex w-fit items-center gap-2 rounded-lg border border-hairline bg-bg-3 p-1.5 pr-2">
+      <img src={src} alt="Attached image preview" className="size-10 rounded object-cover" />
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label="Remove attached image"
+        className="rounded p-1 text-fg-4 transition-colors hover:text-fg-1"
+      >
+        <X className="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/ChatSidebar.tsx
+++ b/webapp/src/features/chat/components/ChatSidebar.tsx
@@ -1,9 +1,13 @@
+import { useEffect, useRef, useState } from 'react'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/Button'
 import { Tabs, TabsList, TabsTrigger } from '@/components/Tabs'
-import { cn } from '@/lib/cn'
 import type { ChatMode } from '../search'
-import type { ChatSession } from '../store'
+import { useChatStore, type ChatSession } from '../store'
+import { ReportsPanel } from './ReportsPanel'
+import { SessionRow } from './SessionRow'
+
+const UNDO_WINDOW_MS = 5000
 
 export interface ChatSidebarProps {
   chats: ChatSession[]
@@ -12,14 +16,25 @@ export interface ChatSidebarProps {
   onSelectChat: (id: string) => void
   onNewChat: () => void
   onModeChange: (mode: ChatMode) => void
+  /** Fires once the delete is FINAL — after the undo window elapses, or
+   *  immediately if the sidebar unmounts mid-window. `ChatPage` owns what
+   *  "final" means for the URL (navigating away if this was the active chat),
+   *  so the sidebar never calls the store's `deleteChat` itself. */
+  onDeleteChat: (id: string) => void
+}
+
+interface PendingDelete {
+  id: string
+  title: string
 }
 
 /**
- * Chat history rail: the new-chat action, the conversation list, and the
- * text/voice mode toggle. Voice (#40) is reserved but disabled here — the
- * toggle exists from day one so the seam is visible in the UI, not so it does
- * anything yet. A reports panel belongs here too; it is built in C4, this
- * sprint just leaves the space for it.
+ * Chat history rail: the new-chat action, the conversation list (inline
+ * rename, delete with an undo window), the text/voice mode toggle, and the
+ * reports panel. Deleting a row hides it immediately but only calls
+ * `onDeleteChat` once `UNDO_WINDOW_MS` passes without the user clicking Undo —
+ * the chat's data is untouched in the store the whole time, so an Undo simply
+ * clears the pending timer and the row reappears.
  */
 export function ChatSidebar({
   chats,
@@ -28,13 +43,59 @@ export function ChatSidebar({
   onSelectChat,
   onNewChat,
   onModeChange,
+  onDeleteChat,
 }: ChatSidebarProps) {
+  const renameChat = useChatStore((s) => s.renameChat)
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null)
+  const pendingTimerRef = useRef<number | null>(null)
+  const pendingIdRef = useRef<string | null>(null)
+
+  function finalizeDelete(id: string) {
+    if (pendingTimerRef.current != null) window.clearTimeout(pendingTimerRef.current)
+    pendingTimerRef.current = null
+    pendingIdRef.current = null
+    setPendingDelete(null)
+    onDeleteChat(id)
+  }
+
+  function requestDelete(chat: ChatSession) {
+    // Only one delete is ever "pending" at a time — flush an earlier one
+    // immediately rather than losing track of its timer.
+    if (pendingIdRef.current) finalizeDelete(pendingIdRef.current)
+    pendingIdRef.current = chat.id
+    setPendingDelete({ id: chat.id, title: chat.title })
+    pendingTimerRef.current = window.setTimeout(() => finalizeDelete(chat.id), UNDO_WINDOW_MS)
+  }
+
+  function undoDelete() {
+    if (pendingTimerRef.current != null) window.clearTimeout(pendingTimerRef.current)
+    pendingTimerRef.current = null
+    pendingIdRef.current = null
+    setPendingDelete(null)
+  }
+
+  // Honor a still-pending delete if the sidebar unmounts mid-window (leaving
+  // the tab should not silently revive a chat the user already dismissed).
+  useEffect(() => {
+    return () => {
+      if (pendingIdRef.current != null) {
+        if (pendingTimerRef.current != null) window.clearTimeout(pendingTimerRef.current)
+        onDeleteChat(pendingIdRef.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const activeChat = chats.find((chat) => chat.id === activeChatId)
+  const visibleChats = chats.filter((chat) => chat.id !== pendingDelete?.id)
+
   return (
     <aside className="flex w-64 shrink-0 flex-col gap-3 border-r border-hairline bg-bg-1 p-3">
       <Button
         size="sm"
         variant="ghost"
         onClick={onNewChat}
+        title="New chat (Ctrl/Cmd+Shift+O)"
         className="justify-start gap-2 border border-hairline bg-bg-3"
       >
         <Plus className="size-4" aria-hidden="true" />
@@ -58,29 +119,32 @@ export function ChatSidebar({
       </Tabs>
 
       <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
-        {chats.length === 0 ? (
+        {visibleChats.length === 0 ? (
           <p className="px-3 py-2 text-xs text-fg-4">No conversations yet.</p>
         ) : (
-          chats.map((chat) => (
-            <button
+          visibleChats.map((chat) => (
+            <SessionRow
               key={chat.id}
-              type="button"
-              onClick={() => onSelectChat(chat.id)}
-              title={chat.title}
-              className={cn(
-                'truncate rounded-lg px-3 py-2 text-left text-sm transition-colors',
-                chat.id === activeChatId
-                  ? 'bg-bg-4 text-fg-1'
-                  : 'text-fg-3 hover:bg-bg-3 hover:text-fg-2',
-              )}
-            >
-              {chat.title}
-            </button>
+              chat={chat}
+              isActive={chat.id === activeChatId}
+              onSelect={() => onSelectChat(chat.id)}
+              onRename={(title) => renameChat(chat.id, title)}
+              onDeleteRequest={() => requestDelete(chat)}
+            />
           ))
         )}
+
+        {pendingDelete ? (
+          <div className="flex items-center justify-between gap-2 rounded-lg border border-hairline bg-bg-3 px-3 py-2 text-xs text-fg-3">
+            <span className="truncate">Deleted &quot;{pendingDelete.title}&quot;</span>
+            <Button size="sm" variant="ghost" onClick={undoDelete} className="h-6 px-2 text-xs">
+              Undo
+            </Button>
+          </div>
+        ) : null}
       </div>
 
-      {/* TODO(C4): ReportsPanel — one-click report generation + history. */}
+      <ReportsPanel activeChat={activeChat} />
     </aside>
   )
 }

--- a/webapp/src/features/chat/components/Composer.tsx
+++ b/webapp/src/features/chat/components/Composer.tsx
@@ -1,7 +1,11 @@
-import { useRef, type KeyboardEvent } from 'react'
+import { useRef, useState, type ClipboardEvent, type KeyboardEvent } from 'react'
 import { Paperclip, Send, Square } from 'lucide-react'
 import { Button } from '@/components/Button'
+import { FileDrop } from '@/components/FileDrop'
+import { useToast } from '@/components/Toast'
 import { cn } from '@/lib/cn'
+import { downscaleImageToDataUri, imageFromClipboard } from '../imageAttachment'
+import { AttachmentChip } from './AttachmentChip'
 
 const MAX_HEIGHT_PX = 160
 
@@ -12,6 +16,11 @@ export interface ComposerProps {
   isStreaming: boolean
   onStop: () => void
   disabled?: boolean
+  /** The downscaled data URI queued for the next send, or null when nothing
+   *  is attached. Controlled by the parent so `onSend` can read it alongside
+   *  `value` and clear both together once the turn is dispatched. */
+  attachment: string | null
+  onAttachmentChange: (dataUri: string | null) => void
 }
 
 /**
@@ -20,6 +29,11 @@ export interface ComposerProps {
  * While a turn is streaming the Send button swaps for a Stop button rather
  * than disabling the whole composer, since the user can keep typing the next
  * message while the current reply finishes.
+ *
+ * The paperclip toggles a compact `FileDrop` zone for picking or dragging an
+ * image; pasting an image directly into the textarea attaches it the same
+ * way, without needing to open the zone first. Either path downscales the
+ * file client-side before it ever becomes an attachment.
  */
 export function Composer({
   value,
@@ -28,14 +42,39 @@ export function Composer({
   isStreaming,
   onStop,
   disabled,
+  attachment,
+  onAttachmentChange,
 }: ComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [isPickingFile, setIsPickingFile] = useState(false)
+  const { toast } = useToast()
 
   function autosize() {
     const el = textareaRef.current
     if (!el) return
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT_PX)}px`
+  }
+
+  async function attachFile(file: File) {
+    try {
+      const dataUri = await downscaleImageToDataUri(file)
+      onAttachmentChange(dataUri)
+      setIsPickingFile(false)
+    } catch (error) {
+      toast({
+        title: 'Could not attach image',
+        description: error instanceof Error ? error.message : 'Unsupported file.',
+        tone: 'danger',
+      })
+    }
+  }
+
+  function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const file = imageFromClipboard(event.clipboardData)
+    if (!file) return
+    event.preventDefault()
+    void attachFile(file)
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -46,47 +85,64 @@ export function Composer({
   }
 
   return (
-    <div className="flex items-end gap-2 border-t border-hairline bg-bg-1 p-3">
-      <button
-        type="button"
-        disabled
-        title="Attach an image (coming soon)"
-        // TODO(C4): wire FileDrop image attach here — client-side downscale to
-        // <=768px JPEG, and thread it through the `image` field / the
-        // `_last_user_image` port so it never rides the text history instead
-        // (see the wire-history discipline in lib/api/chat.ts).
-        className="flex size-9 shrink-0 items-center justify-center rounded-lg text-fg-4 opacity-50"
-      >
-        <Paperclip className="size-4" aria-hidden="true" />
-      </button>
+    <div className="flex flex-col gap-2 border-t border-hairline bg-bg-1 p-3">
+      {isPickingFile && !attachment ? (
+        <FileDrop
+          accept="image/*"
+          onFile={(file) => void attachFile(file)}
+          label="Drop an image, or click to browse"
+          className="py-4"
+        />
+      ) : null}
 
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value)
-          autosize()
-        }}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        rows={1}
-        placeholder="Ask me anything about F1..."
-        className={cn(
-          'max-h-40 flex-1 resize-none rounded-xl border border-hairline bg-bg-2 px-3 py-2 text-sm text-fg-1',
-          'placeholder:text-fg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none',
-          disabled && 'opacity-50',
+      {attachment ? (
+        <AttachmentChip src={attachment} onRemove={() => onAttachmentChange(null)} />
+      ) : null}
+
+      <div className="flex items-end gap-2">
+        <button
+          type="button"
+          onClick={() => setIsPickingFile((v) => !v)}
+          title="Attach an image"
+          aria-pressed={isPickingFile}
+          className={cn(
+            'flex size-9 shrink-0 items-center justify-center rounded-lg text-fg-3 transition-colors',
+            'hover:bg-bg-3 hover:text-fg-1',
+            isPickingFile && 'bg-bg-3 text-fg-1',
+          )}
+        >
+          <Paperclip className="size-4" aria-hidden="true" />
+        </button>
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+            autosize()
+          }}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          disabled={disabled}
+          rows={1}
+          placeholder="Ask me anything about F1..."
+          className={cn(
+            'max-h-40 flex-1 resize-none rounded-xl border border-hairline bg-bg-2 px-3 py-2 text-sm text-fg-1',
+            'placeholder:text-fg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none',
+            disabled && 'opacity-50',
+          )}
+        />
+
+        {isStreaming ? (
+          <Button variant="danger" onClick={onStop} aria-label="Stop the response">
+            <Square className="size-4" aria-hidden="true" />
+          </Button>
+        ) : (
+          <Button onClick={onSend} disabled={disabled || !value.trim()} aria-label="Send message">
+            <Send className="size-4" aria-hidden="true" />
+          </Button>
         )}
-      />
-
-      {isStreaming ? (
-        <Button variant="danger" onClick={onStop} aria-label="Stop the response">
-          <Square className="size-4" aria-hidden="true" />
-        </Button>
-      ) : (
-        <Button onClick={onSend} disabled={disabled || !value.trim()} aria-label="Send message">
-          <Send className="size-4" aria-hidden="true" />
-        </Button>
-      )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/features/chat/components/MessageThread.tsx
+++ b/webapp/src/features/chat/components/MessageThread.tsx
@@ -103,6 +103,13 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           isUser ? 'bg-purple-600/90 text-fg-1' : 'border border-hairline bg-bg-3',
         )}
       >
+        {message.image ? (
+          <img
+            src={message.image}
+            alt="Attached image"
+            className={cn('max-w-full rounded-lg', message.content && 'mb-2')}
+          />
+        ) : null}
         {isUser ? (
           <p className="text-pretty">{message.content}</p>
         ) : (

--- a/webapp/src/features/chat/components/ReportsPanel.tsx
+++ b/webapp/src/features/chat/components/ReportsPanel.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import { Download, FileText, Loader2 } from 'lucide-react'
+import { Button } from '@/components/Button'
+import { useToast } from '@/components/Toast'
+import { buildReportHistory, generateReport } from '@/lib/api/chat'
+import { useChatStore, type ChatReport, type ChatSession } from '../store'
+
+export interface ReportsPanelProps {
+  activeChat?: ChatSession
+}
+
+/** Turn a report's title into a filesystem-safe basename, falling back to a
+ *  generic name when the title has nothing alphanumeric in it (an
+ *  auto-titled "New chat" that never got a first user message, say). */
+function reportFilename(report: ChatReport): string {
+  const slug = report.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return `${slug || 'chat-report'}.md`
+}
+
+/** Trigger a browser download of a saved report as a `.md` file — no viewer
+ *  UI exists yet, so "re-open" a report today means downloading it again. */
+function downloadReport(report: ChatReport): void {
+  const blob = new Blob([report.content], { type: 'text/markdown' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = reportFilename(report)
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * One-click "summarise this conversation" report, plus the list of
+ * previously generated reports (parity: Streamlit's report drawer,
+ * `frontend/pages/chat.py:382-423`). Hits the non-streaming
+ * `/chat/tool-message` endpoint directly rather than going through
+ * `useChatStream` — a report is a single JSON response, not an SSE turn.
+ */
+export function ReportsPanel({ activeChat }: ReportsPanelProps) {
+  const [isGenerating, setIsGenerating] = useState(false)
+  const reports = useChatStore((s) => s.reports)
+  const addReport = useChatStore((s) => s.addReport)
+  const { toast } = useToast()
+
+  const canGenerate = Boolean(activeChat && activeChat.messages.length > 0) && !isGenerating
+
+  async function handleGenerate() {
+    if (!activeChat) return
+    setIsGenerating(true)
+    try {
+      const chatHistory = buildReportHistory(activeChat.messages)
+      const content = await generateReport({ chatHistory })
+      const report: ChatReport = {
+        id: crypto.randomUUID(),
+        chatId: activeChat.id,
+        title: activeChat.title,
+        content,
+        createdAt: Date.now(),
+      }
+      addReport(report)
+      toast({ title: 'Report generated', description: `Saved "${report.title}".`, tone: 'success' })
+    } catch (error) {
+      toast({
+        title: 'Report generation failed',
+        description: error instanceof Error ? error.message : 'Could not reach the backend.',
+        tone: 'danger',
+      })
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-hairline pt-3">
+      <span className="px-1 text-xs font-medium tracking-wide text-fg-4 uppercase">Reports</span>
+
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => void handleGenerate()}
+        disabled={!canGenerate}
+        className="justify-start gap-2 border border-hairline bg-bg-3"
+      >
+        {isGenerating ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <FileText className="size-4" aria-hidden="true" />
+        )}
+        {isGenerating ? 'Generating…' : 'Generate report'}
+      </Button>
+
+      {reports.length > 0 ? (
+        <div className="flex max-h-32 flex-col gap-0.5 overflow-y-auto">
+          {reports.map((report) => (
+            <button
+              key={report.id}
+              type="button"
+              onClick={() => downloadReport(report)}
+              title={`Download "${report.title}"`}
+              className="flex items-center gap-2 truncate rounded-lg px-2 py-1.5 text-left text-xs text-fg-3 transition-colors hover:bg-bg-3 hover:text-fg-1"
+            >
+              <Download className="size-3 shrink-0" aria-hidden="true" />
+              <span className="truncate">{report.title}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/webapp/src/features/chat/components/SessionRow.tsx
+++ b/webapp/src/features/chat/components/SessionRow.tsx
@@ -1,0 +1,100 @@
+import { useState, type KeyboardEvent } from 'react'
+import { Pencil, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/cn'
+import type { ChatSession } from '../store'
+
+export interface SessionRowProps {
+  chat: ChatSession
+  isActive: boolean
+  onSelect: () => void
+  onRename: (title: string) => void
+  onDeleteRequest: () => void
+}
+
+/**
+ * One row in the chat history list: click the title to switch, a pencil to
+ * rename in place, a trash icon to request deletion. The row only REPORTS a
+ * delete request — `ChatSidebar` owns the undo window, so a row never removes
+ * itself. Rename/delete controls stay hidden until hover/focus so the list
+ * reads as plain chat titles at rest.
+ */
+export function SessionRow({
+  chat,
+  isActive,
+  onSelect,
+  onRename,
+  onDeleteRequest,
+}: SessionRowProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draftTitle, setDraftTitle] = useState(chat.title)
+
+  function startEditing() {
+    setDraftTitle(chat.title)
+    setIsEditing(true)
+  }
+
+  function commitRename() {
+    const trimmed = draftTitle.trim()
+    if (trimmed && trimmed !== chat.title) onRename(trimmed)
+    setIsEditing(false)
+  }
+
+  function handleTitleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') commitRename()
+    if (event.key === 'Escape') {
+      setDraftTitle(chat.title)
+      setIsEditing(false)
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <input
+        autoFocus
+        value={draftTitle}
+        onChange={(e) => setDraftTitle(e.target.value)}
+        onBlur={commitRename}
+        onKeyDown={handleTitleKeyDown}
+        aria-label={`Rename "${chat.title}"`}
+        className="rounded-lg border border-purple-400 bg-bg-2 px-3 py-2 text-sm text-fg-1 outline-none"
+      />
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-1 rounded-lg pr-1 transition-colors',
+        isActive ? 'bg-bg-4' : 'hover:bg-bg-3',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        title={chat.title}
+        className={cn(
+          'min-w-0 flex-1 truncate px-3 py-2 text-left text-sm',
+          isActive ? 'text-fg-1' : 'text-fg-3 group-hover:text-fg-2',
+        )}
+      >
+        {chat.title}
+      </button>
+      <button
+        type="button"
+        onClick={startEditing}
+        aria-label={`Rename "${chat.title}"`}
+        className="rounded p-1.5 text-fg-4 opacity-0 transition-opacity hover:text-fg-1 group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        <Pencil className="size-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={onDeleteRequest}
+        aria-label={`Delete "${chat.title}"`}
+        className="rounded p-1.5 text-fg-4 opacity-0 transition-opacity hover:text-danger group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        <Trash2 className="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/webapp/src/features/chat/imageAttachment.ts
+++ b/webapp/src/features/chat/imageAttachment.ts
@@ -1,0 +1,54 @@
+// Client-side image downscale for chat attachments. Mirrors the rationale
+// Streamlit's chart-to-image helper documents for the vision model
+// (`frontend/utils/chat_navigation.py:75-97` — Qwen3-VL's optimal detection
+// range tops out well below a raw phone-camera photo, and a smaller JPEG also
+// means fewer prompt tokens). Kept as a pure, testable module separate from
+// the composer's UI wiring — no image library, just a <canvas>.
+
+export const MAX_ATTACHMENT_EDGE_PX = 768
+const JPEG_QUALITY = 0.85
+
+/** True for a file the browser would actually let `createImageBitmap` decode
+ *  — guards against a renamed non-image slipping past a drag-drop, which
+ *  bypasses the `<input accept="image/*">` picker's own filtering. */
+function isImageFile(file: File): boolean {
+  return file.type.startsWith('image/')
+}
+
+/**
+ * Downscale an image file to a JPEG data URI whose longest edge is at most
+ * `maxEdge` pixels, preserving aspect ratio. Images already smaller than
+ * `maxEdge` are re-encoded but never upscaled.
+ */
+export async function downscaleImageToDataUri(
+  file: File,
+  maxEdge: number = MAX_ATTACHMENT_EDGE_PX,
+): Promise<string> {
+  if (!isImageFile(file)) {
+    throw new Error(`"${file.name}" is not an image file.`)
+  }
+
+  const bitmap = await createImageBitmap(file)
+  try {
+    const scale = Math.min(1, maxEdge / Math.max(bitmap.width, bitmap.height))
+    const width = Math.max(1, Math.round(bitmap.width * scale))
+    const height = Math.max(1, Math.round(bitmap.height * scale))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas 2D context unavailable for image downscale.')
+    ctx.drawImage(bitmap, 0, 0, width, height)
+
+    return canvas.toDataURL('image/jpeg', JPEG_QUALITY)
+  } finally {
+    bitmap.close()
+  }
+}
+
+/** Pull the first pasted image out of a clipboard event's files, or undefined
+ *  if the clipboard held no image (a plain text paste, for instance). */
+export function imageFromClipboard(data: DataTransfer): File | undefined {
+  return Array.from(data.files).find(isImageFile)
+}

--- a/webapp/src/features/chat/store.ts
+++ b/webapp/src/features/chat/store.ts
@@ -19,6 +19,13 @@ export interface ChatMessage {
   type: ChatMessageType
   content: string
   toolResult?: ToolResult
+  /** Data-URI thumbnail of an image the user attached to THIS message.
+   *  Kept in memory for the running session (so a sent attachment stays
+   *  visible in the thread) but stripped before the store persists to
+   *  localStorage — see `withoutImages` below — and never mirrored into wire
+   *  history; the backend only ever sees the CURRENT turn's attachment via
+   *  the request's own `image` field, never through this stored copy. */
+  image?: string
   /** Set once the turn's `done` event lands — only ever present on the
    *  streaming assistant text message, never on a tool_result message. */
   model?: string
@@ -152,15 +159,39 @@ export const useChatStore = create<ChatState>()(
     }),
     {
       name: 'f1sl.chat',
-      // TODO(C4): swap to an idb-keyval storage adapter once image attachments
-      // land — a data-URI image (~100-250 kB) risks blowing the ~5 MB
-      // localStorage quota across many saved chats. Text-only chats are fine
-      // on the default adapter.
+      // Image attachments stay on localStorage (no new dependency) rather than
+      // an IndexedDB adapter: `partialize` strips each message's `image` data
+      // URI before it hits disk (see `withoutImages`), so the quota risk a
+      // photo-heavy chat would otherwise pose never materializes. The
+      // attachment IS visible in the thread for the running session — only a
+      // page reload loses it.
+      // TODO: IndexedDB (idb-keyval) if image history must survive reloads.
       storage: createJSONStorage(() => localStorage),
-      partialize: (s) => ({ chats: s.chats, activeChatId: s.activeChatId, reports: s.reports }),
+      partialize: (s) => ({
+        chats: Object.fromEntries(
+          Object.entries(s.chats).map(([id, chat]) => [id, withoutImages(chat)]),
+        ),
+        activeChatId: s.activeChatId,
+        reports: s.reports,
+      }),
     },
   ),
 )
+
+/** Drop the `image` data URI from every message of a chat before it is
+ *  persisted (see the `partialize` option above). Only allocates a new
+ *  message object for the ones that actually carry an image, so a text-only
+ *  chat — the common case — persists with no extra copying. */
+function withoutImages(chat: ChatSession): ChatSession {
+  return {
+    ...chat,
+    messages: chat.messages.map((message) => {
+      if (!message.image) return message
+      const { id, role, type, content, toolResult, model, tokens, ts } = message
+      return { id, role, type, content, toolResult, model, tokens, ts }
+    }),
+  }
+}
 
 /** The last-activity timestamp for a chat: its newest message, or its creation
  *  time for a chat with none yet. */

--- a/webapp/src/features/chat/useChatStream.ts
+++ b/webapp/src/features/chat/useChatStream.ts
@@ -144,7 +144,10 @@ export interface UseChatStreamResult {
    *  CONTENT itself lives in the store and needs no separate draft to render. */
   turn: ActiveTurn | null
   isStreaming: boolean
-  send: (text: string) => void
+  /** `image` is a data URI already downscaled by the composer — it rides in
+   *  the request's own `image` field, never in wire history, and is attached
+   *  to the optimistic user message purely for the thread to render it back. */
+  send: (text: string, image?: string) => void
   stop: () => void
 }
 
@@ -224,7 +227,7 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
   )
 
   const send = useCallback(
-    (text: string) => {
+    (text: string, image?: string) => {
       const trimmed = text.trim()
       if (!trimmed || !chatId || turn?.status === 'streaming') return
 
@@ -234,6 +237,7 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
         role: 'user',
         type: 'text',
         content: trimmed,
+        ...(image ? { image } : {}),
         ts: Date.now(),
       })
 
@@ -247,6 +251,7 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
       const body: ToolMessageRequestBody = {
         text: trimmed,
         chat_history: buildWireHistory(priorMessages),
+        ...(image ? { image } : {}),
       }
 
       sendChatTurn(body, { onEvent: handleEvent, signal: controller.signal })

--- a/webapp/src/lib/api/chat.ts
+++ b/webapp/src/lib/api/chat.ts
@@ -181,6 +181,10 @@ export interface HistorySourceMessage {
   role: 'user' | 'assistant'
   type: 'text' | 'tool_result'
   content: string
+  /** Present only on a `tool_result` message. `buildWireHistory` ignores it (a
+   *  live turn's own `chat_history` stays text-only); `buildReportHistory`
+   *  reads it to fold the tool run into a one-line summary. */
+  toolResult?: { tool_name: string }
 }
 
 /**
@@ -198,4 +202,85 @@ export function buildWireHistory(messages: HistorySourceMessage[]): WireChatMess
     .filter((m) => m.type === 'text' && m.content.trim() !== '')
     .map((m): WireChatMessage => ({ role: m.role, content: m.content.slice(0, MAX_MESSAGE_CHARS) }))
   return textOnly.slice(-MAX_HISTORY_MESSAGES)
+}
+
+// ── Report generation ────────────────────────────────────────────────────────
+
+const REPORT_INSTRUCTION =
+  'Generate a comprehensive Markdown summary report of our conversation, with ' +
+  'sections for the questions asked, the data analysed, and the strategic ' +
+  'conclusions reached.'
+
+/** Requested `max_tokens` for a report: the backend clamps every
+ *  `ToolMessageRequest` to `F1_CHAT_MAX_TOKENS` (2048 by default,
+ *  `backend/core/config.py:60,79-81`) regardless of what is asked for here.
+ *  Requesting 4000 anyway matches the Streamlit report flow's own request
+ *  (`chat_service.py:415`) and costs nothing if that ceiling is ever raised. */
+const REPORT_MAX_TOKENS = 4000
+const REPORT_TEMPERATURE = 0.4
+
+/**
+ * Build the `chat_history` for a one-shot report request. Unlike
+ * `buildWireHistory` (which drops `tool_result` entries entirely — dead weight
+ * server-side for a live turn), a report is SUPPOSED to summarise "the data
+ * analysed", so each past tool run is folded into a short assistant line
+ * ("[predict_tire] MEDIUM, cliff ~L34, ..."). Without this, `generate_report`
+ * still only ever sees prose: `build_messages` drops raw `tool_result` entries
+ * either way (`llm_service.py:499`), so nothing else describes what ran.
+ */
+export function buildReportHistory(messages: HistorySourceMessage[]): WireChatMessage[] {
+  const withToolLines = messages.flatMap((m): WireChatMessage[] => {
+    if (m.type === 'tool_result' && m.toolResult && m.content.trim() !== '') {
+      return [{ role: 'assistant', content: `[${m.toolResult.tool_name}] ${m.content}` }]
+    }
+    if (m.type === 'text' && m.content.trim() !== '') {
+      return [{ role: m.role, content: m.content.slice(0, MAX_MESSAGE_CHARS) }]
+    }
+    return []
+  })
+  return withToolLines.slice(-MAX_HISTORY_MESSAGES)
+}
+
+export interface GenerateReportOptions {
+  chatHistory: WireChatMessage[]
+  context?: ChatContextPayload
+  signal?: AbortSignal
+}
+
+/** Parse `/chat/tool-message`'s JSON body, throwing a readable message on a
+ *  non-2xx response (mirrors FastAPI's `{detail}` error shape). */
+async function parseReportResponse(res: Response): Promise<string> {
+  const body: unknown = await res.json().catch(() => null)
+  if (!res.ok) {
+    const detail = (body as { detail?: unknown } | null)?.detail
+    throw new Error(typeof detail === 'string' ? detail : `Report request failed (${res.status})`)
+  }
+  const response = (body as { response?: string } | null)?.response
+  return response?.trim() ? response : 'The model returned an empty report.'
+}
+
+/**
+ * One-click chat report: the NON-streaming `/chat/tool-message` endpoint,
+ * instructed to summarise the conversation (parity: Streamlit's
+ * `generate_report`, `chat_service.py:380-425`). A single JSON response, not
+ * an SSE turn, so this bypasses `sendChatTurn`/`postStream` entirely.
+ */
+export async function generateReport({
+  chatHistory,
+  context,
+  signal,
+}: GenerateReportOptions): Promise<string> {
+  const res = await fetch('/api/v1/chat/tool-message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      text: REPORT_INSTRUCTION,
+      chat_history: chatHistory,
+      context: context ?? {},
+      temperature: REPORT_TEMPERATURE,
+      max_tokens: REPORT_MAX_TOKENS,
+    } satisfies ToolMessageRequestBody),
+    signal,
+  })
+  return parseReportResponse(res)
 }


### PR DESCRIPTION
Closes #170

- **Sessions:** New chat, list, inline rename, delete-with-undo (5s), URL-synced active chat, Ctrl/Cmd+Shift+O.
- **Reports:** ReportsPanel + one-click report composing history WITH per-tool summary lines (fixes the server dropping raw tool_results) → POST /chat/tool-message → saved (cap 20) + Markdown download.
- **Attachments:** paperclip/paste → canvas downscale <=768px JPEG → next turn's image field only (never wire history) → stripped from persisted state (no new dep; IndexedDB deferred).
- ?ask= deep-link prefill (no auto-send).

Checks: tsc/build green (ChatPage 50 kB), vitest 11/11, prettier@3.9.5 on changed files. Part of #39.