### PR TITLE
fix(chat): pin the shell so only the thread scrolls (sidebar fixed) + robust auto-follow

### DIFF
--- a/webapp/src/app/Shell.tsx
+++ b/webapp/src/app/Shell.tsx
@@ -31,10 +31,18 @@ export function Shell() {
   const pathname = useLocation({ select: (location) => location.pathname })
 
   return (
-    <div className="flex min-h-dvh">
+    // Fixed to the viewport (h-dvh + overflow-hidden), NOT min-h-dvh: the route
+    // wrapper below is the single scroll container, so the Rail stays put and an
+    // app-like page (Chat) can keep its own composer/sidebar fixed while only an
+    // inner region scrolls. Content pages still scroll — just inside the wrapper
+    // rather than the body, with their sticky header/bars unchanged.
+    <div className="flex h-dvh overflow-hidden">
       <Rail />
-      <div className="flex flex-1 flex-col bg-bg-0 bg-[image:var(--grad-hero)] bg-top bg-no-repeat">
-        <div key={pathname} className="f1sl-route-enter flex flex-1 flex-col gap-6 p-6">
+      <div className="flex min-h-0 flex-1 flex-col bg-bg-0 bg-[image:var(--grad-hero)] bg-top bg-no-repeat">
+        <div
+          key={pathname}
+          className="f1sl-route-enter flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6"
+        >
           <Outlet />
         </div>
       </div>

--- a/webapp/src/features/chat/components/MessageThread.tsx
+++ b/webapp/src/features/chat/components/MessageThread.tsx
@@ -24,29 +24,50 @@ export interface MessageThreadProps {
  */
 export function MessageThread({ messages, streamingFooter }: MessageThreadProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
-  const [isAtBottom, setIsAtBottom] = useState(true)
-
-  function handleScroll() {
-    const el = scrollRef.current
-    if (!el) return
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    setIsAtBottom(distanceFromBottom <= BOTTOM_THRESHOLD_PX)
-  }
+  // Whether to keep the viewport pinned to the latest content. A REF (not
+  // state) so the streaming loop reads the live value without a render lag.
+  const stickToBottomRef = useRef(true)
+  // Set right before a programmatic scroll so the scroll event IT fires is not
+  // mistaken for the reader scrolling away. Without this, a long fast reply
+  // races its own auto-scroll: content grows a chunk before the previous
+  // scroll event is handled, that event reads a transient gap, flips stick
+  // off, and the auto-follow freezes mid-answer. Only a genuine user scroll
+  // (no flag set) ever stops following.
+  const ignoreNextScrollRef = useRef(false)
+  const [showJumpButton, setShowJumpButton] = useState(false)
 
   function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
     const el = scrollRef.current
     if (!el) return
+    ignoreNextScrollRef.current = true
     el.scrollTo({ top: el.scrollHeight, behavior })
   }
 
+  function handleScroll() {
+    const el = scrollRef.current
+    if (!el) return
+    if (ignoreNextScrollRef.current) {
+      ignoreNextScrollRef.current = false
+      return
+    }
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    stickToBottomRef.current = distanceFromBottom <= BOTTOM_THRESHOLD_PX
+    setShowJumpButton(!stickToBottomRef.current)
+  }
+
+  function jumpToLatest() {
+    stickToBottomRef.current = true
+    setShowJumpButton(false)
+    scrollToBottom()
+  }
+
   // Auto-follow the bottom as content arrives — a NEW message, the streaming
-  // footer appearing/disappearing, AND the in-flight message's own text growing
-  // token by token (its length is the signal). The `isAtBottom` guard means a
-  // reader who scrolled up to re-read an earlier turn is never yanked back down;
-  // once they return to the bottom, following resumes.
+  // footer, AND the in-flight message's own text growing token by token (its
+  // length is the signal). Following stops only when the reader scrolls up;
+  // "Jump to latest" (or scrolling back to the bottom) resumes it.
   const streamingLength = messages.length > 0 ? messages[messages.length - 1].content.length : 0
   useEffect(() => {
-    if (isAtBottom) scrollToBottom('auto')
+    if (stickToBottomRef.current) scrollToBottom('auto')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length, streamingLength, streamingFooter != null])
 
@@ -78,11 +99,11 @@ export function MessageThread({ messages, streamingFooter }: MessageThreadProps)
         </div>
       </div>
 
-      {!isAtBottom && (
+      {showJumpButton && (
         <Button
           size="sm"
           variant="ghost"
-          onClick={() => scrollToBottom()}
+          onClick={jumpToLatest}
           className="absolute bottom-3 left-1/2 -translate-x-1/2 border border-hairline bg-bg-3 shadow-[var(--shadow-elev)]"
         >
           <ArrowDown className="size-3.5" aria-hidden="true" />


### PR DESCRIPTION
Closes #179

The chat sidebar scrolled away and the thread didn't auto-follow the streaming reply — both because the app shell was `min-h-dvh` (grew with content → body scroll), so the thread's `overflow-y-auto` never engaged.
- **Shell**: fixed `h-dvh` + the route wrapper is now the single scroll container (`min-h-0 overflow-y-auto`). Content pages scroll within it with sticky header/bars/rail unchanged (verified Dashboard/Race/Strategy/Lab render clean, 0 page errors); the chat keeps its sidebar + composer fixed while only the thread scrolls.
- **Auto-follow**: a stick-to-bottom ref + a guard that ignores the auto-scroll's own scroll events, so a fast reply stays pinned to the newest tokens instead of freezing on a transient gap. Only a real user scroll-up stops following.

Verified live (real backend): sidebar stays fixed, the view follows the streaming down to the latest line; all four other tabs still render + scroll. tsc/build/oxlint/prettier@3.9.5 green. Part of #39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling so new messages continue to follow the latest content reliably.
  * Prevented programmatic scrolling from incorrectly interrupting automatic follow mode.
  * Refined the “Jump to latest” behavior and visibility.
  * Improved viewport sizing and scrolling consistency across routed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->