### PR TITLE
fix(api): say whether each rival is in the pit lane

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -531,6 +531,23 @@ def get_lap_state(
                 "tyre_life": _safe_none(rr.get("TyreLife")),
                 "gap_ahead_s": round(rival_gap, 3),
                 "interval_to_driver_s": interval_to_driver,
+                # An overcut needs someone in the pit lane, and this producer was
+                # not saying whether anyone was. The projection reads the key with
+                # a False default, so its absence was not "unknown", it was an
+                # assertion that nobody is stopping, and OVERCUT could never be
+                # eligible through this endpoint.
+                #
+                # Derivable only when the frame carries PitInTime. The featured
+                # parquet drops that column, but it also drops the pit laps
+                # themselves, so a rival who IS in the pit lane always arrives
+                # through the raw fallback, which keeps it. None where the column
+                # is absent: not knowing is not the same as knowing they stayed
+                # out, and this dict is the only place that distinction survives.
+                "is_pitting": (
+                    bool(pd.notna(rr.get("PitInTime")))
+                    if "PitInTime" in lap_snapshot.columns
+                    else None
+                ),
             }
         )
 

--- a/tests/test_race_data_gaps.py
+++ b/tests/test_race_data_gaps.py
@@ -18,6 +18,7 @@ import pytest
 pytest.importorskip("numpy")
 pytest.importorskip("pandas")
 
+from backend.api.v1.endpoints.strategy import get_lap_state  # noqa: E402
 from backend.api.v1.endpoints.telemetry import get_race_data  # noqa: E402
 from backend.utils.laps_cache import get_laps_df  # noqa: E402
 
@@ -81,3 +82,35 @@ def test_the_cached_race_frame_is_not_mutated_between_requests():
     first = get_race_data(year=YEAR, gp=gp, driver=None)
     second = get_race_data(year=YEAR, gp=gp, driver=None)
     assert first == second
+
+
+# ---------------------------------------------------------------------------
+# An overcut needs to know who is in the pit lane
+# ---------------------------------------------------------------------------
+
+
+def test_lap_state_says_whether_each_rival_is_in_the_pit_lane():
+    """Absence of this key is an assertion, not a silence.
+
+    The projection reads ``is_pitting`` with a ``False`` default, so a producer
+    that omits it is not saying "unknown", it is saying "nobody is stopping".
+    OVERCUT keys off exactly that flag, so leaving it out made the candidate
+    permanently ineligible through this endpoint while every other surface could
+    reach it.
+
+    ``None`` is the honest answer where the frame cannot support one: the
+    featured parquet drops ``PitInTime``. It also drops the pit laps themselves,
+    which is why a rival who genuinely IS in the pit lane arrives through the raw
+    fallback, where the column survives.
+    """
+    gp = _gp_with_gaps()
+    frame = get_laps_df(YEAR)
+    row = frame[frame["GP_Name"] == gp].iloc[0]
+    driver, lap = str(row["Driver"]), int(row["LapNumber"])
+
+    state = get_lap_state(gp=gp, driver=driver, lap=lap, year=YEAR)
+    rivals = state["rivals"]
+    assert rivals, f"no rivals returned for {driver} at {gp} lap {lap}"
+    for rival in rivals:
+        assert "is_pitting" in rival, f"{rival['driver']} carries no pit-lane state"
+        assert rival["is_pitting"] in (True, False, None)


### PR DESCRIPTION
Found by an adversarial audit of the documentation, which is not where I expected a code bug.

## The defect

`/lap-state` built its rivals without an `is_pitting` key. The projection reads it as `rival.get("is_pitting", False)`, so **the absence was not silence, it was an assertion that nobody is stopping.**

`overcut_targets` requires exactly that flag, so **OVERCUT was permanently ineligible through this endpoint** while the CLI, the arcade and the replay engine could all reach it. The candidate looked wired everywhere; it was not.

## Why it is not simply a missing line

The featured parquet has no `PitInTime` column. But it also drops the pit laps themselves, through N04's `IsAccurate` gate, so **a rival who genuinely is in the pit lane always arrives through the raw fallback**, which keeps the column. Fixing the path that can answer fixes the case that occurs.

Where the column is absent the value is `None`, not `False`. Not knowing is not the same as knowing they stayed out, and this dict is the only place that distinction survives.

## Verified

Lusail 2025 lap 7, the Safety Car lap where most of the field boxed:

| driver | position | rivals ahead | overcut targets |
|---|---|---|---|
| NOR | P2 | 1 | none, and correctly so: the only car ahead was not stopping |
| OCO | P10 | 9 | VER, ANT, SAI |
| GAS | P19 | 18 | VER, ANT, SAI |

16 rivals report as pitting on that lap, which is what actually happened in that race.

110 passed, 1 skipped, 1 xfailed.