### PR TITLE
fix(api): carry the mandatory-stop flags into /lap-state

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -381,6 +381,21 @@ def _safe_none(val):
         return val
 
 
+def _stint_flags_for(gp_df: pd.DataFrame, driver: str, lap: int) -> dict:
+    """One driver's Art. 30.5(m) flags as of ``lap``, from the shared implementation.
+
+    A wrapper and nothing more, deliberately. The stint arithmetic lives in
+    ``src/simulation/stint_history.py`` and both this endpoint and the replay
+    engine call it, so the two cannot answer the question differently.
+
+    ``gp_df`` must already be GP-scoped, which it is by the time the caller has
+    a lap row: a season-wide frame would blend a driver's stints across races.
+    """
+    from src.simulation.stint_history import stint_history_flags
+
+    return stint_history_flags(gp_df, driver, lap)
+
+
 @router.get("/lap-state")
 def get_lap_state(
     gp: str,
@@ -543,6 +558,21 @@ def get_lap_state(
             "driver": driver,
             "team": driver_dict["team"],
             "total_laps": total_laps,
+        },
+        # Art. 30.5(m) state, for us and for every rival. Imported from the
+        # simulation package rather than derived here: this endpoint has a
+        # history of reimplementing RaceStateManager and inheriting the bugs
+        # that file had already fixed, and stint counting is exactly the kind of
+        # arithmetic that drifts between two copies. Without these keys the API
+        # path silently loses the terminal liability, since an unknown
+        # obligation disables it by design.
+        "stint_flags": _stint_flags_for(gp_df, driver, int(lap)),
+        "rival_stop_pending": {
+            rival["driver"]: _stint_flags_for(gp_df, rival["driver"], int(lap))[
+                "mandatory_stop_pending"
+            ]
+            for rival in rivals
+            if rival.get("driver")
         },
     }
 

--- a/tests/test_strategy_audit_fixes.py
+++ b/tests/test_strategy_audit_fixes.py
@@ -220,3 +220,34 @@ def test_build_lap_state_from_row_nan_tyre_life_stays_none():
     )
     assert lap_state["driver"]["tyre_life"] is None  # not the old 0 sentinel
     assert lap_state["driver"]["position"] == row["Position"]  # real value untouched
+
+
+# ---------------------------------------------------------------------------
+# #550 -- the Art. 30.5(m) flags must reach the API path too
+# ---------------------------------------------------------------------------
+
+
+def test_get_lap_state_carries_the_mandatory_stop_flags_for_us_and_every_rival():
+    """The terminal liability is silently disabled without these two keys.
+
+    ``race_context_from_lap_state`` reads ``stint_flags.mandatory_stop_pending``
+    and ``rival_stop_pending`` straight off the lap_state, and an unknown
+    obligation switches the liability term off by design. So a producer that
+    omits them does not fail loudly: it quietly returns a projection with the
+    deferred cost of our own stop priced at zero. The replay engine emits both;
+    this asserts the HTTP path does not diverge from it.
+    """
+    row, _gp_df = _first_row_with_prev_lap_time()
+    gp, driver, lap = str(row["GP_Name"]), str(row["Driver"]), int(row["LapNumber"])
+
+    state = get_lap_state(gp=gp, driver=driver, lap=lap, year=2025)
+
+    flags = state["stint_flags"]
+    assert set(flags) == {"stops_made", "compounds_used", "mandatory_stop_pending"}
+    assert flags["mandatory_stop_pending"] in (True, False, None)
+
+    # Every rival the payload lists must also carry a verdict, since a rival
+    # missing from the map is treated as unknown and stops exempting itself.
+    pending = state["rival_stop_pending"]
+    listed = {r["driver"] for r in state["rivals"] if r.get("driver")}
+    assert listed <= set(pending), f"rivals with no obligation verdict: {listed - set(pending)}"


### PR DESCRIPTION
The replay engine emits `stint_flags` and `rival_stop_pending`; this producer did not.

The omission is **silent rather than loud**. `race_context_from_lap_state` reads both straight off the lap_state, and an unknown obligation disables the terminal liability *by design* — so every `/recommend` call priced the deferred cost of our own stop at zero and treated no rival as exempt, while returning a perfectly well-formed projection.

The arithmetic is **imported** from `src/simulation/stint_history.py` rather than rewritten here. This endpoint has a history of reimplementing `RaceStateManager` and inheriting the bugs that file had already fixed, and counting stints across a frame that hides intermediate stints is exactly the logic that drifts between two copies.

Verified on Lusail 2025 lap 30: our own obligation resolves to pending, and **17 rivals** come back with a verdict instead of an empty map.

Refs VforVitorio/F1-StratLab#550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lap-state responses now include mandatory-stop status for the selected driver and rivals.
  * Added stint history details, including stops made, compounds used, and pending mandatory stops.

* **Bug Fixes**
  * Improved strategy decisions by exposing terminal-stint obligation data in lap-state information.

* **Tests**
  * Added regression coverage to verify the new stint and rival stop-status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->