### PR TITLE
chore(cutover): the React web app takes :8501 in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,9 @@ From the F1 StratLab repo root (recommended):
 
 ```bash
 docker compose up
-# or
-f1-streamlit
 ```
 
-`docker compose up` brings the backend up on `:8000` and the React web app on its port (`:3000` during the migration; `:8501` at cutover). The legacy Streamlit UI (`f1-streamlit`) is retained for reference.
+`docker compose up` brings the backend up on `:8000` and the React web app on `:8501`. The legacy Streamlit UI is retained for reference under [`frontend/`](frontend/) and still runs locally via `f1-streamlit`, but it no longer ships in compose.
 
 Standalone (from this directory):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,33 +21,16 @@ services:
     networks:
       - f1_network
 
-  frontend:
-    build:
-      context: .
-      dockerfile: frontend/Dockerfile
-    container_name: f1_frontend
-    ports:
-      - "8501:8501"
-    environment:
-      - BACKEND_URL=http://backend:8000
-    volumes:
-      - ./frontend:/app/frontend
-      - frontend_cache:/root/.cache
-    command: streamlit run frontend/app/main.py --server.port 8501 --server.address 0.0.0.0
-    depends_on:
-      - backend
-    networks:
-      - f1_network
-
-  # Migration epic #25 (strangler): the new React SPA runs beside Streamlit.
-  # Host :3000 during the migration; takes :8501 at cutover (#43).
+  # Cutover done (#43): the React SPA owns :8501 and the Streamlit service is
+  # gone from compose. The legacy Streamlit app stays on disk under frontend/
+  # and still runs locally via f1-streamlit, it just no longer ships here.
   webapp:
     build:
       context: ./webapp
       dockerfile: Dockerfile
     container_name: f1_webapp
     ports:
-      - "3000:80"
+      - "8501:80"
     depends_on:
       - backend
     networks:
@@ -59,4 +42,3 @@ networks:
 
 volumes:
   backend_cache:
-  frontend_cache:


### PR DESCRIPTION
Closes #43, the last strangler step of the migration epic #25: the Streamlit service leaves docker-compose and the webapp publishes on **8501:80**. The webapp's nginx already reverse-proxies `/api` to the `backend` compose service (same-origin), so only the host port changes. The legacy Streamlit app remains under `frontend/` and runs locally via `f1-streamlit`; it just no longer ships in compose. README updated. The parent repo's root compose gets its own companion PR (it still lacked a webapp service entirely).