### PR TITLE
fix(webapp): use the brand favicon in the rail, not an F1 text badge

### DIFF
--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -213,12 +213,12 @@ export function Rail() {
           railCollapsed ? 'justify-center px-0' : 'px-4',
         )}
       >
-        <span
+        <img
+          src="/favicon.png"
+          alt=""
           aria-hidden="true"
-          className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[image:var(--grad-purple)] font-mono text-[10px] font-bold text-white"
-        >
-          F1
-        </span>
+          className="size-6 shrink-0 rounded-md"
+        />
         <span
           className={cn(
             'truncate font-display text-[15px] font-semibold tracking-tight text-fg-1',

--- a/webapp/src/app/Rail.tsx
+++ b/webapp/src/app/Rail.tsx
@@ -213,12 +213,7 @@ export function Rail() {
           railCollapsed ? 'justify-center px-0' : 'px-4',
         )}
       >
-        <img
-          src="/favicon.png"
-          alt=""
-          aria-hidden="true"
-          className="size-6 shrink-0 rounded-md"
-        />
+        <img src="/favicon.png" alt="" aria-hidden="true" className="size-6 shrink-0 rounded-md" />
         <span
           className={cn(
             'truncate font-display text-[15px] font-semibold tracking-tight text-fg-1',


### PR DESCRIPTION
The rail brand block rendered a gradient square with the literal text `F1`. It now uses the actual brand icon (`public/favicon.png`, the node-network + FS mark), so the sidebar matches the browser tab favicon and the rest of the brand system. No layout change (same 24px rounded mark); the `F1 StratLab` wordmark beside it is unchanged.