### PR TITLE
fix(webapp,sim): accept a null gap ahead before anything starts sending one

### DIFF
--- a/backend/services/simulation/simulator.py
+++ b/backend/services/simulation/simulator.py
@@ -519,7 +519,13 @@ def _parse_lap_decision(
         tyre_life=race_state.tyre_life,
         position=race_state.position,
         lap_time_s=lap_time_s,
-        gap_ahead_s=race_state.gap_ahead_s,
+        # The SSE wire keeps float: Arcade consumes this stream and its
+        # renderers are mid-audit, so 0.0 stays the wire's absent-marker -
+        # applied AT THE BOUNDARY only. The RaceState underneath, and the
+        # prompt built from it, carry the honest None (#878). A no-op until
+        # the builder starts emitting None; without it, that day every
+        # leader lap raises ValidationError here.
+        gap_ahead_s=race_state.gap_ahead_s if race_state.gap_ahead_s is not None else 0.0,
         action=action,
         confidence=confidence,
         reasoning=reasoning,

--- a/webapp/src/features/lab/models/SituationResultView.tsx
+++ b/webapp/src/features/lab/models/SituationResultView.tsx
@@ -76,7 +76,10 @@ function threatTone(level: string): 'danger' | 'warning' | 'success' {
  *  reads the same race context whether the bench is showing Overtake or
  *  Safety car odds. */
 function SituationFacts({ agent }: { agent: SituationResult }) {
-  const inDrsWindow = agent.gap_ahead_s < 1.0
+  // The guard is load-bearing, not decorative: JS coerces null to 0, so
+  // `null < 1.0` is TRUE. An unguarded null would render the leader as
+  // being in the DRS window, which is the exact lie the old 0.0 told (#878).
+  const inDrsWindow = agent.gap_ahead_s !== null && agent.gap_ahead_s < 1.0
   const paceRising = agent.pace_delta_s > 0
   const PaceArrow = paceRising ? ArrowUp : ArrowDown
   const paceText = `${paceRising ? '+' : ''}${agent.pace_delta_s.toFixed(2)}s/lap`
@@ -85,7 +88,10 @@ function SituationFacts({ agent }: { agent: SituationResult }) {
     <div className="flex flex-wrap items-center gap-3">
       <MetricRow
         items={[
-          { label: 'Gap ahead', value: `${agent.gap_ahead_s.toFixed(1)}s` },
+          {
+            label: 'Gap ahead',
+            value: agent.gap_ahead_s === null ? '—' : `${agent.gap_ahead_s.toFixed(1)}s`,
+          },
           {
             label: 'Pace delta',
             value: (

--- a/webapp/src/features/strategy/components/LapReadout.tsx
+++ b/webapp/src/features/strategy/components/LapReadout.tsx
@@ -15,10 +15,13 @@ import { STRATEGY_YEAR } from '../search'
 
 /** "+X.Xs" — a gap is always framed as a positive interval to the car ahead,
  *  so the sign is decorative, not a direction indicator (unlike `formatSigned`).
- *  A zero gap means there's no car ahead at all, so it reads as "Leader"
- *  rather than the meaningless "+0.0s". */
-function formatGap(seconds: number): string {
-  if (seconds === 0) return 'Leader'
+ *  Null means there is no car directly ahead to measure: "Leader" at P1, an
+ *  em dash otherwise, because the pos-1 car is simply unclassified this lap.
+ *  A ZERO gap is a real measurement — two cars side by side — and renders as
+ *  one. Keying "Leader" off zero branded 1,053 non-leading 2025 laps as the
+ *  race leader (#878). */
+function formatGap(seconds: number | null, position: number): string {
+  if (seconds === null) return position === 1 ? 'Leader' : '—'
   return `+${seconds.toFixed(1)}s`
 }
 
@@ -102,7 +105,12 @@ interface DuelLineProps {
  */
 function DuelLine({ driver, rival }: DuelLineProps) {
   const tyreDelta = driver.tyre_life - rival.tyre_life
-  const gapDelta = driver.gap_ahead_s - rival.gap_ahead_s
+  // Either car may have no car ahead to measure; a delta against an
+  // absence is not a number, so the metric declines instead of inventing one.
+  const gapDelta =
+    driver.gap_ahead_s !== null && rival.gap_ahead_s !== null
+      ? driver.gap_ahead_s - rival.gap_ahead_s
+      : null
   const driverColor = getDriverTextColor(driver.driver, STRATEGY_YEAR)
   const rivalColor = getDriverTextColor(rival.driver, STRATEGY_YEAR)
 
@@ -116,7 +124,7 @@ function DuelLine({ driver, rival }: DuelLineProps) {
       <Separator />
       <Metric label="Δtyre">{formatSigned(tyreDelta)} laps</Metric>
       <Separator />
-      <Metric label="Δgap">{formatGapDelta(gapDelta)}</Metric>
+      <Metric label="Δgap">{gapDelta === null ? '—' : formatGapDelta(gapDelta)}</Metric>
       <Separator />
       <Metric label={`${rival.driver} tyre`}>
         <CompoundPill compound={rival.compound} />
@@ -162,7 +170,7 @@ export function LapReadout({ lapState, rival, isPreview }: LapReadoutProps) {
         <Separator />
         <Metric label="tyre">{driver.tyre_life} laps</Metric>
         <Separator />
-        <Metric label="gap">{formatGap(driver.gap_ahead_s)}</Metric>
+        <Metric label="gap">{formatGap(driver.gap_ahead_s, driver.position)}</Metric>
         <Separator />
         <Metric label="last">{formatLapTime(driver.lap_time_s)}</Metric>
         <Separator />

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -45,7 +45,10 @@ export interface LapStateDriver {
   sector1_s: number
   sector2_s: number
   sector3_s: number
-  gap_ahead_s: number
+  /** Null = no car directly ahead to measure: leading, or the pos-1 car is
+   *  not classified this lap. 0 is a REAL measured side-by-side gap, and
+   *  keying anything off it branded 1,053 non-leading 2025 laps (#878). */
+  gap_ahead_s: number | null
 }
 
 /** A rival — timing-screen data only (mirrors a real pit wall). */
@@ -56,7 +59,10 @@ export interface LapStateRival {
   lap_time_s: number
   compound: string
   tyre_life: number
-  gap_ahead_s: number
+  /** Null = no car directly ahead to measure: leading, or the pos-1 car is
+   *  not classified this lap. 0 is a REAL measured side-by-side gap, and
+   *  keying anything off it branded 1,053 non-leading 2025 laps (#878). */
+  gap_ahead_s: number | null
   /** On-track interval to OUR driver (rival elapsed time minus ours): sign
    *  encodes ahead/behind, magnitude is the gap. Null when either car's elapsed
    *  time is missing. Used to score a user-chosen rival against our car. */
@@ -118,7 +124,10 @@ export interface SituationResult {
   overtake_prob: number | null
   sc_prob_3lap: number
   threat_level: string
-  gap_ahead_s: number
+  /** Null = no car directly ahead to measure: leading, or the pos-1 car is
+   *  not classified this lap. 0 is a REAL measured side-by-side gap, and
+   *  keying anything off it branded 1,053 non-leading 2025 laps (#878). */
+  gap_ahead_s: number | null
   pace_delta_s: number
   reasoning: string
   // Real safety-car / virtual-safety-car state the agent already returns; the


### PR DESCRIPTION
Step A of the four-step fix for VforVitorio/F1-StratLab#878 — the race leader being told a rival sits 2.0 s ahead.

## Why this is its own PR, and first

The backend imports `src/agents/` from the **parent** checkout at runtime, so a parent merge changes backend behaviour immediately, ahead of any pointer bump. Landing the semantic change there first would make the simulator raise `ValidationError` on **every leader lap** — `LapDecision.gap_ahead_s` is a `float` and the builder would hand it `None`. That is a regression the bug never had.

So this accepts `null` everywhere it can arrive, while nothing yet sends one. **No behaviour changes today.**

## What

| File | Change |
|---|---|
| `backend/services/simulation/simulator.py` | The SSE wire keeps `float`, converting `None → 0.0` **at the boundary**; the `RaceState` and the prompt built from it carry the honest `None` |
| `webapp/src/lib/api/strategy.ts` | The three `gap_ahead_s` interfaces widen to `number \| null` |
| `webapp/.../LapReadout.tsx` | `formatGap` stops reading zero as "Leader" |
| `webapp/.../SituationResultView.tsx` | The DRS-window guard, and the gap row |

## The one that is a live bug, not preparation

`formatGap` rendered `seconds === 0` as **"Leader"**. Measured on the served 2025 frame: **1,053 laps of cars that are not leading** are labelled the race leader today — 1,049 where the car ahead simply is not in the classified snapshot, plus **4 genuinely measured zeros**, two cars side by side. Zero is a measurement. The leader is an *absence*.

And the DRS guard is load-bearing rather than defensive: **JS coerces `null` to 0, so `null < 1.0` is true**. Unguarded, the leader would render as being in the DRS window — the same lie the 0.0 told.

## Checks

`tsc --noEmit` clean · `vitest` 188 passed / 27 files · lint clean (pre-existing warnings only) · prettier 3.9.5

Parent tracking issue: VforVitorio/F1-StratLab#878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gap displays when no measurable car-ahead gap is available.
  * Leader status now displays as “Leader” rather than an invalid or misleading gap.
  * Unavailable gaps are shown as an em dash, while genuine zero-second gaps remain displayed as `+0.0s`.
  * DRS eligibility and situation details now handle missing gap data correctly.
  * Preserved accurate gap values throughout race strategy and simulation views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->