### PR TITLE
fix(ci): make the test job able to pass at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,6 @@ jobs:
       # of backend.core.config, which the security tests import; it does not pull
       # the heavy ML stack, so it stays in the deps-lite set.
       - name: Install test deps
-        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx python-dotenv
+        run: pip install pytest pytest-asyncio requests pydantic fastapi httpx python-dotenv pandas
       - name: Run unit tests
         run: pytest tests/ -v

--- a/tests/test_prev_lap_anchor.py
+++ b/tests/test_prev_lap_anchor.py
@@ -19,6 +19,13 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+# These exercise backend modules whose own imports reach into the parent F1-StratLab
+# checkout (``src.agents``). The submodule's CI clones this repository standalone, so
+# there is no ``src`` there and collection ERRORED, turning the test job red on every
+# pull request regardless of its contents. Skipping is the honest outcome: the code
+# under test genuinely needs the parent, and it is exercised there.
+pytest.importorskip("src", reason="needs the parent F1-StratLab checkout")
+
 from backend.api.v1.endpoints.strategy import _prev_lap_time_for_row
 
 

--- a/tests/test_race_data_gaps.py
+++ b/tests/test_race_data_gaps.py
@@ -12,6 +12,13 @@ from __future__ import annotations
 
 import pytest
 
+# These exercise backend modules whose own imports reach into the parent F1-StratLab
+# checkout (``src.agents``). The submodule's CI clones this repository standalone, so
+# there is no ``src`` there and collection ERRORED, turning the test job red on every
+# pull request regardless of its contents. Skipping is the honest outcome: the code
+# under test genuinely needs the parent, and it is exercised there.
+pytest.importorskip("src", reason="needs the parent F1-StratLab checkout")
+
 # The lite CI installs neither numpy nor pandas, yet the endpoint below imports
 # both at module load time. Skip gracefully there rather than erroring during
 # collection, matching how the other dep-heavy suites behave.


### PR DESCRIPTION
The `test` job has been red on **every** pull request in this repository regardless of its contents, so it carried no signal. Two causes, one behind the other.

1. `tests/test_prev_lap_anchor.py` imports pandas at module level and the deps-lite install list did not include it. That list exists to keep the heavy ML stack and the broken whisper pin (#28) out of CI — pandas is neither.
2. With pandas installed the next import failed: that module and `tests/test_race_data_gaps.py` import backend endpoints whose own imports reach into the parent F1-StratLab checkout (`src.agents`). This repository's CI clones it standalone, so there is no `src` and **collection errored**, which fails the whole job rather than the two modules.

`pytest.importorskip("src")` at the top of both. A skip is the honest outcome: the code under test genuinely needs the parent checkout and is exercised there, in the parent's own suite.

## Result

`test` passes. It was failing before this branch and on every branch cut from `main`.