### PR TITLE
fix(chat): Chat #39 — stream auto-scroll, remove chart maximize, UI polish

### DIFF
--- a/webapp/src/features/chat/charts/InlineChart.tsx
+++ b/webapp/src/features/chat/charts/InlineChart.tsx
@@ -97,7 +97,7 @@ function ChartedPane({ option, title }: { option: EChartsOption; title: string }
   const chartTheme = useChartTheme()
   const paintedOption = useFirstPaintAnimation(option)
   return (
-    <ChartCard title={title}>
+    <ChartCard title={title} maximizable={false}>
       <div role="img" aria-label={title}>
         <ReactECharts
           theme={chartTheme}

--- a/webapp/src/features/chat/components/ChatSidebar.tsx
+++ b/webapp/src/features/chat/components/ChatSidebar.tsx
@@ -96,9 +96,9 @@ export function ChatSidebar({
         variant="ghost"
         onClick={onNewChat}
         title="New chat (Ctrl/Cmd+Shift+O)"
-        className="justify-start gap-2 border border-hairline bg-bg-3"
+        className="justify-start gap-2 border border-hairline bg-bg-3 text-fg-1"
       >
-        <Plus className="size-4" aria-hidden="true" />
+        <Plus className="size-4 text-purple-300" aria-hidden="true" />
         New chat
       </Button>
 

--- a/webapp/src/features/chat/components/Composer.tsx
+++ b/webapp/src/features/chat/components/Composer.tsx
@@ -85,63 +85,67 @@ export function Composer({
   }
 
   return (
-    <div className="flex flex-col gap-2 border-t border-hairline bg-bg-1 p-3">
-      {isPickingFile && !attachment ? (
-        <FileDrop
-          accept="image/*"
-          onFile={(file) => void attachFile(file)}
-          label="Drop an image, or click to browse"
-          className="py-4"
-        />
-      ) : null}
+    <div className="border-t border-hairline bg-bg-1 p-3">
+      {/* Shares the thread's centered reading column so the input lines up
+          with the prose above it instead of stretching edge to edge. */}
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2">
+        {isPickingFile && !attachment ? (
+          <FileDrop
+            accept="image/*"
+            onFile={(file) => void attachFile(file)}
+            label="Drop an image, or click to browse"
+            className="py-4"
+          />
+        ) : null}
 
-      {attachment ? (
-        <AttachmentChip src={attachment} onRemove={() => onAttachmentChange(null)} />
-      ) : null}
+        {attachment ? (
+          <AttachmentChip src={attachment} onRemove={() => onAttachmentChange(null)} />
+        ) : null}
 
-      <div className="flex items-end gap-2">
-        <button
-          type="button"
-          onClick={() => setIsPickingFile((v) => !v)}
-          title="Attach an image"
-          aria-pressed={isPickingFile}
-          className={cn(
-            'flex size-9 shrink-0 items-center justify-center rounded-lg text-fg-3 transition-colors',
-            'hover:bg-bg-3 hover:text-fg-1',
-            isPickingFile && 'bg-bg-3 text-fg-1',
+        <div className="flex items-end gap-2">
+          <button
+            type="button"
+            onClick={() => setIsPickingFile((v) => !v)}
+            title="Attach an image"
+            aria-pressed={isPickingFile}
+            className={cn(
+              'flex size-9 shrink-0 items-center justify-center rounded-lg text-fg-3 transition-colors',
+              'hover:bg-bg-3 hover:text-fg-1',
+              isPickingFile && 'bg-bg-3 text-fg-1',
+            )}
+          >
+            <Paperclip className="size-4" aria-hidden="true" />
+          </button>
+
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => {
+              onChange(e.target.value)
+              autosize()
+            }}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            disabled={disabled}
+            rows={1}
+            placeholder="Ask the pit wall anything about F1..."
+            className={cn(
+              'max-h-40 flex-1 resize-none rounded-xl border border-hairline bg-bg-2 px-3 py-2 text-sm text-fg-1',
+              'placeholder:text-fg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none',
+              disabled && 'opacity-50',
+            )}
+          />
+
+          {isStreaming ? (
+            <Button variant="danger" onClick={onStop} aria-label="Stop the response">
+              <Square className="size-4" aria-hidden="true" />
+            </Button>
+          ) : (
+            <Button onClick={onSend} disabled={disabled || !value.trim()} aria-label="Send message">
+              <Send className="size-4" aria-hidden="true" />
+            </Button>
           )}
-        >
-          <Paperclip className="size-4" aria-hidden="true" />
-        </button>
-
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => {
-            onChange(e.target.value)
-            autosize()
-          }}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-          disabled={disabled}
-          rows={1}
-          placeholder="Ask me anything about F1..."
-          className={cn(
-            'max-h-40 flex-1 resize-none rounded-xl border border-hairline bg-bg-2 px-3 py-2 text-sm text-fg-1',
-            'placeholder:text-fg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none',
-            disabled && 'opacity-50',
-          )}
-        />
-
-        {isStreaming ? (
-          <Button variant="danger" onClick={onStop} aria-label="Stop the response">
-            <Square className="size-4" aria-hidden="true" />
-          </Button>
-        ) : (
-          <Button onClick={onSend} disabled={disabled || !value.trim()} aria-label="Send message">
-            <Send className="size-4" aria-hidden="true" />
-          </Button>
-        )}
+        </div>
       </div>
     </div>
   )

--- a/webapp/src/features/chat/components/ExamplePrompts.tsx
+++ b/webapp/src/features/chat/components/ExamplePrompts.tsx
@@ -31,26 +31,32 @@ export interface ExamplePromptsProps {
 }
 
 /**
- * The empty-chat starting point: a hint line plus four example prompts.
- * Clicking one sends it immediately — the same behaviour as the Streamlit
- * example cards (parity, `chat_history.py:229-236`), not just a prefill.
+ * The empty-chat starting point: a display heading, a hint line, and four
+ * example prompts. Clicking one sends it immediately — the same behaviour as
+ * the Streamlit example cards (parity, `chat_history.py:229-236`), not just a
+ * prefill — so each card shows the actual prompt it will send, keeping the
+ * click informed rather than a surprise.
  */
 export function ExamplePrompts({ onSelect }: ExamplePromptsProps) {
   return (
-    <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
-      <p className="max-w-sm text-sm text-fg-3">
-        Mention a <span className="font-medium text-fg-2">driver</span>,{' '}
-        <span className="font-medium text-fg-2">GP</span>, and{' '}
-        <span className="font-medium text-fg-2">lap</span> to trigger an analysis, or try an example
-        below.
-      </p>
-      <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
+    <div className="flex flex-col items-center gap-6 px-6 py-10 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="font-display text-2xl font-semibold tracking-tight text-fg-1">
+          Ask the pit wall
+        </h2>
+        <p className="max-w-sm text-sm text-fg-3">
+          Mention a <span className="font-medium text-fg-2">driver</span>,{' '}
+          <span className="font-medium text-fg-2">GP</span>, and{' '}
+          <span className="font-medium text-fg-2">lap</span> to trigger an analysis, or start from
+          an example.
+        </p>
+      </div>
+      <div className="grid w-full max-w-xl grid-cols-1 gap-2.5 sm:grid-cols-2">
         {EXAMPLE_PROMPTS.map(({ Icon, label, prompt }) => (
           <Card
             key={label}
             role="button"
             tabIndex={0}
-            title={prompt}
             onClick={() => onSelect(prompt)}
             onKeyDown={(event) => {
               if (event.key === 'Enter' || event.key === ' ') {
@@ -58,10 +64,13 @@ export function ExamplePrompts({ onSelect }: ExamplePromptsProps) {
                 onSelect(prompt)
               }
             }}
-            className="flex cursor-pointer items-center gap-2 p-3 text-left transition-colors hover:bg-bg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none"
+            className="flex cursor-pointer flex-col items-start gap-1.5 p-3.5 text-left transition-colors hover:bg-bg-4 focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:outline-none"
           >
-            <Icon className="size-4 shrink-0 text-purple-300" aria-hidden="true" />
-            <span className="text-sm font-medium text-fg-1">{label}</span>
+            <span className="flex items-center gap-2">
+              <Icon className="size-4 shrink-0 text-purple-300" aria-hidden="true" />
+              <span className="text-sm font-medium text-fg-1">{label}</span>
+            </span>
+            <span className="line-clamp-2 text-xs leading-relaxed text-fg-3">{prompt}</span>
           </Card>
         ))}
       </div>

--- a/webapp/src/features/chat/components/MessageThread.tsx
+++ b/webapp/src/features/chat/components/MessageThread.tsx
@@ -39,15 +39,16 @@ export function MessageThread({ messages, streamingFooter }: MessageThreadProps)
     el.scrollTo({ top: el.scrollHeight, behavior })
   }
 
+  // Auto-follow the bottom as content arrives — a NEW message, the streaming
+  // footer appearing/disappearing, AND the in-flight message's own text growing
+  // token by token (its length is the signal). The `isAtBottom` guard means a
+  // reader who scrolled up to re-read an earlier turn is never yanked back down;
+  // once they return to the bottom, following resumes.
+  const streamingLength = messages.length > 0 ? messages[messages.length - 1].content.length : 0
   useEffect(() => {
     if (isAtBottom) scrollToBottom('auto')
-    // Only a NEW message (or the footer appearing/disappearing) should trigger
-    // auto-follow. A streaming message's own content grows on every token —
-    // re-running this on every character would fight the reader's scroll
-    // position mid-turn far too often, so `messages.length` is the real
-    // dependency, not `messages` itself.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages.length, streamingFooter != null])
+  }, [messages.length, streamingLength, streamingFooter != null])
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
@@ -57,12 +58,24 @@ export function MessageThread({ messages, streamingFooter }: MessageThreadProps)
         role="log"
         aria-live="polite"
         aria-relevant="additions"
-        className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-4"
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-6"
       >
-        {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
-        ))}
-        {streamingFooter}
+        {/* Centered reading column: caps the measure on wide screens so long
+            answers stay readable. Spacing is turn-grouped rather than uniform —
+            a user message opens a new turn with a wider gap, while the tool
+            cards and prose that answer it stack tight underneath, so one
+            question-and-answer reads as a single unit. */}
+        <div className="mx-auto flex w-full max-w-3xl flex-col">
+          {messages.map((message, index) => (
+            <div
+              key={message.id}
+              className={cn(index > 0 && (message.role === 'user' ? 'mt-6' : 'mt-3'))}
+            >
+              <MessageBubble message={message} />
+            </div>
+          ))}
+          {streamingFooter}
+        </div>
       </div>
 
       {!isAtBottom && (
@@ -80,6 +93,13 @@ export function MessageThread({ messages, streamingFooter }: MessageThreadProps)
   )
 }
 
+/**
+ * One message in the thread. Three deliberate treatments, not one bubble
+ * template: the user speaks in a purple pill, tool results stand as bordered
+ * data cards, and the assistant answers as unboxed flowing prose — so a card
+ * always reads as "the data" and the prose as "the interpretation" instead of
+ * two competing boxes saying the same thing.
+ */
 function MessageBubble({ message }: { message: ChatMessage }) {
   if (message.type === 'tool_result' && message.toolResult) {
     return <ToolResultCard toolResult={message.toolResult} />
@@ -99,8 +119,10 @@ function MessageBubble({ message }: { message: ChatMessage }) {
     >
       <div
         className={cn(
-          'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm',
-          isUser ? 'bg-purple-600/90 text-fg-1' : 'border border-hairline bg-bg-3',
+          'text-sm',
+          isUser
+            ? 'max-w-[85%] rounded-2xl bg-purple-600/90 px-4 py-2.5 text-fg-1'
+            : 'w-full space-y-2 px-1',
         )}
       >
         {message.image ? (

--- a/webapp/src/features/chat/components/ReportsPanel.tsx
+++ b/webapp/src/features/chat/components/ReportsPanel.tsx
@@ -75,7 +75,7 @@ export function ReportsPanel({ activeChat }: ReportsPanelProps) {
 
   return (
     <div className="flex flex-col gap-2 border-t border-hairline pt-3">
-      <span className="px-1 text-xs font-medium tracking-wide text-fg-4 uppercase">Reports</span>
+      <span className="px-1 text-xs font-medium tracking-widest text-fg-4 uppercase">Reports</span>
 
       <Button
         size="sm"

--- a/webapp/src/features/chat/components/TextResult.tsx
+++ b/webapp/src/features/chat/components/TextResult.tsx
@@ -9,11 +9,16 @@ import { toLapRange, toRagResultData, toStringChips } from './toolResultParsing'
 // card (citations + source passages); the three listing/lookup tools get a
 // small chip list or one-liner instead of the raw JSON a fallback would show.
 
-/** A chip per entry — `list_available_gps` / `list_available_drivers`. */
+/** A chip per entry — `list_available_gps` / `list_available_drivers`. The
+ *  header carries a mono count so the card reads as a data receipt at a
+ *  glance, even when the chip rows wrap. */
 function ChipList({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">{label}</span>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium tracking-widest text-fg-3 uppercase">{label}</span>
+        <span className="font-mono text-[11px] text-fg-4">{items.length}</span>
+      </div>
       <div className="flex flex-wrap gap-1.5">
         {items.map((item) => (
           <Pill key={item} tone="neutral">

--- a/webapp/src/features/chat/components/ToolBadge.tsx
+++ b/webapp/src/features/chat/components/ToolBadge.tsx
@@ -15,12 +15,26 @@ const STATUS_TONE: Record<ToolBadgeStatus, 'purple' | 'success' | 'danger'> = {
   error: 'danger',
 }
 
+/** Domain initialisms that must keep their casing when a snake_case tool
+ *  name is spelled out — "list_available_gps" should read "List available
+ *  GPs", not "gps" (which scans as satellite GPS). */
+const ACRONYMS: Record<string, string> = {
+  gps: 'GPs',
+  fia: 'FIA',
+  sc: 'SC',
+  drs: 'DRS',
+  llm: 'LLM',
+}
+
 /** "predict_pace" -> "Predict pace". Tool names are already readable
  *  snake_case; this borrows the same sentence-case rendering the stage-label
  *  fallback uses (`../stageLabels.ts`) so a badge and its ticker line never
  *  disagree in tone. */
 function humanize(toolName: string): string {
-  const words = toolName.split('_').join(' ')
+  const words = toolName
+    .split('_')
+    .map((word) => ACRONYMS[word] ?? word)
+    .join(' ')
   return `${words.charAt(0).toUpperCase()}${words.slice(1)}`
 }
 


### PR DESCRIPTION
Closes #175

From live testing + a Fable UI-polish audit.
**Bugs**
- Streamed reply now visibly streams + the thread auto-follows it (the auto-scroll effect keyed on `messages.length`, which doesn't change as a message's own content grows token by token).
- Removed the maximize control on inline charts (no zoomed state worth expanding, as on the Lab gauges).
**Polish (less generic-AI)**
- Assistant replies render as unboxed editorial prose — only the user keeps a bubble, tool results keep their data card (card = the data, prose = the interpretation).
- Centered `max-w-3xl` reading column, turn-grouped spacing, branded empty state ("Ask the pit wall") with real example prompts, brand-voice placeholder, acronym-aware tool badges, sidebar/reports refinements.

Verified live against the real backend (OpenAI) in dark + light themes, 0 console errors; tsc/build/oxlint/prettier@3.9.5/vitest clean. Part of #39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example prompts now display clearer headings, guidance, and full prompt text.
  * Chip lists show the number of items received.
* **Improvements**
  * Chat messages now stay scrolled to the latest streaming content.
  * Composer layout is more centered, with updated placeholder guidance.
  * Tool labels preserve familiar acronym capitalization.
* **Style**
  * Refined chat sidebar, message, report, and attachment styling.
  * Inline charts no longer offer a maximize option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->