### PR TITLE
fix(api): resolve the GP spelling on the two range routes

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -251,6 +251,7 @@ def _agent_error(agent: str, exc: Exception, status: int = 500) -> HTTPException
 from backend.utils.laps_cache import get_laps_df  # noqa: E402
 from backend.utils.laps_cache import require_laps_df as _require_laps_df  # noqa: E402
 from backend.utils.laps_cache import scope_to_race as _scope_to_race  # noqa: E402
+from src.f1_strat_manager.gp_slugs import resolve_gp_key as _resolve_gp_key  # noqa: E402
 from backend.utils.serialization import agent_output_to_dict as _to_dict  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -671,7 +672,11 @@ def predict_pace_range(request: PaceRangeRequest):
     if df is None:
         raise HTTPException(503, detail=f"No parquet for {request.year}")
 
-    gp_df = df[df["GP_Name"] == request.gp]
+    # Through the resolver: a GP arrives in whichever of its four spellings the caller
+    # holds, and a bare mask 404s on data that is present — 'Miami Gardens' against a
+    # frame that stores 'Miami' matches nothing. Loud rather than corrupting, but still
+    # a route refusing a race it has.
+    gp_df = df[df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)]
     if gp_df.empty:
         raise HTTPException(404, detail=f"GP '{request.gp}' not found")
 
@@ -998,7 +1003,11 @@ def predict_tire_range(
     df = get_laps_df(request.year)
     if df is None:
         raise HTTPException(503, detail=f"No parquet for {request.year}")
-    gp_df = df[df["GP_Name"] == request.gp]
+    # Through the resolver: a GP arrives in whichever of its four spellings the caller
+    # holds, and a bare mask 404s on data that is present — 'Miami Gardens' against a
+    # frame that stores 'Miami' matches nothing. Loud rather than corrupting, but still
+    # a route refusing a race it has.
+    gp_df = df[df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)]
     if gp_df.empty:
         raise HTTPException(404, detail=f"GP '{request.gp}' not found")
     drv_df = gp_df[gp_df["Driver"] == request.driver].sort_values("LapNumber")


### PR DESCRIPTION
The last pair of bare `==` masks on a GP name, found by the adversarial gate over PR #213 and left out of it deliberately: those routes fail **loudly**, so they were not in the same class as the ones silently feeding agents another race's telemetry.

A Grand Prix arrives in whichever of its four spellings the caller holds. `/pace-range` and `/tire-range` matched it exactly, so both returned **404 for a race whose data is present** — `'Miami Gardens'` against a frame that stores `'Miami'` matches nothing.

Now through `resolve_gp_key`, the same resolver every other lookup uses:

```
Miami Gardens -> 'Miami'   rows=857
Miami         -> 'Miami'   rows=857
Lusail        -> 'Lusail'  rows=904
```

## Checks

- `ruff check --select=E9,F63,F7,F82` (what CI enforces) green.
- The parent repo's suite: 275 passed across `tests/audit` + `tests/agents`, with only the pre-existing `test_weather_restore` failure, which is the featured-artefact defect the next PR fixes.