### PR TITLE
feat(strategy): tolerate the nullable scenario_scores schema

### DIFF
--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -424,10 +424,13 @@ def _run_no_llm_path(
         # The engine hands back the raw MC dict ({scenario: {"score": ..., ...}}), the
         # same shape the old body flattened here. _coerce_scenario_scores downstream
         # accepts either, but flatten anyway to keep the emitted contract unchanged.
-        "scenario_scores": {
-            k: round(float(v["score"] if isinstance(v, dict) else v), 3)
-            for k, v in (rec.scenario_scores or {}).items()
-        },
+        #
+        # A null score means the candidate was not offered at all — the projection MC
+        # marks a candidate ineligible when it has no valid target, rather than handing
+        # it a number it did not earn. Such a candidate is OMITTED here: an absent key
+        # cannot be mistaken for a score, whereas coercing it would either crash on
+        # float(None) or, worse, quietly render as 0.0 and look like a real result.
+        "scenario_scores": _coerce_scenario_scores(rec.scenario_scores),
         "regulation_context": rec.regulation_context or "",
         "guardrail_reason": outputs.get("guardrail_reason"),
         "_pit_out": outputs.get("pit_out"),
@@ -445,6 +448,12 @@ def _coerce_scenario_scores(raw: Any) -> dict[str, float]:
     a simple ``{scenario: float}`` dict. Both shapes show up in the wild:
     ``_run_mc_simulation`` returns the nested form, while the orchestrator
     re-attaches it post-synthesis and other code paths sometimes pre-flatten.
+
+    A candidate whose score is ``None`` is dropped rather than defaulted. The
+    projection MC emits that for a candidate it refused to score — an undercut
+    with no reachable target, an overcut with nobody in the pit lane — and the
+    one thing that must never happen is for it to reach a chart as 0.0, which
+    reads as a real, merely unattractive option.
     """
     if not isinstance(raw, dict):
         return {}
@@ -453,10 +462,10 @@ def _coerce_scenario_scores(raw: Any) -> dict[str, float]:
         if isinstance(val, dict):
             score = val.get("score")
             if score is not None:
-                flat[key] = float(score)
+                flat[key] = round(float(score), 3)
         else:
             try:
-                flat[key] = float(val)
+                flat[key] = round(float(val), 3)
             except (TypeError, ValueError):
                 continue
     return flat

--- a/webapp/src/charts/ScenarioScoresChart.tsx
+++ b/webapp/src/charts/ScenarioScoresChart.tsx
@@ -69,17 +69,45 @@ const WHISKER_DOT_RADIUS = 3.5
 // label being struck through by the whisker line when it sat on the bar).
 const WHISKER_LABEL_GAP_PX = 8
 
+/** A candidate that survived the eligibility filter: every number is present.
+ *
+ *  Narrowing once here is what keeps the rest of this file free of null checks
+ *  and non-null assertions — the guarantee is established at the boundary and
+ *  the compiler carries it through the option builders. */
+type PlottedScore = ScenarioScore & { E: number; P10: number; P90: number; score: number }
+
 interface ScenarioRow {
   action: string
-  score: ScenarioScore
+  score: PlottedScore
+}
+
+/** True when the candidate carries a full set of numbers to plot.
+ *
+ *  The projection engine emits `eligible: false` with null numbers for a
+ *  candidate it refused to score. Plotting that as zero would plant a bar for a
+ *  strategy that was never on the table, so those rows leave the chart and are
+ *  listed underneath instead. The null checks stand on their own: a payload
+ *  from before the projection has no `eligible` flag at all. */
+function isPlottable(score: ScenarioScore): score is PlottedScore {
+  if (score.eligible === false) return false
+  return score.E != null && score.P10 != null && score.P90 != null && score.score != null
 }
 
 /** Rows sorted best-first (E descending). Combined with `yAxis.inverse` in
  *  `buildScoresOption`, the winner renders at the TOP of the chart. */
 function sortedRows(scores: Record<string, ScenarioScore>): ScenarioRow[] {
+  const rows: ScenarioRow[] = []
+  for (const [action, score] of Object.entries(scores)) {
+    if (isPlottable(score)) rows.push({ action, score })
+  }
+  return rows.sort((a, b) => b.score.E - a.score.E)
+}
+
+/** Candidates the engine declined to score, with the reason it can give. */
+function unofferedRows(scores: Record<string, ScenarioScore>): string[] {
   return Object.entries(scores)
-    .map(([action, score]) => ({ action, score }))
-    .sort((a, b) => b.score.E - a.score.E)
+    .filter(([, score]) => !isPlottable(score))
+    .map(([action]) => action.replace(/_/g, ' '))
 }
 
 /** Clamp the chart's pixel height to the row count so a 2-candidate run
@@ -315,6 +343,7 @@ export function ScoresPlot({ scores, chosenAction }: ScoresPlotProps) {
   const chartTheme = useChartTheme()
   const palette = chartTheme === F1_LIGHT_THEME ? LIGHT_SCORE_PALETTE : DARK_SCORE_PALETTE
   const rows = useMemo(() => sortedRows(scores), [scores])
+  const unoffered = useMemo(() => unofferedRows(scores), [scores])
   const option = useMemo(
     () => buildScoresOption(rows, chosenAction, palette),
     [rows, chosenAction, palette],
@@ -339,6 +368,12 @@ export function ScoresPlot({ scores, chosenAction }: ScoresPlotProps) {
         style={{ height: chartHeight(rows.length) }}
         notMerge
       />
+      {unoffered.length > 0 && (
+        // Named rather than hidden: a candidate missing from the chart with no
+        // explanation reads as a bug, while "not offered" is the actual finding —
+        // there was no car to aim at.
+        <p className="px-2 pb-1 text-xs text-fg-3">Not offered: {unoffered.join(', ')}</p>
+      )}
     </div>
   )
 }

--- a/webapp/src/features/chat/components/toolResultParsing.ts
+++ b/webapp/src/features/chat/components/toolResultParsing.ts
@@ -147,8 +147,18 @@ function toScenarioScores(raw: unknown): Record<string, ScenarioScore> {
     const p10 = numOrUndef(row.P10)
     const p90 = numOrUndef(row.P90)
     const score = numOrUndef(row.score)
+    const target = typeof row.target === 'string' ? row.target : null
+
     if (e != null && p10 != null && p90 != null && score != null) {
-      scores[action] = { E: e, P10: p10, P90: p90, score }
+      scores[action] = { E: e, P10: p10, P90: p90, score, eligible: true, target }
+      continue
+    }
+    // A candidate the projection engine declined to score is kept, with nulls
+    // intact, so the chart can name it as "not offered". Dropping it here would
+    // make an unoffered strategy indistinguishable from one the run never
+    // considered. Anything else half-parsed is still discarded.
+    if (row.eligible === false) {
+      scores[action] = { E: null, P10: null, P90: null, score: null, eligible: false, target }
     }
   }
   return scores

--- a/webapp/src/features/strategy/components/DecisionBanner.test.tsx
+++ b/webapp/src/features/strategy/components/DecisionBanner.test.tsx
@@ -111,6 +111,67 @@ describe('DecisionBanner', () => {
   })
 })
 
+/** What the projection engine returns when a candidate has no car to aim at:
+ *  eligible false, every number null. Never a 0, which would draw a real bar. */
+const withIneligibleCandidates: StrategyRecommendation = {
+  ...richResult,
+  scenario_scores: {
+    PIT_NOW: { E: 0.61, P10: 0.4, P90: 0.8, score: 0.61, eligible: true, target: null },
+    STAY_OUT: { E: 0.44, P10: 0.2, P90: 0.6, score: 0.44, eligible: true, target: null },
+    UNDERCUT: { E: null, P10: null, P90: null, score: null, eligible: false, target: null },
+    OVERCUT: { E: null, P10: null, P90: null, score: null, eligible: false, target: null },
+  },
+}
+
+describe('DecisionBanner with the projection schema', () => {
+  it('names the candidates it was not offered instead of plotting them at zero', () => {
+    render(
+      <DecisionBanner
+        result={withIneligibleCandidates}
+        lapState={lapState}
+        rival="LEC"
+        onDownloadJson={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Not offered:/)).toBeInTheDocument()
+    expect(screen.getByText(/UNDERCUT|OVERCUT/)).toBeInTheDocument()
+    expect(screen.queryByText(/undefined|NaN|null/)).not.toBeInTheDocument()
+  })
+
+  it('still renders the old all-numeric payload untouched', () => {
+    render(
+      <DecisionBanner
+        result={richResult}
+        lapState={lapState}
+        rival="LEC"
+        onDownloadJson={vi.fn()}
+      />,
+    )
+    // No projection fields present, so nothing is flagged as unoffered.
+    expect(screen.queryByText(/Not offered:/)).not.toBeInTheDocument()
+  })
+
+  it('survives every candidate being ineligible', () => {
+    const allIneligible: StrategyRecommendation = {
+      ...richResult,
+      scenario_scores: {
+        PIT_NOW: { E: null, P10: null, P90: null, score: null, eligible: false, target: null },
+        UNDERCUT: { E: null, P10: null, P90: null, score: null, eligible: false, target: null },
+      },
+    }
+    render(
+      <DecisionBanner
+        result={allIneligible}
+        lapState={lapState}
+        rival="LEC"
+        onDownloadJson={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/No scenario scores for this run/)).toBeInTheDocument()
+    expect(screen.queryByText(/undefined|NaN|null/)).not.toBeInTheDocument()
+  })
+})
+
 describe('DecisionDetails', () => {
   it('surfaces key risks, the playbook, and both disclosures when present', () => {
     render(<DecisionDetails result={richResult} />)

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -147,12 +147,26 @@ export interface AgentResultMap {
 
 // ── Orchestrator v2 recommendation (POST /recommend) ────────────────────────
 
-/** One Monte-Carlo scored strategy candidate. */
+/**
+ * One Monte-Carlo strategy candidate.
+ *
+ * Every number is nullable because the projection engine refuses to score a
+ * candidate it cannot offer: an undercut with no reachable target, an overcut
+ * with nobody in the pit lane. Those arrive as `eligible: false` with null
+ * numbers, and consumers must render them as "not offered" rather than as a
+ * score — a null coerced to 0 would draw a real-looking bar for a strategy that
+ * does not exist. Payloads predating the projection carry numbers with no
+ * `eligible` flag, which reads as eligible.
+ */
 export interface ScenarioScore {
-  E: number
-  P10: number
-  P90: number
-  score: number
+  E: number | null
+  P10: number | null
+  P90: number | null
+  score: number | null
+  /** Absent on pre-projection payloads; treat a missing flag as eligible. */
+  eligible?: boolean
+  /** The car this candidate is aimed at, when it is aimed at one. */
+  target?: string | null
 }
 
 /** A conditional branch the LLM planned for upcoming laps (IF trigger → action). */


### PR DESCRIPTION
PR-5a of the parent MC projection redesign (VforVitorio/F1-StratLab#550). Makes every `scenario_scores` consumer safe for the nullable schema **before** the parent starts emitting it, while leaving the old all-numeric payloads rendering exactly as they do today.

## Why the schema changes at all

The parent's rebuilt Monte Carlo scores candidates in projected track position and **refuses to score a candidate it cannot offer** — an undercut with no reachable target, an overcut with nobody in the pit lane. Those arrive as `eligible: false` with null numbers.

The one outcome that must never happen is a null reaching a chart as `0.0`, because a zero draws a real-looking bar for a strategy that was never on the table. That is the same class of bug as the 0.5 undercut coin-flip this redesign exists to kill.

## Changes

- **Backend**: the inline SSE flatten did `float(v["score"])` and would raise `TypeError` on a null. It now reuses `_coerce_scenario_scores`, which drops unscored candidates instead — one flattening rule instead of two, and the crash goes with the duplicate. `_coerce_scenario_scores` gains the rounding the inline version had, so the emitted contract is unchanged for existing payloads.
- **Types**: `ScenarioScore` numbers become nullable, plus optional `eligible` and `target`. A payload with no `eligible` flag reads as eligible, so nothing predating the projection changes shape.
- **Chart**: `isPlottable` is a type guard, so the narrowing happens once at the boundary and the option builders stay free of null checks and non-null assertions. Unscored candidates leave the plot and are listed under it as "Not offered: …" — naming them, because a candidate silently missing from the chart reads as a bug while "not offered" is the actual finding.
- **Chat parser**: keeps an `eligible: false` entry with its nulls intact so the chat card can name it too. Anything else half-parsed is still discarded, as before.

## Verification

- 187 webapp tests pass, including three new DecisionBanner cases: a mixed payload (two scored, two not), the old all-numeric payload asserting nothing is flagged as unoffered, and the all-ineligible edge, which falls through to the existing "No scenario scores for this run" empty state.
- `tsc --noEmit` clean; prettier 3.9.5 (the version CI pins) clean.
- 116 backend tests pass.
- Every new test also asserts no literal `undefined` / `NaN` / `null` leaks into the DOM, matching the existing null-tolerance convention in this suite.

Closes #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scenario score results now support targeted candidates and clearly identify options that were not offered.
  * Charts display a “Not offered” notice for candidates without valid scoring data.

* **Bug Fixes**
  * Null-scored candidates are no longer treated as zero-score options.
  * Numeric scenario scores are consistently rounded to three decimal places.
  * Empty and fully unavailable score results now display appropriate messages without showing invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->