### PR TITLE
fix(backend): one gap fallback, imported, and an honest note on the one that stays different

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -14,6 +14,7 @@ import json
 import logging
 import sys
 from pathlib import Path
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -106,7 +107,7 @@ class RecommendRequest(BaseModel):
     lap_state: Dict[str, Any]
     gp_name: str = ""
     year: int = 2025
-    gap_ahead_s: float = 2.0
+    gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S
     pace_delta_s: float = 0.0
     risk_tolerance: float = 0.5
     radio_msgs: Optional[List[Dict[str, Any]]] = None
@@ -152,6 +153,12 @@ class SituationResult(BaseModel):
     overtake_prob: float
     sc_prob_3lap: float
     threat_level: str
+    # 0.0 here is NOT the request-side fallback above, and the two are deliberately
+    # different. This is what the agent OBSERVED, so zero means it reported a zero,
+    # and substituting 2.0 would invent a measurement. The honest shape is
+    # `float | None`, which RivalState.gap_ahead_s in position_projection already
+    # uses and whose consumers guard with `is not None`; changing it here is a
+    # response-schema break for every client, so it is tracked, not smuggled (#633).
     gap_ahead_s: float = 0.0
     pace_delta_s: float = 0.0
     reasoning: str = ""

--- a/backend/mcp_tools.py
+++ b/backend/mcp_tools.py
@@ -18,6 +18,7 @@ import functools
 import json
 import logging
 import sys
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any
 
 from fastmcp import FastMCP
@@ -594,7 +595,9 @@ def recommend_strategy(
 
     race_state = build_race_state(
         lap_state,
-        gap_ahead_s=driver_state.get("gap_ahead_s", 2.0),
+        # Note the two-arg .get: a key that is PRESENT and None returns None, not
+        # the fallback, so the `or` is what actually catches an unmeasured gap.
+        gap_ahead_s=driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S,
         pace_delta_s=pace_delta_s,
         risk_tolerance=_normalize_risk_tolerance(risk_tolerance),
         radio_msgs=None,

--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -27,6 +27,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any, Generator, Optional
 
 import pandas as pd
@@ -253,7 +254,17 @@ def _compute_gap_ahead(lap_state: dict[str, Any]) -> float:
     car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
     if not car_ahead:
         return 0.0
-    return abs(car_ahead.get("interval_to_driver_s") or 0.0)
+
+    # Two different zeros used to hide in one expression here. No car ahead means we
+    # lead, and 0.0 is honest for that. A car ahead whose interval was never measured
+    # is NOT a zero gap: 0.0 reads as side by side, which the orchestrator's clean-air
+    # band and N27's sub-1.0s DRS window both act on, so a missing measurement looked
+    # like the most aggressive situation on the board. This is the live SSE producer,
+    # so that value reaches the agents on every /simulate lap (#633).
+    measured_interval = car_ahead.get("interval_to_driver_s")
+    if measured_interval is None:
+        return GAP_UNKNOWN_FALLBACK_S
+    return abs(measured_interval)
 
 
 def _driver2_gap(lap_state: dict[str, Any], driver2: Optional[str]) -> Optional[float]:

--- a/backend/utils/race_state_builder.py
+++ b/backend/utils/race_state_builder.py
@@ -1,5 +1,6 @@
 """Build a RaceState from a raw lap_state dict."""
 
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -52,7 +53,7 @@ def _targeting_against_rival(
 def build_race_state(
     lap_state: Dict[str, Any],
     *,
-    gap_ahead_s: float = 2.0,
+    gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S,
     pace_delta_s: float = 0.0,
     risk_tolerance: float = 0.5,
     radio_msgs: Optional[List[dict]] = None,


### PR DESCRIPTION
Closes VforVitorio/F1-StratLab#633.

The parent repo extracted `GAP_UNKNOWN_FALLBACK_S` and its comments claimed the CLI, the arcade **and this backend** now shared it. Two of three moved. An adversarial gate caught the overclaim and counted what survived here.

## The one that mattered

`simulator.py`'s `_compute_gap_ahead` returned `abs(interval or 0.0)`, so **a car ahead whose interval was never measured came back as a 0.0 second gap**, meaning side by side.

This is the **live SSE producer**, so that value reached the agents on every `/simulate` lap, and `0.0` is exactly what the orchestrator's clean-air band and N27's sub-1.0s DRS window act on. A missing measurement looked like the most aggressive situation on the board.

Two different zeros were hiding in one expression: **no car ahead**, which is honestly zero, and **an unmeasured interval**, which is not.

## The three literal copies

`race_state_builder`, `mcp_tools` and the strategy request model each held their own `2.0`. They import the constant now.

`mcp_tools` also used the two-arg `.get` form, which returns `None` for a key that is **present and None** rather than the fallback, so that lookup is now an `or`.

## The one that deliberately stays different, because the gate was wrong about it

The gate called `SituationResult.gap_ahead_s = 0.0` "the drift, verbatim" against the request model in the same file. **Checking mattered: it is not.** One is an *input* fallback; the other is what the agent **observed**, where zero means it reported zero and substituting 2.0 would invent a measurement.

It keeps its `0.0` and gets a comment saying so. The honest shape is `float | None`, matching `RivalState` in `position_projection`, but that is a response-schema break for every client and is tracked rather than smuggled in.

## Verification

```
no car ahead                     -> 0.0
car ahead, measured 3.4s         -> 3.4
car ahead, interval NOT measured -> 2.0
```
