### PR TITLE
fix(chat): Chat #39 C5 — adversarial bug-audit fixes (7)

### DIFF
--- a/webapp/src/features/chat/ChatPage.tsx
+++ b/webapp/src/features/chat/ChatPage.tsx
@@ -69,7 +69,7 @@ export function ChatPage() {
   const messages = activeChat?.messages ?? NO_MESSAGES
   const chatsList = useMemo(() => chatList(chats), [chats])
 
-  const { turn, isStreaming, send, stop } = useChatStream(activeChatId)
+  const { turn, turnChatId, isStreaming, send, stop } = useChatStream(activeChatId)
   const [draft, setDraft] = useState(() => search.ask ?? '')
   const [attachment, setAttachment] = useState<string | null>(null)
 
@@ -102,7 +102,10 @@ export function ChatPage() {
   }, [])
 
   function handleSend() {
-    if (!draft.trim()) return
+    // While a reply streams the user can keep TYPING the next message, but
+    // Enter must not clear it: `send` would reject the turn (one stream at a
+    // time) and wiping the draft here would silently lose the text.
+    if (!draft.trim() || isStreaming) return
     send(draft, attachment ?? undefined)
     setDraft('')
     setAttachment(null)
@@ -119,8 +122,11 @@ export function ChatPage() {
     if (wasActive) patch({ c: newChat() })
   }
 
+  // Gate on `turnChatId`: a turn keeps streaming into the chat it STARTED in
+  // even if the user switches conversations mid-stream, and its stage ticker
+  // must not appear inside an unrelated thread.
   const streamingFooter =
-    turn && turn.status === 'streaming' ? (
+    turn && turn.status === 'streaming' && turnChatId === activeChatId ? (
       <div className="flex items-center gap-2 px-1 py-2">
         <span className="size-1.5 animate-pulse rounded-full bg-purple-400" aria-hidden="true" />
         <span className="text-xs text-fg-3">{turn.stageLabel}</span>

--- a/webapp/src/features/chat/charts/buildLapTimesOption.ts
+++ b/webapp/src/features/chat/charts/buildLapTimesOption.ts
@@ -37,7 +37,11 @@ function parseLapTimeRecords(data: unknown): LapTimeRecord[] | null {
       lapNumber,
       lapTime: asNumberOrNull(row.lap_time),
       isValid: asBoolean(row.is_valid, true),
-      compound: asString(row.compound, '').toUpperCase() || 'UNK',
+      // Left empty (never defaulted) when absent: the pit detector's
+      // compound-change signal skips empty values, exactly like the Python
+      // detector reading the raw row — a placeholder here would manufacture
+      // a phantom pit line at every gap in the compound data.
+      compound: asString(row.compound, '').toUpperCase(),
     })
   }
   return records

--- a/webapp/src/features/chat/charts/buildRaceDataOptions.ts
+++ b/webapp/src/features/chat/charts/buildRaceDataOptions.ts
@@ -39,7 +39,10 @@ function parseRaceDataRows(data: unknown): RaceDataRow[] | null {
       lapNumber,
       position: asNumberOrNull(row.Position),
       lapTime: asNumberOrNull(row.LapTime_s),
-      compound: asString(row.Compound, '').toUpperCase() || 'UNK',
+      // Left empty (never defaulted) when absent so the pit detector's
+      // compound-change signal skips it, matching the Python detector's
+      // raw-row read — a placeholder would manufacture phantom pit lines.
+      compound: asString(row.Compound, '').toUpperCase(),
       stint: asNumberOrNull(row.Stint),
     })
   }

--- a/webapp/src/features/chat/useChatStream.ts
+++ b/webapp/src/features/chat/useChatStream.ts
@@ -8,6 +8,7 @@ import {
   type ToolResult,
 } from '@/lib/api/chat'
 import { useToast } from '@/components/Toast'
+import { isToolError } from './components/toolResultParsing'
 import { stageLabel, toolNameFromStage } from './stageLabels'
 import { useChatStore, type ChatMessage } from './store'
 
