### PR TITLE
feat(home): persist recent sessions and restore them from the pit wall

### DIFF
--- a/webapp/src/features/home/HomePage.tsx
+++ b/webapp/src/features/home/HomePage.tsx
@@ -1,7 +1,8 @@
 // Home page (issue #34 punch-list) — the "Pit Wall" launcher hub, the app's
 // landing surface. A hero moment, a session launcher that hands its
-// selection to whichever surface the user opens next, a recent-sessions
-// stub, and a data-driven grid of every surface the app offers.
+// selection to whichever surface the user opens next, the persisted
+// recent-sessions panel (#186), and a data-driven grid of every surface the
+// app offers.
 //
 // The launcher's selection lives in local component state, NOT the URL —
 // unlike DashboardPage, Home has no "view" of its own worth deep-linking to.
@@ -9,32 +10,12 @@
 // each action link's `search={toRaw(selection)}`.
 
 import { useState } from 'react'
-import { Link } from '@tanstack/react-router'
-import { History } from 'lucide-react'
 import { Header } from '@/app/Header'
-import { Button } from '@/components/Button'
-import { Card } from '@/components/Card'
-import { EmptyState } from '@/components/EmptyState'
-import { SectionHeader } from '@/features/dashboard/components/SectionHeader'
-import {
-  applySelectionPatch,
-  type DashboardSearch,
-  type RawDashboardSearch,
-} from '@/features/dashboard/search'
+import { applySelectionPatch, type DashboardSearch } from '@/features/dashboard/search'
 import { prewarmTelemetry } from '@/features/dashboard/queries'
+import { RecentSessions } from './components/RecentSessions'
 import { SessionLauncher } from './components/SessionLauncher'
 import { SurfaceCards } from './components/SurfaceCards'
