### PR TITLE
fix(api): scope the laps frame to one race before any agent sees it

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -250,6 +250,7 @@ def _agent_error(agent: str, exc: Exception, status: int = 500) -> HTTPException
 
 from backend.utils.laps_cache import get_laps_df  # noqa: E402
 from backend.utils.laps_cache import require_laps_df as _require_laps_df  # noqa: E402
+from backend.utils.laps_cache import scope_to_race as _scope_to_race  # noqa: E402
 from backend.utils.serialization import agent_output_to_dict as _to_dict  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -1121,7 +1122,9 @@ def predict_tire(
     try:
         from src.agents.tire_agent import run_tire_agent_from_state
 
-        result = run_tire_agent_from_state(request.lap_state, laps_df)
+        result = run_tire_agent_from_state(
+            request.lap_state, _scope_to_race(laps_df, request.lap_state)
+        )
         return StrategyResponse(agent="tire", result=_to_dict(result))
     except (KeyError, TypeError, ValueError) as exc:
         logger.warning("Tire agent validation error: %s", exc)
@@ -1151,7 +1154,9 @@ def predict_situation(
     try:
         from src.agents.race_situation_agent import run_race_situation_agent_from_state
 
-        result = run_race_situation_agent_from_state(request.lap_state, laps_df)
+        result = run_race_situation_agent_from_state(
+            request.lap_state, _scope_to_race(laps_df, request.lap_state)
+        )
         return StrategyResponse(agent="situation", result=_to_dict(result))
     except (KeyError, TypeError, ValueError) as exc:
         logger.warning("Situation agent validation error: %s", exc)
@@ -1181,7 +1186,9 @@ def predict_pit(
     try:
         from src.agents.pit_strategy_agent import run_pit_strategy_agent_from_state
 
-        result = run_pit_strategy_agent_from_state(request.lap_state, laps_df)
+        result = run_pit_strategy_agent_from_state(
+            request.lap_state, _scope_to_race(laps_df, request.lap_state)
+        )
         return StrategyResponse(agent="pit", result=_to_dict(result))
     except (KeyError, TypeError, ValueError) as exc:
         logger.warning("Pit agent validation error: %s", exc)
@@ -1225,7 +1232,7 @@ def analyze_radio(
             "rcm_events": rcm_events,
         }
 
-        result = run_radio_agent_from_state(lap_state, laps_df)
+        result = run_radio_agent_from_state(lap_state, _scope_to_race(laps_df, lap_state))
         return StrategyResponse(agent="radio", result=_to_dict(result))
     except (KeyError, TypeError, ValueError) as exc:
         logger.warning("Radio agent validation error: %s", exc)
@@ -1372,7 +1379,13 @@ def recommend_strategy(
         # from Zandvoort and PIA's lap-7 row from Barcelona, while analysing Lusail.
         # Every one of those lookups wants the single race, so one filter here fixes
         # them all without touching the agents.
-        race_laps_df = laps_df[laps_df["GP_Name"] == gp] if gp else laps_df
+        #
+        # Through the shared helper rather than the raw `==` this used to be. A bare mask
+        # neither resolves the four spellings of a GP name — 'Miami Gardens' against a
+        # frame that stores 'Miami' matches nothing — nor guards the result, so an
+        # unresolved name handed the agents an EMPTY frame, which is worse than the
+        # unscoped one this filter exists to replace.
+        race_laps_df = _scope_to_race(laps_df, request.lap_state)
 
         race_state = build_race_state(
             request.lap_state,

--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -1385,7 +1385,11 @@ def recommend_strategy(
         # frame that stores 'Miami' matches nothing — nor guards the result, so an
         # unresolved name handed the agents an EMPTY frame, which is worse than the
         # unscoped one this filter exists to replace.
-        race_laps_df = _scope_to_race(laps_df, request.lap_state)
+        # `gp` first, mirroring the old `request.gp_name or session_meta` precedence: the
+        # request carries an explicit field and reading only the lap_state would drop a
+        # documented input, handing the season back to the agents for any caller that
+        # fills the field but not the meta.
+        race_laps_df = _scope_to_race(laps_df, request.lap_state, gp_name=gp or None)
 
         race_state = build_race_state(
             request.lap_state,

--- a/backend/mcp_tools.py
+++ b/backend/mcp_tools.py
@@ -414,10 +414,24 @@ def _build_lap_state(gp: str, driver: str, lap: int, year: int = 2025) -> dict[s
 
 
 def _get_laps_df(year: int = 2025):
-    """Return the cached featured DataFrame for the given season."""
+    """Return the cached featured DataFrame for the given season — ALL of its races."""
     from backend.utils.laps_cache import get_laps_df
 
     return get_laps_df(year)
+
+
+def _scope_to_race(laps_df, lap_state: dict):
+    """Narrow a season frame to the race a lap_state names, before any agent sees it.
+
+    Every tool below hands its frame to an agent whose lookups filter by Driver and
+    LapNumber and never by GP, so the whole season resolves `(VER, lap 20)` to 21 rows
+    across 21 Grands Prix and picks the first. Deferred import for the same reason as
+    `_get_laps_df` above: this module is imported by the MCP server before the parent
+    package is necessarily importable.
+    """
+    from backend.utils.laps_cache import scope_to_race
+
+    return scope_to_race(laps_df, lap_state)
 
 
 def _serialize(obj: Any) -> dict[str, Any]:
@@ -464,7 +478,7 @@ def predict_tire(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     from src.agents.tire_agent import run_tire_agent_from_state
 
     lap_state = _build_lap_state(gp, driver, lap, year)
-    laps_df = _get_laps_df(year)
+    laps_df = _scope_to_race(_get_laps_df(year), lap_state)
     result = run_tire_agent_from_state(lap_state, laps_df)
     return _format_result(_serialize(result))
 
@@ -481,7 +495,7 @@ def predict_situation(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     from src.agents.race_situation_agent import run_race_situation_agent_from_state
 
     lap_state = _build_lap_state(gp, driver, lap, year)
-    laps_df = _get_laps_df(year)
+    laps_df = _scope_to_race(_get_laps_df(year), lap_state)
     result = run_race_situation_agent_from_state(lap_state, laps_df)
     return _format_result(_serialize(result))
 
@@ -497,7 +511,7 @@ def predict_pit(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     from src.agents.pit_strategy_agent import run_pit_strategy_agent_from_state
 
     lap_state = _build_lap_state(gp, driver, lap, year)
-    laps_df = _get_laps_df(year)
+    laps_df = _scope_to_race(_get_laps_df(year), lap_state)
     result = run_pit_strategy_agent_from_state(lap_state, laps_df)
     return _format_result(_serialize(result))
 
@@ -519,7 +533,7 @@ def analyze_radio(gp: str, driver: str, lap: int, year: int = 2025) -> str:
     norm_year = _normalize_year(year)
 
     base_state = _build_lap_state(norm_gp, norm_driver, norm_lap, norm_year)
-    laps_df = _get_laps_df(norm_year)
+    laps_df = _scope_to_race(_get_laps_df(norm_year), base_state)
 
     # Real radio corpus + Safety Car RCM state, mirroring what the /radio and
     # /recommend HTTP endpoints already wire in strategy.py, instead of the
@@ -581,7 +595,7 @@ def recommend_strategy(
 
     year = _normalize_year(year)
     lap_state = _build_lap_state(gp, driver, lap, year)
-    laps_df = _get_laps_df(year)
+    laps_df = _scope_to_race(_get_laps_df(year), lap_state)
 
     # pace_delta_s contract is rival-relative (our lap minus the rival's),
     # but we only have the same driver's consecutive-lap times here, a self-delta

--- a/backend/utils/laps_cache.py
+++ b/backend/utils/laps_cache.py
@@ -58,8 +58,16 @@ def require_laps_df(year: int = 2025) -> pd.DataFrame:
     return df
 
 
-def scope_to_race(laps_df: pd.DataFrame, lap_state: dict) -> pd.DataFrame:
+def scope_to_race(
+    laps_df: pd.DataFrame, lap_state: dict, gp_name: Optional[str] = None
+) -> pd.DataFrame:
     """Narrow a season frame to the one race a ``lap_state`` describes.
+
+    ``gp_name`` wins when given, which is what ``/recommend`` needs: its request carries an
+    explicit ``gp_name`` field and the old code read ``request.gp_name or session_meta``.
+    Dropping it here would silently ignore a documented input, and a caller that sends the
+    race in the field but not in the lap_state would get the whole season back — the very
+    bug this function exists to kill.
 
     THE ONE PLACE THIS IS DONE, and that is the point. Every agent lookup that takes a
     laps frame (``_get_lap_row``, ``_get_position_map``, ``_get_undercut_candidates``,
@@ -81,6 +89,15 @@ def scope_to_race(laps_df: pd.DataFrame, lap_state: dict) -> pd.DataFrame:
     an agent an empty one. Applying it twice is a no-op, so a caller that was already
     scoped upstream loses nothing.
     """
-    from src.strategy.inference.engine import _scope_laps_to_gp
+    # From the LEAF module, never from `engine`: importing that one instantiates the radio
+    # agent's three transformer models, so the first scoped request used to pay 16.7 s and
+    # pull RoBERTa, the NER head, the RAG agent and the orchestrator into a worker that may
+    # never serve a radio call. `src/agents/__init__` is lazy for exactly that reason.
+    from src.strategy.inference.scoping import _scope_laps_to_gp
 
+    if gp_name:
+        lap_state = {
+            **(lap_state or {}),
+            "session_meta": {**((lap_state or {}).get("session_meta") or {}), "gp_name": gp_name},
+        }
     return _scope_laps_to_gp(laps_df, lap_state)

--- a/backend/utils/laps_cache.py
+++ b/backend/utils/laps_cache.py
@@ -42,7 +42,11 @@ def get_laps_df(year: int = 2025) -> Optional[pd.DataFrame]:
 
 
 def require_laps_df(year: int = 2025) -> pd.DataFrame:
-    """Like get_laps_df but raises HTTPException(503) if unavailable."""
+    """Like get_laps_df but raises HTTPException(503) if unavailable.
+
+    Returns the WHOLE SEASON. Anything that hands this to an agent must narrow it with
+    :func:`scope_to_race` first — see that function for what happens otherwise.
+    """
     from fastapi import HTTPException
 
     df = get_laps_df(year)
@@ -52,3 +56,31 @@ def require_laps_df(year: int = 2025) -> pd.DataFrame:
             detail=f"Featured parquet (data/processed/laps_featured_{year}.parquet) not available.",
         )
     return df
+
+
+def scope_to_race(laps_df: pd.DataFrame, lap_state: dict) -> pd.DataFrame:
+    """Narrow a season frame to the one race a ``lap_state`` describes.
+
+    THE ONE PLACE THIS IS DONE, and that is the point. Every agent lookup that takes a
+    laps frame (``_get_lap_row``, ``_get_position_map``, ``_get_undercut_candidates``,
+    ``_get_driver_stint``, the SC and overtake feature builders) filters by Driver and
+    LapNumber but never by GP. Handed the whole season, they resolve to whichever race
+    sorts first in the file: measured on the augmented 2025 frame, ``(VER, lap 20)``
+    matches **21 rows across 21 Grands Prix** and every one of those lookups picks Austin.
+
+    So a Model Lab run for Qatar computed its gap, its DRS window and every N12/N14 feature
+    from Austin's telemetry, and the page rendered the answer as Qatar's.
+
+    This is the #429/#480 lesson, which had reached ``run_lap`` and ``/recommend`` and the
+    tyre-eval route — each with its own explanatory comment in this very repository — and
+    none of the five per-agent POST routes or the five MCP tools the chat calls. Ten sites,
+    one rule, so it lives here rather than being written an eleventh time.
+
+    Delegates to the parent's ``_scope_laps_to_gp``: it already resolves the four spellings
+    of a GP name and already falls back to the unscoped frame, loudly, rather than handing
+    an agent an empty one. Applying it twice is a no-op, so a caller that was already
+    scoped upstream loses nothing.
+    """
+    from src.strategy.inference.engine import _scope_laps_to_gp
+
+    return _scope_laps_to_gp(laps_df, lap_state)

--- a/tests/test_route_gp_scoping.py
+++ b/tests/test_route_gp_scoping.py
@@ -28,6 +28,11 @@ from backend.utils.laps_cache import get_laps_df, scope_to_race  # noqa: E402
 _FEATURED = get_data_root() / "processed" / "laps_featured_2025.parquet"
 pytestmark = pytest.mark.skipif(not _FEATURED.exists(), reason="featured parquet absent")
 
+# Functions in the two web-facing modules that hand a laps frame to an agent: the four
+# per-agent POST routes, /recommend, the tyre-eval route, and the five MCP tools. Pinned
+# EXACTLY, so a new entry point has to be looked at rather than silently joining the set.
+_FRAME_PASSING_CALL_SITES = 11
+
 
 def _lap_state(gp: str, driver: str, lap: int) -> dict:
     return {
@@ -87,6 +92,64 @@ def test_an_unresolvable_race_keeps_the_full_frame_rather_than_an_empty_one():
     assert len(scoped) == len(season)
 
 
+def test_an_explicit_gp_name_wins_over_the_lap_state():
+    """`/recommend` accepts a `gp_name` field, and the first version of this dropped it.
+
+    A caller that fills the field but not the meta would otherwise get the whole season
+    back — the exact bug the helper exists to kill, reintroduced through the fix for it.
+    """
+    season = get_laps_df(2025)
+    scoped = scope_to_race(season, _lap_state("Sakhir", "VER", 20), gp_name="Lusail")
+
+    assert set(scoped["GP_Name"].astype(str)) == {"Lusail"}
+
+
+@pytest.mark.parametrize(
+    "lap_state",
+    [
+        {"session_meta": None},
+        {},
+        {"session_meta": {"gp_name": None}},
+        {"session_meta": {}},
+    ],
+    ids=["meta-is-null", "no-meta", "name-is-null", "empty-meta"],
+)
+def test_a_malformed_lap_state_falls_back_instead_of_raising(lap_state):
+    """`{"session_meta": null}` is a present key holding None, so the two-arg get never fires.
+
+    The chained `.get` raised AttributeError there — a 500 where the honest answer is the
+    same loud fallback an unknown GP already takes. Fourth form of this trap in this
+    project, after dict.get, Series.get and getattr.
+    """
+    season = get_laps_df(2025)
+    assert len(scope_to_race(season, lap_state)) == len(season)
+
+
+def test_the_helper_does_not_drag_in_the_agent_family():
+    """It used to import `engine`, which builds the radio agent's three NLP models.
+
+    Measured at 16.7 s and a worker holding RoBERTa, the NER head, the RAG agent and the
+    orchestrator in RAM and VRAM to serve a tyre request. `src/agents/__init__` is lazy for
+    precisely that reason, and importing the helper from `engine` undid it one layer up.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; from src.strategy.inference.scoping import _scope_laps_to_gp; "
+        "print(','.join(m for m in sys.modules if m.startswith('src.agents.')))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=str(__import__("pathlib").Path(__file__).parent.parent.parent.parent),
+    )
+    assert result.returncode == 0, result.stderr[-500:]
+    loaded = [name for name in result.stdout.strip().split(",") if name]
+    assert loaded == [], f"the scoping helper pulled in agent modules: {loaded}"
+
+
 def test_scoping_twice_changes_nothing():
     """Callers already scoped upstream (`run_lap`, `/recommend`) must lose nothing."""
     season = get_laps_df(2025)
@@ -126,12 +189,16 @@ def test_every_web_entry_point_scopes_before_calling_an_agent():
                 calls = [line.strip() for line in function.body if "_from_state(" in line]
                 unscoped.append(f"{name}:{function.line} {function.name}(): {calls[0]}")
 
-    # Non-vacuity. A parser that silently stopped finding the call sites — a rename, a
-    # decorator change, a move to another module — would leave this test green while
-    # guarding nothing, which is the exact failure this project has a name for.
-    assert examined >= 9, (
-        f"only {examined} frame-passing agent call sites found; there were 9 when this was "
-        "written (4 HTTP routes + 5 MCP tools), so the scan has stopped seeing them"
+    # Non-vacuity, and the floor is the MEASURED count rather than the one in the prose.
+    # It was first written as 9 — the four HTTP routes plus the five MCP tools — while the
+    # scan actually reaches 11, because /recommend and the tyre-eval route pass a frame
+    # too. A floor two below the real number lets two sites disappear in silence, which is
+    # the same "guard that asserts nothing" this file exists to prevent.
+    assert examined == _FRAME_PASSING_CALL_SITES, (
+        f"{examined} frame-passing agent call sites found, expected "
+        f"{_FRAME_PASSING_CALL_SITES}. Fewer means the scan has stopped seeing them and "
+        "guards nothing; more means a new entry point arrived — check it scopes, then "
+        "raise this number deliberately"
     )
 
     assert unscoped == [], (

--- a/tests/test_route_gp_scoping.py
+++ b/tests/test_route_gp_scoping.py
@@ -1,0 +1,172 @@
+"""Every agent entry point on the web side is handed ONE race, not the whole season.
+
+The agents' lookups (`_get_lap_row`, `_get_position_map`, `_get_undercut_candidates`,
+`_get_driver_stint`, the SC and overtake feature builders) filter by Driver and LapNumber
+and never by GP. Handed the season, they resolve to whichever race sorts first in the file.
+
+Measured on the augmented 2025 frame: `(VER, lap 20)` matches **21 rows across 21 Grands
+Prix**, and `iloc[0]` picks Austin every time. A Model Lab run for Qatar computed its gap,
+its DRS window and every N12/N14 feature from Austin's telemetry, then rendered the answer
+as Qatar's.
+
+The #429/#480 lesson had reached `run_lap`, `/recommend` and the tyre-eval route — each with
+its own explanatory comment in this repository — and none of the four per-agent POST routes
+or the five MCP tools the chat calls.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import pytest
+
+pytest.importorskip("src", reason="needs the parent F1-StratLab checkout")
+
+from backend.core.paths import get_data_root  # noqa: E402
+from backend.utils.laps_cache import get_laps_df, scope_to_race  # noqa: E402
+
+_FEATURED = get_data_root() / "processed" / "laps_featured_2025.parquet"
+pytestmark = pytest.mark.skipif(not _FEATURED.exists(), reason="featured parquet absent")
+
+
+def _lap_state(gp: str, driver: str, lap: int) -> dict:
+    return {
+        "lap_number": lap,
+        "driver": {"driver": driver, "lap_number": lap},
+        "session_meta": {"gp_name": gp, "year": 2025, "driver": driver},
+    }
+
+
+def test_the_season_frame_really_does_resolve_to_the_wrong_race():
+    """The premise. Without it the assertions below could hold for a trivial reason.
+
+    If this ever stops being true — because the frame gained a GP-aware index, say — the
+    scoping is no longer load-bearing and the tests after it are measuring nothing.
+    """
+    season = get_laps_df(2025)
+    assert season is not None
+
+    rows = season[(season["Driver"] == "VER") & (season["LapNumber"] == 20)]
+    assert rows["GP_Name"].nunique() > 1, "a (driver, lap) key is unique across the season"
+    assert str(rows.iloc[0]["GP_Name"]) != "Lusail", (
+        "the first row already happens to be the race we ask for below, so the check "
+        "would pass without any scoping"
+    )
+
+
+@pytest.mark.parametrize("gp", ["Lusail", "Sakhir", "Monaco"])
+def test_scoping_resolves_the_requested_race_not_the_first_in_the_file(gp):
+    """The effect, not the call: the row an agent would pick belongs to the right GP."""
+    season = get_laps_df(2025)
+    scoped = scope_to_race(season, _lap_state(gp, "VER", 20))
+
+    rows = scoped[(scoped["Driver"] == "VER") & (scoped["LapNumber"] == 20)]
+    assert not rows.empty, f"{gp}: scoping left no row for the driver's own lap"
+    assert set(rows["GP_Name"].astype(str)) == {gp}
+    assert rows["GP_Name"].nunique() == 1
+
+
+def test_the_metadata_spelling_of_a_race_also_resolves():
+    """`session_meta.gp_name` arrives in whichever of the four spellings the caller holds.
+
+    Miami is the race where they differ, and PR 3's resolver is what makes this work — so
+    if someone replaces `_scope_laps_to_gp` here with a plain `==` mask, this fails.
+    """
+    season = get_laps_df(2025)
+    scoped = scope_to_race(season, _lap_state("Miami Gardens", "VER", 20))
+
+    assert scoped["GP_Name"].nunique() == 1
+    assert str(scoped["GP_Name"].iloc[0]) == "Miami"
+
+
+def test_an_unresolvable_race_keeps_the_full_frame_rather_than_an_empty_one():
+    """Handing an agent an empty frame is worse than the bug this fixes (#429's own rule)."""
+    season = get_laps_df(2025)
+    scoped = scope_to_race(season, _lap_state("Nowhere Grand Prix", "VER", 20))
+
+    assert len(scoped) == len(season)
+
+
+def test_scoping_twice_changes_nothing():
+    """Callers already scoped upstream (`run_lap`, `/recommend`) must lose nothing."""
+    season = get_laps_df(2025)
+    once = scope_to_race(season, _lap_state("Lusail", "VER", 20))
+    twice = scope_to_race(once, _lap_state("Lusail", "VER", 20))
+
+    assert len(once) == len(twice)
+
+
+def test_every_web_entry_point_scopes_before_calling_an_agent():
+    """The enumeration, because this defect is one-site-fixed-nine-times-missed.
+
+    Reads the SOURCE FILES rather than importing them: the failure mode is a new call site
+    added later without the scope, no runtime assertion catches that, and importing
+    `mcp_tools` needs fastmcp, which CI deliberately does not install.
+    """
+    from pathlib import Path
+
+    backend_root = Path(__file__).parent.parent / "backend"
+    sources = {
+        "strategy.py": backend_root / "api" / "v1" / "endpoints" / "strategy.py",
+        "mcp_tools.py": backend_root / "mcp_tools.py",
+    }
+
+    unscoped: list[str] = []
+    examined = 0
+    for name, path in sources.items():
+        for function in _top_level_functions(path.read_text(encoding="utf-8")):
+            # Per function, and looking for the two tokens anywhere in it: the call is
+            # written across several lines in one module and on one line in the other, so
+            # a per-line match sees five of the nine sites and reports the rest as absent
+            # rather than as unscoped — which is how this assertion first went green.
+            if "_from_state(" not in function.source or "laps_df" not in function.source:
+                continue  # no frame passed at all (the pace agent) — nothing to scope
+            examined += 1
+            if not any(token in function.source for token in ("_scope_to_race", "gp_df")):
+                calls = [line.strip() for line in function.body if "_from_state(" in line]
+                unscoped.append(f"{name}:{function.line} {function.name}(): {calls[0]}")
+
+    # Non-vacuity. A parser that silently stopped finding the call sites — a rename, a
+    # decorator change, a move to another module — would leave this test green while
+    # guarding nothing, which is the exact failure this project has a name for.
+    assert examined >= 9, (
+        f"only {examined} frame-passing agent call sites found; there were 9 when this was "
+        "written (4 HTTP routes + 5 MCP tools), so the scan has stopped seeing them"
+    )
+
+    assert unscoped == [], (
+        "an agent is handed a laps frame that was never narrowed to one race — it will "
+        f"resolve (Driver, LapNumber) against the whole season: {unscoped}"
+    )
+
+
+class _Function(NamedTuple):
+    name: str
+    line: int
+    body: list[str]
+
+    @property
+    def source(self) -> str:
+        return "\n".join(self.body)
+
+
+def _top_level_functions(source: str) -> list[_Function]:
+    """Split a module into its top-level `def` blocks.
+
+    Per FUNCTION, not per line: the scope can be applied at the call or one line earlier
+    on the variable, and a line-based check would force the code into whichever shape the
+    grep happened to expect rather than reading what it actually does.
+    """
+    lines = source.splitlines()
+    starts = [
+        (index, line)
+        for index, line in enumerate(lines)
+        if line.startswith(("def ", "async def "))
+    ]
+
+    functions: list[_Function] = []
+    for position, (index, line) in enumerate(starts):
+        end = starts[position + 1][0] if position + 1 < len(starts) else len(lines)
+        name = line.split("(")[0].removeprefix("async ").removeprefix("def ").strip()
+        functions.append(_Function(name=name, line=index + 1, body=lines[index:end]))
+    return functions


### PR DESCRIPTION
Found by the adversarial gate over the parent repo's PR 5, deliberately split out so that diff stayed reviewable. Pre-existing — PR 5 did not cause it, its webapp behaviour merely rode on it.

## The defect

Every agent lookup that takes a laps frame (`_get_lap_row`, `_get_position_map`, `_get_undercut_candidates`, `_get_driver_stint`, the SC and overtake feature builders) filters by **Driver and LapNumber and never by GP**.

Handed the whole season they resolve to whichever race sorts first in the file. Executed on the augmented 2025 frame:

```
VER lap 20: 21 rows across 21 GPs -> iloc[0] picks 'Austin'
NOR lap 20: 21 rows across 21 GPs -> iloc[0] picks 'Austin'
LEC lap 35: 21 rows across 21 GPs -> iloc[0] picks 'Austin'
```

So a Model Lab "Situation" run for **Qatar** computed its gap, its DRS window and every N12/N14 feature from **Austin's** telemetry — and rendered the answer as Qatar's.

## Nine sites, and the two that already knew

The #429/#480 lesson had landed on `run_lap`, `/recommend` and the tyre-eval route — **each with its own explanatory comment in this very file** — and reached none of:

| | |
|---|---|
| HTTP routes | `/tire`, `/situation`, `/pit`, `/radio` |
| MCP tools (the **chat** path) | tyre, situation, pit, radio, orchestrator |

`/pace` is unaffected: it takes no frame at all.

So the rule now lives in **one helper**, `laps_cache.scope_to_race`, rather than being written a tenth time. It delegates to the parent's `_scope_laps_to_gp`, which already resolves the four spellings of a GP name and already falls back to the unscoped frame — loudly — rather than handing an agent an empty one.

## `/recommend` gets it too

It did scope, with `laps_df[laps_df["GP_Name"] == gp]`. A bare mask neither resolves the spellings — `'Miami Gardens'` against a frame storing `'Miami'` matches **nothing** — nor guards the result, so an unresolved name handed the agents an **empty** frame. That is worse than the unscoped one the filter exists to replace.

## Verification

```
Lusail           -> agent picks 'Lusail' (904 rows)
Sakhir           -> agent picks 'Sakhir' (924 rows)
Miami Gardens    -> agent picks 'Miami'  (857 rows)
```

All three picked Austin before.

`tests/test_route_gp_scoping.py`, 8 tests. It asserts the **effect**, not the call, and it opens by asserting the **premise** — that a (driver, lap) key really is ambiguous across the season — so the rest cannot pass for a trivial reason. The enumeration carries a **non-vacuity floor**: its first version silently saw five of the nine sites, because the calls are written across several lines in one module and on one line in the other, and would have stayed green while guarding a third of what it claimed.

- `ruff check --select=E9,F63,F7,F82` (what CI enforces) green — it caught a real one on the way: the first version of the MCP change referenced a name imported inside another function, which would have been a `NameError` on every chat call.
- The parent repo's suite is unaffected; this changes only the web entry points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved race-specific strategy analysis across tire, situation, pit, radio, and orchestration features.
  * Fixed issues where alternate Grand Prix names could select the wrong race or return no data.
  * Preserved complete season data when a race cannot be identified, preventing empty or misleading results.
  * Ensured repeated race filtering remains consistent and reliable across web and MCP entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->