@@ -79,7 +80,9 @@ export function applyStreamEvent(turn: ActiveTurn, event: ChatStreamEvent): Acti
       }
     }
     case 'tool_result': {
-      const hasError = 'error' in event.toolResult.data
+      // Same detector ToolResultCard routes on — a successful payload that
+      // merely CONTAINS an `error`-named field must not flip the badge red.
+      const hasError = isToolError(event.toolResult.data)
       return {
         ...turn,
         toolResultMessage: newToolResultMessage(event.toolResult),
@@ -143,6 +146,11 @@ export interface UseChatStreamResult {
    *  first message. Drives the ticker (stage label + tool badge) — message
    *  CONTENT itself lives in the store and needs no separate draft to render. */
   turn: ActiveTurn | null
+  /** Which chat `turn` belongs to. The hook survives a mid-stream chat switch
+   *  (tokens keep landing in the chat the turn started in), so the page must
+   *  compare this against the ACTIVE chat before rendering the ticker — the
+   *  stage line for chat A must not appear inside chat B's thread. */
+  turnChatId?: string
   isStreaming: boolean
   /** `image` is a data URI already downscaled by the composer — it rides in
    *  the request's own `image` field, never in wire history, and is attached
@@ -161,6 +169,7 @@ export interface UseChatStreamResult {
 export function useChatStream(chatId: string | undefined): UseChatStreamResult {
   const [turn, setTurn] = useState<ActiveTurn | null>(null)
   const turnRef = useRef<ActiveTurn>(createActiveTurn())
+  const turnChatIdRef = useRef<string | undefined>(undefined)
   const assistantMessageIdRef = useRef<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const { toast } = useToast()
@@ -219,6 +228,11 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
       } else if (turnRef.current.status !== 'error' && isEmptyTurn(turnRef.current)) {
         turnRef.current = { ...turnRef.current, status: 'error' }
         commitAssistantDelta(EMPTY_STREAM_NOTICE)
+      } else if (turnRef.current.status === 'streaming') {
+        // The server closed the stream without a `done` frame (proxy drop,
+        // backend crash after some tokens landed): the turn is over — never
+        // leave the composer stuck on a Stop button for a dead connection.
+        turnRef.current = { ...turnRef.current, status: 'done' }
       }
       setTurn(turnRef.current)
       abortRef.current = null
@@ -229,7 +243,10 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
   const send = useCallback(
     (text: string, image?: string) => {
       const trimmed = text.trim()
-      if (!trimmed || !chatId || turn?.status === 'streaming') return
+      // `abortRef` is the synchronous in-flight guard: the `turn` state check
+      // alone is stale for a same-tick double invoke (state updates are async)
+      // and two concurrent streams would interleave into the shared refs.
+      if (!trimmed || !chatId || abortRef.current || turn?.status === 'streaming') return
 
       const priorMessages = useChatStore.getState().chats[chatId]?.messages ?? []
       appendMessage(chatId, {
@@ -242,6 +259,7 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
       })
 
       turnRef.current = createActiveTurn()
+      turnChatIdRef.current = chatId
       assistantMessageIdRef.current = null
       setTurn(turnRef.current)
 
@@ -279,5 +297,11 @@ export function useChatStream(chatId: string | undefined): UseChatStreamResult {
     abortRef.current?.abort()
   }, [])
 
-  return { turn, isStreaming: turn?.status === 'streaming', send, stop }
+  return {
+    turn,
+    turnChatId: turnChatIdRef.current,
+    isStreaming: turn?.status === 'streaming',
+    send,
+    stop,
+  }
 }

--- a/webapp/src/lib/api/chat.ts
+++ b/webapp/src/lib/api/chat.ts
@@ -115,17 +115,32 @@ function toToolResult(raw: unknown): ToolResult | null {
   }
 }
 
+/** Parse a frame's JSON payload, tolerating the bare `NaN`/`Infinity` literals
+ *  Python's `json.dumps` emits for non-finite floats (predict_pace's
+ *  `delta_vs_median` is documented NaN at new circuits) — strictly invalid
+ *  JSON that would otherwise silently drop the whole tool_result frame. The
+ *  strict parse runs first, so well-formed frames never pay for the fallback;
+ *  the sanitized retry nulls those literals out instead of losing the frame. */
+function parseFramePayload(raw: string): Record<string, unknown> | null {
+  try {
+    return asRecord(JSON.parse(raw))
+  } catch {
+    try {
+      const sanitized = raw.replace(/-?\bInfinity\b/g, 'null').replace(/\bNaN\b/g, 'null')
+      return asRecord(JSON.parse(sanitized))
+    } catch {
+      return null
+    }
+  }
+}
+
 /** Parse one raw SSE frame into a typed `ChatStreamEvent`, or null for a frame
  *  this client does not understand (an unrecognised event name, or a payload
  *  missing its required fields) — dropped rather than thrown, so one bad frame
  *  cannot tear down an otherwise-good turn. */
 function parseChatFrame(message: EventSourceMessage): ChatStreamEvent | null {
-  let payload: Record<string, unknown>
-  try {
-    payload = asRecord(JSON.parse(message.data))
-  } catch {
-    return null
-  }
+  const payload = parseFramePayload(message.data)
+  if (payload == null) return null
   switch (message.event) {
     case 'stage':
       return typeof payload.stage === 'string' ? { event: 'stage', stage: payload.stage } : null
@@ -183,8 +198,9 @@ export interface HistorySourceMessage {
   content: string
   /** Present only on a `tool_result` message. `buildWireHistory` ignores it (a
    *  live turn's own `chat_history` stays text-only); `buildReportHistory`
-   *  reads it to fold the tool run into a one-line summary. */
-  toolResult?: { tool_name: string }
+   *  reads it to fold the tool run into a one-line summary, falling back to
+   *  `data` because the engine only fills the summary field on a FAILED call. */
+  toolResult?: { tool_name: string; data?: Record<string, unknown> }
 }
 
 /**
@@ -219,19 +235,39 @@ const REPORT_INSTRUCTION =
 const REPORT_MAX_TOKENS = 4000
 const REPORT_TEMPERATURE = 0.4
 
+/** One chat bubble's worth of raw tool output is plenty of report evidence —
+ *  chart payloads (race_data et al.) run to hundreds of rows otherwise. */
+const TOOL_LINE_MAX_CHARS = 600
+
+/** The evidence line for one past tool run: the engine's own summary when it
+ *  sent one, otherwise the (truncated) raw data. The fallback is load-bearing,
+ *  not defensive: the engine sets `summary: tool_error or ""` — it is ONLY
+ *  ever non-empty on a failed call — so without reading `data` no successful
+ *  tool run would ever reach the report at all. */
+function toolEvidenceLine(m: HistorySourceMessage): string {
+  const summary = m.content.trim()
+  if (summary !== '') return summary
+  const data = m.toolResult?.data
+  if (!data || Object.keys(data).length === 0) return ''
+  return JSON.stringify(data).slice(0, TOOL_LINE_MAX_CHARS)
+}
+
 /**
  * Build the `chat_history` for a one-shot report request. Unlike
  * `buildWireHistory` (which drops `tool_result` entries entirely — dead weight
  * server-side for a live turn), a report is SUPPOSED to summarise "the data
  * analysed", so each past tool run is folded into a short assistant line
- * ("[predict_tire] MEDIUM, cliff ~L34, ..."). Without this, `generate_report`
+ * ("[predict_tire] {...deg_rate, cliff...}"). Without this, `generate_report`
  * still only ever sees prose: `build_messages` drops raw `tool_result` entries
  * either way (`llm_service.py:499`), so nothing else describes what ran.
  */
 export function buildReportHistory(messages: HistorySourceMessage[]): WireChatMessage[] {
   const withToolLines = messages.flatMap((m): WireChatMessage[] => {
-    if (m.type === 'tool_result' && m.toolResult && m.content.trim() !== '') {
-      return [{ role: 'assistant', content: `[${m.toolResult.tool_name}] ${m.content}` }]
+    if (m.type === 'tool_result' && m.toolResult) {
+      const evidence = toolEvidenceLine(m)
+      return evidence !== ''
+        ? [{ role: 'assistant', content: `[${m.toolResult.tool_name}] ${evidence}` }]
+        : []
     }
     if (m.type === 'text' && m.content.trim() !== '') {
       return [{ role: m.role, content: m.content.slice(0, MAX_MESSAGE_CHARS) }]


### PR DESCRIPTION
Closes #172

Adversarial audit of the combined Chat build (C1-C4). 7 fixes (3 HIGH), all surgical.
- **HIGH** reports never saw successful tool runs (backend sets `summary` only on failure) → JSON evidence line.
- **HIGH** NaN/Infinity in a Phase-1 payload dropped the whole SSE frame (JSON.parse) → sanitized retry.
- **HIGH** stream truncated without `done` left the turn streaming forever → final branch forces done.
- **MEDIUM** Enter mid-stream cleared the draft; same-tick double-send race; stage ticker bled to the wrong chat; 'UNK' compound default made phantom pit lines. **LOW** badge error-detector.

Backend root causes of the two HIGH bugs (non-finite floats in `_sse`; `summary` unset on success) flagged for a follow-up backend issue.

Checks: tsc/build green, vitest 28/28, prettier@3.9.5 + oxlint clean. Part of #39.