-
-/** Sample session behind the "recent sessions" empty state's CTA — the one
- *  FastF1 session guaranteed to be offline-cached in every environment (the
- *  golden verify session used across the whole migration, see MEMORY.md), so
- *  a first-time visitor always gets a real, fast-loading Dashboard. */
-const SAMPLE_SESSION_SEARCH: RawDashboardSearch = {
-  year: 2023,
-  gp: 'Monaco Grand Prix',
-  session: 'R',
-  drivers: 'VER,LEC',
-}
 
 export function HomePage() {
   const [selection, setSelection] = useState<DashboardSearch>({ drivers: [] })
@@ -75,26 +56,7 @@ export function HomePage() {
             <SessionLauncher value={selection} onChange={handleChange} />
           </div>
 
-          {/* Recent sessions — a stub for this MVP (no persistence yet). Wrapped
-              in a resting Card so the column reads as a real panel next to the
-              launcher's glow card, instead of bare text floating beside it. */}
-          <div className="flex flex-col gap-4 xl:col-span-1">
-            <SectionHeader title="Recent sessions" />
-            <Card className="flex-1">
-              <EmptyState
-                icon={<History className="size-8" aria-hidden="true" />}
-                title="No sessions yet"
-                description="Sessions you open land here so you can jump straight back in."
-                action={
-                  <Link to="/dashboard" search={SAMPLE_SESSION_SEARCH}>
-                    <Button variant="ghost" size="sm">
-                      Try the sample session
-                    </Button>
-                  </Link>
-                }
-              />
-            </Card>
-          </div>
+          <RecentSessions />
         </div>
 
         <SurfaceCards />

--- a/webapp/src/features/home/components/RecentSessions.tsx
+++ b/webapp/src/features/home/components/RecentSessions.tsx
@@ -1,0 +1,159 @@
+// Recent sessions panel (Home, #186): the persisted launch history, rendered.
+// Each row restores its session by navigating — the tab's URL contract
+// rebuilds the full state from the search params, so the row only needs the
+// stored fields. Clicking a row also re-records it (refreshes the timestamp
+// and moves it to the front). The empty state keeps the sample-session CTA:
+// the one FastF1 session guaranteed to be offline-cached everywhere, so a
+// first-time visitor always gets a real, fast-loading Dashboard.
+
+import { Link } from '@tanstack/react-router'
+import { ArrowRightLeft, Crosshair, Gauge, History, X, type LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/Button'
+import { Card } from '@/components/Card'
+import { EmptyState } from '@/components/EmptyState'
+import { SectionHeader } from '@/features/dashboard/components/SectionHeader'
+import { toRaw } from '@/features/dashboard/search'
+import {
+  useSessionsStore,
+  type RecentSession,
+  type RecordableSelection,
+  type SessionSurface,
+} from '../sessionsStore'
+
+const SAMPLE_SESSION: RecordableSelection = {
+  year: 2023,
+  gp: 'Monaco Grand Prix',
+  session: 'R',
+  drivers: ['VER', 'LEC'],
+}
+
+const SURFACE_ICON: Record<SessionSurface, LucideIcon> = {
+  dashboard: Gauge,
+  comparison: ArrowRightLeft,
+  strategy: Crosshair,
+}
+
+/** Coarse relative time — recents only need "how long ago", not a clock. */
+function timeAgo(thenMs: number): string {
+  const minutes = Math.floor((Date.now() - thenMs) / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+/** The surface-specific Link around a row's content. `to` stays a literal
+ *  string per branch (never threaded through a prop) so TanStack Router's
+ *  typed route tree checks each target — same convention as Rail.tsx and the
+ *  SessionLauncher. Strategy maps the selection onto its scenario shape (the
+ *  first two drivers become driver + optional rival). */
+function SessionLink({
+  session,
+  onOpen,
+  children,
+}: {
+  session: RecentSession
+  onOpen: () => void
+  children: ReactNode
+}) {
+  const className =
+    'flex min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-fg-1/[0.04]'
+  if (session.surface === 'comparison') {
+    return (
+      <Link to="/comparison" search={toRaw(session)} className={className} onClick={onOpen}>
+        {children}
+      </Link>
+    )
+  }
+  if (session.surface === 'strategy') {
+    return (
+      <Link
+        to="/strategy"
+        search={{
+          gp: session.gp,
+          ...(session.drivers[0] ? { driver: session.drivers[0] } : {}),
+          ...(session.drivers[1] ? { rival: session.drivers[1] } : {}),
+        }}
+        className={className}
+        onClick={onOpen}
+      >
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <Link to="/dashboard" search={toRaw(session)} className={className} onClick={onOpen}>
+      {children}
+    </Link>
+  )
+}
+
+export function RecentSessions() {
+  const sessions = useSessionsStore((state) => state.sessions)
+  const recordSession = useSessionsStore((state) => state.recordSession)
+  const removeSession = useSessionsStore((state) => state.removeSession)
+
+  return (
+    <div className="flex flex-col gap-4 xl:col-span-1">
+      <SectionHeader title="Recent sessions" />
+      <Card className="flex-1">
+        {sessions.length === 0 ? (
+          <EmptyState
+            icon={<History className="size-8" aria-hidden="true" />}
+            title="No sessions yet"
+            description="Sessions you open land here so you can jump straight back in."
+            action={
+              <Link
+                to="/dashboard"
+                search={toRaw(SAMPLE_SESSION)}
+                onClick={() => recordSession(SAMPLE_SESSION, 'dashboard')}
+              >
+                <Button variant="ghost" size="sm">
+                  Try the sample session
+                </Button>
+              </Link>
+            }
+          />
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {sessions.map((session) => {
+              const Icon = SURFACE_ICON[session.surface]
+              return (
+                <li key={session.id} className="flex items-center gap-1">
+                  <SessionLink
+                    session={session}
+                    onOpen={() => recordSession(session, session.surface)}
+                  >
+                    <Icon className="size-4 shrink-0 text-purple-300" aria-hidden="true" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-fg-1">
+                        {session.gp} · {session.year}
+                      </span>
+                      <span className="block truncate font-mono text-xs text-fg-3">
+                        {session.session}
+                        {session.drivers.length > 0 ? ` · ${session.drivers.join(' · ')}` : ''}
+                      </span>
+                    </span>
+                    <span className="shrink-0 text-xs text-fg-4">
+                      {timeAgo(session.lastOpenedAt)}
+                    </span>
+                  </SessionLink>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${session.gp} ${session.year} from recent sessions`}
+                    onClick={() => removeSession(session.id)}
+                    className="shrink-0 rounded-md p-1.5 text-fg-4 transition-colors hover:bg-fg-1/[0.06] hover:text-fg-1"
+                  >
+                    <X className="size-3.5" aria-hidden="true" />
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/webapp/src/features/home/components/SessionLauncher.tsx
+++ b/webapp/src/features/home/components/SessionLauncher.tsx
@@ -14,6 +14,7 @@ import { toRaw, type DashboardSearch } from '@/features/dashboard/search'
 import { Card } from '@/components/Card'
 import { Button } from '@/components/Button'
 import { Pill } from '@/components/Pill'
+import { useSessionsStore, type SessionSurface } from '../sessionsStore'
 
 export interface SessionLauncherProps {
   value: DashboardSearch
@@ -59,6 +60,18 @@ function ActionContent({
  */
 export function SessionLauncher({ value, onChange }: SessionLauncherProps) {
   const ready = value.year != null && !!value.gp && !!value.session
+  const recordSession = useSessionsStore((state) => state.recordSession)
+
+  /** Persist the launch into the recents panel (#186). Guarded on the same
+   *  fields `ready` checks so TypeScript narrows them; only reachable from
+   *  the ready branches below. */
+  function recordLaunch(surface: SessionSurface) {
+    if (value.year == null || !value.gp || !value.session) return
+    recordSession(
+      { year: value.year, gp: value.gp, session: value.session, drivers: value.drivers },
+      surface,
+    )
+  }
 
   return (
     <Card elevation="glow" className="flex flex-col gap-5 p-6">
@@ -67,7 +80,7 @@ export function SessionLauncher({ value, onChange }: SessionLauncherProps) {
 
       <div className="flex flex-wrap items-center gap-2 border-t border-hairline pt-4">
         {ready ? (
-          <Link to="/dashboard" search={toRaw(value)}>
+          <Link to="/dashboard" search={toRaw(value)} onClick={() => recordLaunch('dashboard')}>
             <Button size="md">
               <ActionContent icon={Gauge} label="Open in Dashboard" />
             </Button>
@@ -79,7 +92,7 @@ export function SessionLauncher({ value, onChange }: SessionLauncherProps) {
         )}
 
         {ready ? (
-          <Link to="/comparison" search={toRaw(value)}>
+          <Link to="/comparison" search={toRaw(value)} onClick={() => recordLaunch('comparison')}>
             <Button variant="ghost">
               <ActionContent icon={ArrowRightLeft} label="Comparison" soon />
             </Button>
@@ -96,6 +109,7 @@ export function SessionLauncher({ value, onChange }: SessionLauncherProps) {
           // the driver + optional rival for the pit-wall duel.
           <Link
             to="/strategy"
+            onClick={() => recordLaunch('strategy')}
             search={{
               ...(value.gp ? { gp: value.gp } : {}),
               ...(value.drivers[0] ? { driver: value.drivers[0] } : {}),

--- a/webapp/src/features/home/sessionsStore.test.ts
+++ b/webapp/src/features/home/sessionsStore.test.ts
@@ -1,0 +1,73 @@
+// Store-level tests for the recent-sessions slice (#186): the dedupe, cap and
+// ordering rules are the feature's actual contract — the component is just a
+// renderer over this list.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  MAX_RECENT_SESSIONS,
+  sessionId,
+  useSessionsStore,
+  type RecordableSelection,
+} from './sessionsStore'
+
+function sel(overrides: Partial<RecordableSelection> = {}): RecordableSelection {
+  return {
+    year: 2025,
+    gp: 'British Grand Prix',
+    session: 'R',
+    drivers: ['NOR', 'VER'],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useSessionsStore.setState({ sessions: [] })
+})
+
+describe('recordSession', () => {
+  it('adds the newest session to the front', () => {
+    useSessionsStore.getState().recordSession(sel({ gp: 'Monaco Grand Prix' }), 'dashboard')
+    useSessionsStore.getState().recordSession(sel(), 'comparison')
+
+    const sessions = useSessionsStore.getState().sessions
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0].gp).toBe('British Grand Prix')
+    expect(sessions[0].surface).toBe('comparison')
+  })
+
+  it('dedupes by year+gp+drivers: a re-open refreshes and moves to front', () => {
+    useSessionsStore.getState().recordSession(sel(), 'dashboard')
+    useSessionsStore.getState().recordSession(sel({ gp: 'Monaco Grand Prix' }), 'dashboard')
+    // Same identity as the first record, drivers in a different order.
+    useSessionsStore.getState().recordSession(sel({ drivers: ['VER', 'NOR'] }), 'strategy')
+
+    const sessions = useSessionsStore.getState().sessions
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0].id).toBe(sessionId(sel()))
+    expect(sessions[0].surface).toBe('strategy')
+  })
+
+  it('caps the list, evicting the oldest', () => {
+    for (let i = 0; i < MAX_RECENT_SESSIONS + 2; i++) {
+      useSessionsStore.getState().recordSession(sel({ gp: `GP ${i}` }), 'dashboard')
+    }
+
+    const sessions = useSessionsStore.getState().sessions
+    expect(sessions).toHaveLength(MAX_RECENT_SESSIONS)
+    expect(sessions[0].gp).toBe(`GP ${MAX_RECENT_SESSIONS + 1}`)
+    expect(sessions.some((s) => s.gp === 'GP 0')).toBe(false)
+  })
+})
+
+describe('removeSession', () => {
+  it('removes only the targeted session', () => {
+    useSessionsStore.getState().recordSession(sel(), 'dashboard')
+    useSessionsStore.getState().recordSession(sel({ gp: 'Monaco Grand Prix' }), 'dashboard')
+
+    useSessionsStore.getState().removeSession(sessionId(sel()))
+
+    const sessions = useSessionsStore.getState().sessions
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].gp).toBe('Monaco Grand Prix')
+  })
+})

--- a/webapp/src/features/home/sessionsStore.ts
+++ b/webapp/src/features/home/sessionsStore.ts
@@ -1,0 +1,75 @@
+// Recent-sessions store (Home, #186). A "session" here is just the launcher's
+// selection plus where it was opened: every tab rebuilds its full state from
+// URL search params, so persisting a session means persisting the fields the
+// URL contract needs — restoring one is nothing more than navigating.
+//
+// Records happen at launch time (the SessionLauncher's action links and the
+// sample CTA) and when a recent row is re-opened. Dedup identity is
+// year + GP + drivers: re-opening the same session refreshes its timestamp
+// and surface and moves it to the front instead of piling up duplicates. The
+// list is capped so the panel never grows unbounded. localStorage only
+// (`f1sl.sessions`), same persist pattern as `f1sl.ui` and the chat store.
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type SessionSurface = 'dashboard' | 'comparison' | 'strategy'
+
+export interface RecentSession {
+  id: string
+  year: number
+  gp: string
+  session: string
+  drivers: string[]
+  surface: SessionSurface
+  lastOpenedAt: number
+}
+
+/** The launcher fields a record needs — `DashboardSearch` with the three
+ *  required pieces actually present (the launcher only fires when ready). */
+export interface RecordableSelection {
+  year: number
+  gp: string
+  session: string
+  drivers: string[]
+}
+
+export const MAX_RECENT_SESSIONS = 8
+
+/** Dedup identity: what a user would call "the same session" — GP + drivers
+ *  + year. Drivers are sorted so NOR,VER and VER,NOR collapse into one. */
+export function sessionId(sel: RecordableSelection): string {
+  return `${sel.year}·${sel.gp}·${[...sel.drivers].sort().join(',')}`
+}
+
+interface SessionsState {
+  sessions: RecentSession[]
+  recordSession: (sel: RecordableSelection, surface: SessionSurface) => void
+  removeSession: (id: string) => void
+}
+
+export const useSessionsStore = create<SessionsState>()(
+  persist(
+    (set) => ({
+      sessions: [],
+      recordSession: (sel, surface) =>
+        set((state) => {
+          const id = sessionId(sel)
+          const rest = state.sessions.filter((existing) => existing.id !== id)
+          const entry: RecentSession = {
+            id,
+            year: sel.year,
+            gp: sel.gp,
+            session: sel.session,
+            drivers: sel.drivers,
+            surface,
+            lastOpenedAt: Date.now(),
+          }
+          return { sessions: [entry, ...rest].slice(0, MAX_RECENT_SESSIONS) }
+        }),
+      removeSession: (id) =>
+        set((state) => ({ sessions: state.sessions.filter((existing) => existing.id !== id) })),
+    }),
+    { name: 'f1sl.sessions' },
+  ),
+)


### PR DESCRIPTION
## What

Replaces the Home recent-sessions stub with a working, persisted panel (#186).

- New zustand persist slice `f1sl.sessions` (localStorage): each launched session stores year, GP, session, drivers and the surface it was opened on.
- Dedupe identity is year + GP + drivers (order-insensitive): re-opening the same session refreshes its timestamp and moves it to the front instead of duplicating. List capped at 8, oldest evicted.
- `RecentSessions` panel: per-surface icon (Dashboard / Comparison / Strategy), relative time, one-click restore by navigating with the tab's URL-contract search params, per-row remove.
- Recording hooks: the three SessionLauncher action links and the empty-state sample CTA.

## Why

A session in this app IS a URL (every tab rebuilds state from search params), so persisting sessions = persisting the URL-contract fields; restoring one is just navigating. No backend involved.

## Checks

- `npm run typecheck` green, vitest 184/184 (4 new store tests: ordering, dedupe, cap, removal), prettier 3.9.5 clean.
- Functional Playwright run against the dev server: empty state, sample CTA records + opens Monaco 2023, row restores the exact URL, persists across a hard reload, remove returns the empty state. Verified in dark and light themes.

Closes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Recent Sessions panel to the home page.
  * Automatically saves launched sessions and displays up to eight recent entries.
  * Select a recent session to reopen it in the appropriate view.
  * Recent sessions show key details and when they were last opened.
  * Added controls to remove individual sessions.
  * Recent sessions persist between visits and are deduplicated when reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->