### PR TITLE
feat(simulate): thread the orchestrator decision memory through the rich branch

### DIFF
--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -48,6 +48,7 @@ from backend.utils.laps_cache import get_laps_df  # noqa: E402
 from backend.utils.race_state_builder import build_race_state  # noqa: E402
 from src.agents.strategy_orchestrator import RaceState  # noqa: E402
 from src.simulation.replay_engine import RaceReplayEngine  # noqa: E402
+from src.strategy.inference.decision_memory import DecisionMemory  # noqa: E402
 from src.strategy.inference.engine import run_lap  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -830,6 +831,12 @@ def simulate_race(config: SimConfig) -> Generator[dict[str, Any], None, None]:
     # missing corpus degrades to no RCM, exactly the pre-fix behaviour.
     rcm_runner, sc_tracker = _build_rcm_feed(config.year, config.gp, laps_df)
 
+    # One DecisionMemory per race, same lifetime and shape as sc_tracker above.
+    # run_lap stays pure per lap (test_engine_no_llm.py depends on that), so the
+    # running memory of the orchestrator's own past calls is owned here and
+    # threaded in as a value rather than kept inside the engine.
+    decision_memory = DecisionMemory()
+
     for lap_state in engine.replay():
         lap_num = lap_state.get("lap_number", 0)
         if lap_num < lap_start or lap_num > lap_end:
@@ -861,8 +868,16 @@ def simulate_race(config: SimConfig) -> Generator[dict[str, Any], None, None]:
                 # still handing agents the whole season, letting the Zandvoort grid
                 # decide a race at Lusail (#463; #440 fixed only the no-LLM half).
                 result, _agent_outputs, _timings = run_lap(
-                    race_state, laps_df, lap_state, profile="rich"
+                    race_state, laps_df, lap_state, profile="rich", memory=decision_memory
                 )
+                # Recorded from the StrategyRecommendation itself, not from the
+                # LapDecision built below: the DTO drops contingencies entirely and
+                # this is the branch where pit_lap_target comes from the LLM rather
+                # than N28, so a DTO-sourced record would mean something different
+                # than the same field on the no-llm branch (see DecisionMemory's
+                # docstring). The no-llm branch above never reaches this call, so
+                # memory only ever sees rich-profile laps.
+                decision_memory.record(lap_num, result)
 
             lap_time_s = lap_state.get("driver", {}).get("lap_time_s")
             decision = _parse_lap_decision(result, race_state, lap_state, lap_time_s)


### PR DESCRIPTION
Backend half of `VforVitorio/F1-StratLab#684` (epic `#648`). The parent repo bumps the submodule pointer once this lands.

## What

The Layer 3 prompt is stateless, so the orchestrator re-argues an unrelated case every lap and never reuses a plan it made. `DecisionMemory` (parent repo, `src/strategy/inference/decision_memory.py`) echoes this race's own previous calls back into the prompt. `run_lap` already accepts it; this wires the simulator.

One accumulator per race, created next to `sc_tracker` and with the same lifetime. The engine only READS it — recording is the caller's job, which is what keeps `run_lap` pure per lap.

## Three things that are the point

1. **`rich` branch only.** The `no-llm` branch builds no prompt for a block to reach and is untouched. `config.no_llm` is fixed for the whole run, so a race never mixes the two.
2. **Recorded from the `StrategyRecommendation`, never from `LapDecision`.** The DTO drops `contingencies` entirely — and that is the load-bearing field — while `pit_lap_target` comes from the LLM on this branch and from N28 on the other, so a DTO-sourced record would mean two different things on one surface.
3. **No record on a lap the surface skipped.** Both `continue` guards (lap range, DNF/incomplete) fire before the `try`, and a `run_lap` that raises is caught before the record line.

`DecisionMemory.record` raises on a non-increasing lap, deliberately. Checked rather than assumed: `RaceReplayEngine.replay()` is a single forward pass over `range(1, total_laps + 1)` with no seek or retry, and the guards only skip laps, so the recorded laps are a strictly increasing subsequence. No defensive `try` was added around it — if it ever fires, that is a real bug and should be loud.

## Why this ships

Measured on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42 the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Full write-up in the parent repo's `documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md`.

## Checks

- `ruff check --select=E9,F63,F7,F82` (this repo's CI gate) clean on the changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rich simulation runs to remember prior strategy recommendations across laps.
  * Improved continuity and context for strategy decisions during simulated races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->