### PR TITLE
docs(readme): React web app replaces Streamlit (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # F1 Telemetry Manager
 
-### *FastAPI backend and Streamlit post-race UI for F1 StratLab.*
+### *FastAPI backend and React web app (post-race UI) for F1 StratLab.*
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE) [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![FastAPI](https://img.shields.io/badge/FastAPI-0.109-teal)](https://fastapi.tiangolo.com/) [![Streamlit](https://img.shields.io/badge/Streamlit-1.37%2B-red)](https://streamlit.io/) [![FastMCP](https://img.shields.io/badge/FastMCP-3.x-purple)](https://github.com/jlowin/fastmcp) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/VforVitorio/F1_Telemetry_Manager)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE) [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![FastAPI](https://img.shields.io/badge/FastAPI-0.109-teal)](https://fastapi.tiangolo.com/) [![React](https://img.shields.io/badge/React-19-149eca)](https://react.dev/) [![Vite](https://img.shields.io/badge/Vite-7-646cff)](https://vite.dev/) [![FastMCP](https://img.shields.io/badge/FastMCP-3.x-purple)](https://github.com/jlowin/fastmcp) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/VforVitorio/F1_Telemetry_Manager)
 
 [Parent project: F1 StratLab](https://github.com/VforVitorio/F1-StratLab) · [Architecture](docs/telemetry-architecture.md) · [Backend API reference](../../docs/backend-api.md) · [Changelog](docs/CHANGELOG.md)
 
@@ -14,7 +14,7 @@
 
 ## What it is
 
-F1 Telemetry Manager is the post-race surface of [F1 StratLab](https://github.com/VforVitorio/F1-StratLab): a FastAPI backend that wraps the strategy agents (N25–N31) and the telemetry / comparison / circuit-domination services, and a Streamlit frontend that consumes them. It is vendored into F1 StratLab as a git submodule at [`src/telemetry/`](.) and shares the parent's data root, ML weights, and `.env`.
+F1 Telemetry Manager is the post-race surface of [F1 StratLab](https://github.com/VforVitorio/F1-StratLab): a FastAPI backend that wraps the strategy agents (N25–N31) and the telemetry / comparison / circuit-domination services, and a React web app (Vite + TypeScript + Tailwind + ECharts) that consumes them. It is vendored into F1 StratLab as a git submodule at [`src/telemetry/`](.) and shares the parent's data root, ML weights, and `.env`.
 
 The repo can also be cloned standalone if you only want the analytics dashboard, but the chat and strategy endpoints assume the F1 StratLab models live alongside.
 
@@ -23,7 +23,7 @@ The repo can also be cloned standalone if you only want the analytics dashboard,
 | Surface | Entry point | What it does |
 | --- | --- | --- |
 | **FastAPI backend** | `uvicorn backend.main:app --port 8000` | REST endpoints for telemetry, comparison, circuit domination, strategy, chat and voice. Mounts a FastMCP server at `/mcp` exposing the strategy agents as tools. |
-| **Streamlit frontend** | `streamlit run frontend/app/main.py` | Post-race dashboard: telemetry charts, driver comparison, microsector analysis, chat with tool-calling, voice mode, downloads and reports. |
+| **React web app** | `docker compose up` (service `webapp`) *or* `cd webapp && npm run dev` | Post-race SPA: telemetry dashboard, 60fps driver comparison, ML model lab, multi-agent strategy, race analysis, and a streaming AI chat that renders tool results (cards + ECharts) inline. Reports, sessions, image attach. |
 
 The chat pipeline runs in-process against the strategy agents through a tool-calling loop (OpenAI tool contract); the same tools are exposed externally over MCP, so Claude Desktop, Cursor or any MCP client can drive the agents directly.
 
@@ -37,7 +37,7 @@ docker compose up
 f1-streamlit
 ```
 
-`f1-streamlit` is the convenience entry point installed by F1 StratLab; both routes bring the backend up on `:8000` and the frontend on `:8501`.
+`docker compose up` brings the backend up on `:8000` and the React web app on its port (`:3000` during the migration; `:8501` at cutover). The legacy Streamlit UI (`f1-streamlit`) is retained for reference.
 
 Standalone (from this directory):
 
@@ -52,7 +52,7 @@ Manual install for development:
 ```bash
 uv sync
 uvicorn backend.main:app --reload --port 8000          # terminal 1
-streamlit run frontend/app/main.py --server.port 8501  # terminal 2
+cd webapp && npm install && npm run dev                # terminal 2 (web app on :5173)
 ```
 
 Requires Python 3.11+. The voice pipeline pulls Whisper (`openai-whisper`) and `edge-tts`; first run downloads the Whisper medium weights.
@@ -85,19 +85,19 @@ All endpoints sit under `/api/v1`. The full reference lives at [`docs/backend-ap
 ## Tech stack
 
 Backend: FastAPI 0.109, Pydantic 2.5, FastF1 3.4, FastMCP 3.x.
-Frontend: Streamlit 1.37+, Plotly 5.18, streamlit-shadcn-ui, hydralit-components, kaleido.
+Frontend (web app): React 19, Vite, TypeScript, Tailwind v4, ECharts, TanStack Router/Query, Zustand. (The retired Streamlit UI lives under `frontend/` for reference.)
 AI / voice: OpenAI-compatible LLM (LM Studio local server or OpenAI API), openai-whisper (medium), edge-tts, pydub, soundfile.
 
-## Future direction — frontend migration (planned, priority #1)
+## Frontend migration — done (v2)
 
-The **backend stays FastAPI**, no question. The **Streamlit frontend is slated to be replaced by a modern web stack** — candidates: **React · Vite · Three.js · GSAP** (one or several together). The goal is to keep the current structure, menus and flows almost identical, but escape Streamlit's design constraints and gain speed/fluidity. This is marked as the **first future change** of this repository. Framework choice and migration plan are deferred — see the tracking issue.
+The **backend stays FastAPI**, no question — and the **Streamlit frontend has been replaced by a modern React web app** (Vite + TypeScript + Tailwind v4 + ECharts + TanStack Router/Query). It keeps the original structure, menus and flows, but escapes Streamlit's design constraints: instant client-side navigation, a 60fps canvas replay, a redesigned pit-wall aesthetic, and a chat that streams the LLM reply for real over SSE and renders each tool's output (cards + charts) inline. The web app is now the default surface; the legacy Streamlit app is retained under `frontend/` for reference.
 
 ## Related
 
 This repo is one piece of F1 StratLab:
 
 - [F1 StratLab](https://github.com/VforVitorio/F1-StratLab) — strategy engine, agents, CLI and Arcade live UI
-- F1 Telemetry Manager *(this repo)* — backend and post-race Streamlit, vendored as a submodule
+- F1 Telemetry Manager *(this repo)* — backend and post-race React web app, vendored as a submodule
 - [F1 AI Team Detection](https://github.com/VforVitorio/F1_AI_team_detection) — YOLOv12 team identification from race footage
 - [F1 Strategy Dataset](https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset) — trained weights and processed race data
 


### PR DESCRIPTION
Rewrites the README so the React web app (Vite + TS + Tailwind + ECharts) is the default post-race surface — subtitle, badges, surfaces table, run commands, tech stack, and the migration section (now marked done). Legacy Streamlit retained under frontend/ for reference. Part of the v2 rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and usage instructions for the React-based web application.
  * Documented the current React, Vite, Tailwind, ECharts, TanStack, and Zustand technology stack.
  * Added details about chat streaming and inline tool rendering.
  * Clarified Docker Compose port mapping and noted the legacy interface is retained for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->