### PR TITLE
fix(api): compute gaps over the field, and stop re-reading static corpora

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -1318,6 +1318,52 @@ def _driver_number_to_code(year: int = 2025) -> dict:
     return dict(zip(mapping["DriverNumber"].astype(int), mapping["Driver"]))
 
 
+# The radio corpus is static for the life of the process, exactly like the raw
+# laps above, but both radio endpoints were re-reading their parquet and
+# re-parsing transcripts.json on every request — every click through a lap list
+# or a transcript. Same (year, slug) cache pattern, in the two places that were
+# missing it.
+_RADIO_CORPUS_CACHE: Dict[tuple, Optional[pd.DataFrame]] = {}
+_RADIO_TRANSCRIPT_CACHE: Dict[tuple, dict] = {}
+
+
+def _get_radio_corpus(year: int, slug: str) -> Optional[pd.DataFrame]:
+    """The radio parquet for one race, or None when the corpus is absent."""
+    key = (year, slug)
+    if key in _RADIO_CORPUS_CACHE:
+        return _RADIO_CORPUS_CACHE[key]
+
+    path = _radio_corpus_root() / str(year) / slug / "radios.parquet"
+    frame = pd.read_parquet(path) if path.exists() else None
+    _RADIO_CORPUS_CACHE[key] = frame
+    return frame
+
+
+def _get_radio_transcripts(year: int, slug: str) -> dict:
+    """Whisper transcripts for one race, keyed by audio path.
+
+    An empty dict is the honest answer for a race nobody has transcribed yet,
+    and it is also what a corrupt cache file yields — the audio and the lap
+    list are still worth serving without the text, so a bad JSON file degrades
+    the response rather than failing the request. It is logged rather than
+    swallowed, which the previous bare ``except Exception: pass`` did not do.
+    """
+    key = (year, slug)
+    if key in _RADIO_TRANSCRIPT_CACHE:
+        return _RADIO_TRANSCRIPT_CACHE[key]
+
+    path = _transcript_cache_root() / str(year) / slug / "transcripts.json"
+    transcripts: dict = {}
+    if path.exists():
+        try:
+            transcripts = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+            logger.warning("Unreadable transcript cache %s: %s", path, exc)
+
+    _RADIO_TRANSCRIPT_CACHE[key] = transcripts
+    return transcripts
+
+
 @router.get("/radio-available-gps")
 def radio_available_gps(year: int = 2025):
     """Return GP names that have a radio corpus for the given year."""
