### PR TITLE
fix(strategy): serve the Tyres tab the trained cluster mean

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -974,7 +974,11 @@ def predict_tire_range(
     """
     import torch
 
-    from src.agents.tire_agent import _compound_name_to_id, _get_default_tire_agent
+    from src.agents.tire_agent import (
+        TireAgentConfig,
+        _compound_name_to_id,
+        _get_default_tire_agent,
+    )
 
     df = get_laps_df(request.year)
     if df is None:
@@ -1014,7 +1018,15 @@ def predict_tire_range(
         clean_times = lap_times
     agent.session_meta = {
         "fastest_lap_s": float(clean_times.min()) if len(clean_times) > 0 else 90.0,
-        "cluster_mean_lap_s": float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
+        # The TRAINED per-cluster constant, not this race's own mean lap time. N04 built
+        # lap_time_vs_cluster_mean by subtracting one constant per CLUSTER (standard
+        # deviation 0.0 within a cluster); a race's own mean is a different quantity that
+        # happens to share the units. The two sibling builders in the parent repo were
+        # corrected together and this third one was missed, which left the Tyres tab's TCN
+        # chart running on a delta shifted by a mean of 6.14 s and up to 14.56 s.
+        "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
+            agent.cfg.circuit_cluster_map.get(request.gp, 0), 0.0
+        ),
         "total_laps": total_laps,
         "cluster_id": agent.cfg.circuit_cluster_map.get(request.gp, 0),
         "team_id": agent.cfg.team_id_map.get(team, 4),


### PR DESCRIPTION
The **third** `session_meta` builder, missed when the two in the parent repo were corrected together.

It set `cluster_mean_lap_s` to **this race's own mean lap time**. N04 built `lap_time_vs_cluster_mean` by subtracting one constant per CLUSTER (standard deviation 0.0 within a cluster); a race's own mean is a different quantity that happens to share the units.

Effect: the Tyres tab's TCN chart ran on a delta shifted from the trained one by a **mean of 6.14 s and up to 14.56 s**. The parent repo's fix made `lap_time_vs_cluster_mean` a recompute rather than a passthrough, so until this lands that change makes *this* path worse rather than better.

Found by an adversarial gate that took the claim "both `session_meta` builders changed" and refuted it.

Pairs with the parent-repo PR that added `TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S`, which this imports rather than restating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tire-range calculations by using trained lap-time data for each track cluster.
  * Preserved a safe fallback when no cluster mapping is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->