### PR TITLE
feat(strategy-tab): state that the brief has no memory of earlier calls

### DIFF
--- a/webapp/src/features/strategy/components/DecisionBanner.test.tsx
+++ b/webapp/src/features/strategy/components/DecisionBanner.test.tsx
@@ -193,4 +193,17 @@ describe('DecisionDetails', () => {
     // Never leak literal null/undefined/NaN into the DOM.
     expect(screen.queryByText(/undefined|NaN|null/)).not.toBeInTheDocument()
   })
+
+  it('says the brief has no memory of earlier calls, on every result shape', () => {
+    // The orchestrator keeps a per-race memory of its own previous calls and it
+    // measurably changes decisions. This tab cannot use it: `/recommend` answers
+    // one lap per request with nothing surviving between calls. That boundary is
+    // deliberate, and stating it stops the absence reading as a missing feature
+    // someone then "fixes" with a per-request accumulator on the endpoint side.
+    for (const result of [richResult, sparseResult]) {
+      const { unmount } = render(<DecisionDetails result={result} />)
+      expect(screen.getByText(/no memory of earlier calls in the race/)).toBeInTheDocument()
+      unmount()
+    }
+  })
 })

--- a/webapp/src/features/strategy/components/DecisionDetails.tsx
+++ b/webapp/src/features/strategy/components/DecisionDetails.tsx
@@ -112,6 +112,18 @@ export function DecisionDetails({ result }: DecisionDetailsProps) {
           </Disclosure>
         ) : null}
       </div>
+
+      {/* The orchestrator keeps a per-race memory of its own previous calls, and it
+       *  measurably changes decisions: under a Safety Car it flipped the call on 8 of
+       *  8 runs. This tab cannot use it. `/recommend` answers one lap per request with
+       *  nothing surviving between calls, so there is no race to accumulate over, and
+       *  that is a deliberate boundary rather than a gap waiting to be closed. Saying
+       *  so in one line is cheaper than letting someone read the absence as a bug and
+       *  "fix" it by inventing a per-request accumulator on the endpoint side. */}
+      <p className="text-xs text-fg-3">
+        Single-lap query: this brief is reasoned from the lap above alone, with no memory of earlier
+        calls in the race.
+      </p>
     </Card>
   )
 }


### PR DESCRIPTION
Webapp half of `VforVitorio/F1-StratLab#694`. One line of copy plus its test.

## A finding that shrank this half of the issue

The plan assumed the webapp would render the memory block in simulation mode and show a note in query mode. **It cannot: nothing in the webapp consumes the `/simulate` stream.** Verified by grep across `src/` — `strategy/simulate` appears only in the generated `schema.ts` and one comment in `sse.ts`, never in a runtime call. The Strategy tab is built entirely on `POST /recommend`, which is stateless per request.

So the block has no consumer here, and the useful part of this step is the note alone. The block still travels on the lap payload (backend PR #205) so a future consumer gets it for free.

## What

One line at the foot of `DecisionDetails`:

> Single-lap query: this brief is reasoned from the lap above alone, with no memory of earlier calls in the race.

Plus a test that it renders on **both** result shapes (rich and sparse), so a future refactor of the sparse path cannot silently drop it.

## Why bother with one line

The orchestrator's per-race memory measurably changes decisions: under a Safety Car it flipped the call on 8 of 8 runs. This tab genuinely cannot use it. Stating that is cheaper than letting the absence read as a missing feature that someone later closes by inventing a per-request accumulator on the endpoint side, which is exactly how `_rcm_events_for_lap` came to exist twice with two signatures.

## Checks

- `vitest` — 8 passed in the touched file
- `tsc -b` clean
- `oxlint` clean
- prettier: both touched files formatted. Note `prettier --check .` fails **locally on Windows for 201 files even on a clean tree**, because `core.autocrlf=true` rewrites the working copy to CRLF; on the Linux runner the checkout is LF. Local format-check is not a meaningful gate in this repo on Windows.