@@ -1343,29 +1389,17 @@ def radio_laps(gp: str, year: int = 2025, driver: Optional[str] = None):
     If *driver* is provided (3-letter code, e.g. 'VER'), only that driver's
     laps are returned.  Otherwise all drivers with radio are listed.
     """
-    import json as _json
-
     try:
         slug = resolve_gp_slug(gp)
     except ValueError as exc:
         raise HTTPException(400, detail=str(exc))
 
-    radios_path = _radio_corpus_root() / str(year) / slug / "radios.parquet"
-    if not radios_path.exists():
+    rdf = _get_radio_corpus(year, slug)
+    if rdf is None:
         return {"drivers": []}
 
-    rdf = pd.read_parquet(radios_path)
     drv_map = _driver_number_to_code(year)
-
-    # Load cached transcripts (if available)
-    transcripts: dict = {}
-    tx_path = _transcript_cache_root() / str(year) / slug / "transcripts.json"
-    if tx_path.exists():
-        try:
-            with open(tx_path, encoding="utf-8") as f:
-                transcripts = _json.load(f)
-        except Exception:
-            pass
+    transcripts = _get_radio_transcripts(year, slug)
 
     # Optionally filter by driver code
     if driver:
@@ -1401,18 +1435,15 @@ def radio_laps(gp: str, year: int = 2025, driver: Optional[str] = None):
 @router.get("/radio-transcript")
 def radio_transcript(gp: str, driver: str, lap: int, year: int = 2025):
     """Return the transcript text for a specific driver/lap radio message."""
-    import json as _json
-
     try:
         slug = resolve_gp_slug(gp)
     except ValueError as exc:
         raise HTTPException(400, detail=str(exc))
 
-    radios_path = _radio_corpus_root() / str(year) / slug / "radios.parquet"
-    if not radios_path.exists():
+    rdf = _get_radio_corpus(year, slug)
+    if rdf is None:
         raise HTTPException(404, detail=f"No radio corpus for {gp} {year}")
 
-    rdf = pd.read_parquet(radios_path)
     drv_map = _driver_number_to_code(year)
     code_to_num = {v: k for k, v in drv_map.items()}
     drv_num = code_to_num.get(driver)
@@ -1424,14 +1455,7 @@ def radio_transcript(gp: str, driver: str, lap: int, year: int = 2025):
     if rows.empty:
         raise HTTPException(404, detail=f"No radio for {driver} at lap {lap}")
 
-    tx_path = _transcript_cache_root() / str(year) / slug / "transcripts.json"
-    transcripts: dict = {}
-    if tx_path.exists():
-        try:
-            with open(tx_path, encoding="utf-8") as f:
-                transcripts = _json.load(f)
-        except Exception:
-            pass
+    transcripts = _get_radio_transcripts(year, slug)
 
     results = []
     for _, row in rows.iterrows():

--- a/backend/api/v1/endpoints/telemetry.py
+++ b/backend/api/v1/endpoints/telemetry.py
@@ -265,6 +265,35 @@ def _compute_gap_consistency(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+# One entry per race, never invalidated: the featured parquet behind it is
+# static for the life of the process, the same assumption get_laps_df already
+# makes one layer down.
+_RACE_GAPS_CACHE: dict[tuple, pd.DataFrame] = {}
+
+
+def _race_frame_with_gaps(year: int, gp: str, race_laps: pd.DataFrame) -> pd.DataFrame:
+    """The whole field's laps for one race, with the inter-driver gap columns.
+
+    Computed over every car on track, because that is the only frame in which
+    "the gap to the car ahead" means anything. Returned unfiltered so callers
+    can narrow it afterwards without changing what the numbers describe.
+
+    Frames returned from here are shared, so a caller that intends to mutate
+    one must copy it first.
+    """
+    key = (year, gp)
+    if key in _RACE_GAPS_CACHE:
+        return _RACE_GAPS_CACHE[key]
+
+    frame = race_laps.copy()
+    if "LapTime_s" in frame.columns and "Position" in frame.columns:
+        frame = _compute_gaps(frame)
+        frame = _compute_gap_consistency(frame)
+
+    _RACE_GAPS_CACHE[key] = frame
+    return frame
+
+
 _RACE_DATA_COLS = [
     "Driver", "DriverNumber", "LapNumber", "Stint", "SpeedI1", "SpeedI2",
     "SpeedFL", "SpeedST", "Compound", "TyreLife", "FreshTyre", "Team",
@@ -304,7 +333,14 @@ def get_race_data(
     if not mask.any():
         raise HTTPException(404, detail=f"GP '{gp}' not found in {year} data")
 
-    subset = df[mask].copy()
+    # Gaps first, driver filter second, and the order is not cosmetic. A gap is
+    # a relation between cars, so computing it after the filter left a
+    # single-driver request with nothing to measure against: every
+    # GapToCarAhead came back null. Doing it on the whole field also makes the
+    # result a pure function of (year, gp), which is what lets it be cached
+    # instead of recomputed on every request — the consistency pass is a nested
+    # Python loop over every driver and lap.
+    subset = _race_frame_with_gaps(year, gp, df[mask])
 
     if driver:
         codes = [d.strip() for d in driver.split(",")]
@@ -312,10 +348,7 @@ def get_race_data(
         if subset.empty:
             raise HTTPException(404, detail=f"Driver(s) {codes} not found in {gp} {year}")
 
-    # Compute inter-driver gap columns from cumulative lap times
-    if "LapTime_s" in subset.columns and "Position" in subset.columns:
-        subset = _compute_gaps(subset)
-        subset = _compute_gap_consistency(subset)
+    subset = subset.copy()
 
     # Add TyreAge alias expected by tire charts
     subset["TyreAge"] = subset["TyreLife"]

--- a/backend/services/telemetry_service.py
+++ b/backend/services/telemetry_service.py
@@ -15,6 +15,7 @@ import os
 import warnings
 
 from backend.core.driver_colors import get_driver_color
+from backend.core.paths import get_data_root
 from backend.services.telemetry.session_cache import get_loaded_session
 
 # Suppress specific FastF1/pandas warnings
@@ -24,10 +25,18 @@ warnings.filterwarnings('ignore', message='.*fill_value.*')
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Enable FastF1 cache to avoid re-downloading data
-cache_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'cache')
-os.makedirs(cache_dir, exist_ok=True)
-fastf1.Cache.enable_cache(cache_dir)
+# Enable FastF1 cache to avoid re-downloading data.
+#
+# Resolved through get_data_root() rather than relative to this file, which put
+# it at src/telemetry/cache: a second, independent cache of the same FastF1
+# sessions the arcade already had under data/cache/fastf1. Both were live and
+# both were being written, so whichever surface opened a given race first paid
+# the full parse cost and the other paid it again from scratch, for about 4 GB
+# of duplicated seasons. One directory, and it follows $F1_STRAT_DATA_ROOT the
+# way every other path in the project does.
+cache_dir = get_data_root() / "cache" / "fastf1"
+cache_dir.mkdir(parents=True, exist_ok=True)
+fastf1.Cache.enable_cache(str(cache_dir))
 logger.info(f"FastF1 cache enabled at: {cache_dir}")
 
 # Official track lengths in meters (imported from frontend for consistency)

--- a/tests/test_race_data_gaps.py
+++ b/tests/test_race_data_gaps.py
@@ -12,8 +12,14 @@ from __future__ import annotations
 
 import pytest
 
-from backend.api.v1.endpoints.telemetry import get_race_data
-from backend.utils.laps_cache import get_laps_df
+# The lite CI installs neither numpy nor pandas, yet the endpoint below imports
+# both at module load time. Skip gracefully there rather than erroring during
+# collection, matching how the other dep-heavy suites behave.
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
+
+from backend.api.v1.endpoints.telemetry import get_race_data  # noqa: E402
+from backend.utils.laps_cache import get_laps_df  # noqa: E402
 
 YEAR = 2025
 

--- a/tests/test_race_data_gaps.py
+++ b/tests/test_race_data_gaps.py
@@ -1,0 +1,77 @@
+"""A gap is a relation between cars, so it cannot be measured on one car (#193).
+
+``/telemetry/race-data`` applied the driver filter before computing gaps, which
+left a single-driver request diffing a frame containing only that driver: every
+``GapToCarAhead`` came back null. The fix computes over the whole field first,
+which also makes the result a pure function of ``(year, gp)`` and therefore
+cacheable — the consistency pass is a nested Python loop over every driver and
+every lap, and it was being paid on every request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.api.v1.endpoints.telemetry import get_race_data
+from backend.utils.laps_cache import get_laps_df
+
+YEAR = 2025
+
+
+def _gp_with_gaps() -> str:
+    """A GP present in the featured parquet, or skip when data is absent."""
+    df = get_laps_df(YEAR)
+    if df is None:
+        pytest.skip(f"featured parquet for {YEAR} not available in this environment")
+    if "LapTime_s" not in df.columns or "Position" not in df.columns:
+        pytest.skip("featured parquet carries no lap times or positions here")
+    return str(df["GP_Name"].dropna().iloc[0])
+
+
+def _gaps_for(payload: dict, driver: str) -> list:
+    return [row.get("GapToCarAhead") for row in payload["race_data"] if row["Driver"] == driver]
+
+
+def test_a_driver_filtered_request_reports_the_same_gaps_as_the_full_field():
+    """The filter narrows which rows come back, never what the numbers mean."""
+    gp = _gp_with_gaps()
+    full = get_race_data(year=YEAR, gp=gp, driver=None)
+
+    drivers = [row["Driver"] for row in full["race_data"]]
+    assert drivers, f"no rows returned for {gp} {YEAR}"
+    driver = max(set(drivers), key=drivers.count)
+
+    filtered = get_race_data(year=YEAR, gp=gp, driver=driver)
+    assert _gaps_for(filtered, driver) == _gaps_for(full, driver)
+
+
+def test_a_single_driver_request_still_has_real_gaps():
+    """The regression itself: not merely equal to the full field, but populated.
+
+    Asserting equality alone would pass on a version that returned null in both
+    cases, which is exactly what a future refactor of _compute_gaps could
+    reintroduce.
+    """
+    gp = _gp_with_gaps()
+    full = get_race_data(year=YEAR, gp=gp, driver=None)
+    drivers = [row["Driver"] for row in full["race_data"]]
+    driver = max(set(drivers), key=drivers.count)
+
+    gaps = _gaps_for(get_race_data(year=YEAR, gp=gp, driver=driver), driver)
+    assert any(gap is not None for gap in gaps), (
+        f"every gap for {driver} at {gp} is null: the gaps are being computed after "
+        f"the driver filter, on a frame with no other car in it"
+    )
+
+
+def test_the_cached_race_frame_is_not_mutated_between_requests():
+    """The frame is shared, so a caller that adds a column must copy first.
+
+    ``get_race_data`` appends a TyreAge alias and drops to a column subset. Doing
+    that in place would corrupt the cached frame for every later request, and the
+    symptom would be a second call returning fewer columns than the first.
+    """
+    gp = _gp_with_gaps()
+    first = get_race_data(year=YEAR, gp=gp, driver=None)
+    second = get_race_data(year=YEAR, gp=gp, driver=None)
+    assert first == second


### PR DESCRIPTION
Three findings from the data-engineering audit, all in the same layer.

## 1. `race-data` returned null gaps for any driver-filtered request (#193)

The driver filter ran **before** the gap computation, so a single-driver request was diffing a frame with one car in it. A gap is a relation between cars; there was nothing to relate to.

| request | GapToCarAhead (Melbourne 2025, VER) |
|---|---|
| no filter | 0.954, 0.631, 1.151, 1.415 |
| `driver=VER` | null, null, null, null |

Gaps are computed over the whole field now and the filter applies afterwards. That is both correct and what makes the result a pure function of `(year, gp)` — the consistency pass is a **nested Python loop over every driver and every lap**, and it was being paid on every request.

**191 ms cold, 5.1 ms warm**, driver-filtered values now identical to the full field.

## 2. Both radio endpoints re-read their parquet and re-parsed `transcripts.json` on every call

On the same corpus a cache three hundred lines above in the same file already treats as static. Same `(year, slug)` pattern applied: **189.5 ms to 2.0 ms**, identical payloads.

The transcript reader also stops swallowing every exception. An unreadable cache is logged and degrades to no text — the lap list and audio are still worth serving — rather than disappearing into a bare `except Exception: pass`.

## 3. The FastF1 disk cache was resolved relative to `__file__`

Which put it at `src/telemetry/cache`: a second, independent copy of the same sessions the arcade already kept under `data/cache/fastf1`. Both were live and both were being written, so whichever surface opened a given race first paid the full parse and the other paid it again from scratch — about **4 GB** of duplicated seasons. It now resolves through `get_data_root()` like every other path, so it also follows `$F1_STRAT_DATA_ROOT` in docker.

Closes #193