### PR TITLE
fix(api): resolve the GP spelling before every name-keyed lookup

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -1024,11 +1024,13 @@ def predict_tire_range(
         # happens to share the units. The two sibling builders in the parent repo were
         # corrected together and this third one was missed, which left the Tyres tab's TCN
         # chart running on a delta shifted by a mean of 6.14 s and up to 14.56 s.
+        # `cluster_for`, not a raw `.get`: request.gp arrives in whichever of the four GP
+        # spellings the caller holds, and the map is keyed by the parquet slug.
         "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
-            agent.cfg.circuit_cluster_map.get(request.gp, 0), 0.0
+            agent.cfg.cluster_for(request.gp, 0), 0.0
         ),
         "total_laps": total_laps,
-        "cluster_id": agent.cfg.circuit_cluster_map.get(request.gp, 0),
+        "cluster_id": agent.cfg.cluster_for(request.gp, 0),
         "team_id": agent.cfg.team_id_map.get(team, 4),
         "year": request.year,
         "AirTemp": 28.0,

--- a/backend/api/v1/endpoints/telemetry.py
+++ b/backend/api/v1/endpoints/telemetry.py
@@ -14,6 +14,7 @@ from backend.services.telemetry.telemetry_service import (
 )
 from backend.utils.laps_cache import get_laps_df
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from src.f1_strat_manager.gp_slugs import resolve_gp_key
 
 logger = logging.getLogger(__name__)
 
@@ -329,7 +330,10 @@ def get_race_data(
     if df is None:
         raise HTTPException(404, detail=f"No parquet data for {year}")
 
-    mask = df["GP_Name"] == gp
+    # The parameter's own description promises the country form is accepted; without a
+    # resolution step that was only true for the names the parquet already stores, so
+    # 'Miami Gardens' 404'd on a season whose data is there under 'Miami'.
+    mask = df["GP_Name"] == resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), gp)
     if not mask.any():
         raise HTTPException(404, detail=f"GP '{gp}' not found in {year} data")
 


### PR DESCRIPTION
Part of the parent repo's gp_name keyspace sweep (`documents/audits/PR3_GP_KEYSPACE_SWEEP.md`).

A GP is spelled four ways across the project and these two lookups were queried with one keyspace while keyed by another.

**`strategy.py`** — the third `session_meta` builder queried `circuit_cluster_map` with a raw `.get(request.gp, 0)`. It is the same twin that was missed when the two builders in the parent repo were corrected for `cluster_mean_lap_s`. Now goes through `TireAgentConfig.cluster_for`.

**`telemetry.py`** — `get_race_data`'s own parameter description promises the country form is accepted; without a resolution step that was only true for the names the parquet already stores, so a request for 'Miami Gardens' 404'd on a season whose data is there under 'Miami'.

## Checks

- `ruff check` / `ruff format --check` green in the parent tree.
- The parent repo's `tests/agents/test_gp_keyspace.py` enumerates every race directory against every consumer.