### PR TITLE
fix(backend,webapp): emit an absent gap ahead and stop the falsy-or rewriting it

### DIFF
--- a/backend/api/v1/endpoints/strategy.py
+++ b/backend/api/v1/endpoints/strategy.py
@@ -14,7 +14,6 @@ import json
 import logging
 import sys
 from pathlib import Path
-from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -107,7 +106,11 @@ class RecommendRequest(BaseModel):
     lap_state: Dict[str, Any]
     gp_name: str = ""
     year: int = 2025
-    gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S
+    # None = "derive it from the lap_state in this same body", which the
+    # canonical builder does - strictly better information than a client
+    # echo. Widening a REQUEST field is non-breaking: a client that sends a
+    # number keeps byte-identical behaviour (#878).
+    gap_ahead_s: Optional[float] = None
     pace_delta_s: float = 0.0
     risk_tolerance: float = 0.5
     radio_msgs: Optional[List[Dict[str, Any]]] = None
@@ -167,13 +170,13 @@ class SituationResult(BaseModel):
     overtake_prob: Optional[float]
     sc_prob_3lap: float
     threat_level: str
-    # 0.0 here is NOT the request-side fallback above, and the two are deliberately
-    # different. This is what the agent OBSERVED, so zero means it reported a zero,
-    # and substituting 2.0 would invent a measurement. The honest shape is
-    # `float | None`, which RivalState.gap_ahead_s in position_projection already
-    # uses and whose consumers guard with `is not None`; changing it here is a
-    # response-schema break for every client, so it is tracked, not smuggled (#633).
-    gap_ahead_s: float = 0.0
+    # None = no pair was scored (leading / no classified car ahead / the tool
+    # was never called), the absence semantics `overtake_prob` above already
+    # carries. 0.0 stays exactly what the agent OBSERVED, a genuinely
+    # side-by-side pair: substituting a number for either case invents a
+    # measurement. This IS the `float | None` migration #633 deferred and
+    # nothing then tracked - both trackers were closed - landing via #878.
+    gap_ahead_s: Optional[float] = None
     pace_delta_s: float = 0.0
     reasoning: str = ""
 
@@ -251,8 +254,9 @@ def _agent_error(agent: str, exc: Exception, status: int = 500) -> HTTPException
 from backend.utils.laps_cache import get_laps_df  # noqa: E402
 from backend.utils.laps_cache import require_laps_df as _require_laps_df  # noqa: E402
 from backend.utils.laps_cache import scope_to_race as _scope_to_race  # noqa: E402
-from src.f1_strat_manager.gp_slugs import resolve_gp_key as _resolve_gp_key  # noqa: E402
 from backend.utils.serialization import agent_output_to_dict as _to_dict  # noqa: E402
+
+from src.f1_strat_manager.gp_slugs import resolve_gp_key as _resolve_gp_key  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helper GET endpoints — parquet metadata for frontend selectors
@@ -502,7 +506,14 @@ def get_lap_state(
     # lookup key downstream (#465, same collision class as the #428/#430 rival
     # fix a few lines below).
     drv_pos = _safe_none(r.get("Position"))
-    gap_ahead_s = 0.0
+    # None, not 0.0, when there is no car directly ahead to measure (#878).
+    # The leader, an unresolved Position and a pos-1 car missing from the
+    # classified snapshot all used to collapse into 0.0 - a value this same
+    # producer ALSO measures for a genuinely side-by-side pair (four laps in
+    # 2025) - and a falsy `or` downstream then rewrote it into a fabricated
+    # 2.0 rival on the 1,262 laps our driver led. 2,315 laps of the served
+    # season carried that zero; 1,049 of them were not even the leader.
+    gap_ahead_s: Optional[float] = None
     if drv_pos is not None and drv_pos > 1:
         car_ahead = lap_snapshot[lap_snapshot["Position"] == drv_pos - 1]
         if not car_ahead.empty:
@@ -549,7 +560,7 @@ def get_lap_state(
         "sector1_s": float(_safe(r.get("Sector1_s", 0))),
         "sector2_s": float(_safe(r.get("Sector2_s", 0))),
         "sector3_s": float(_safe(r.get("Sector3_s", 0))),
-        "gap_ahead_s": round(gap_ahead_s, 3),
+        "gap_ahead_s": round(gap_ahead_s, 3) if gap_ahead_s is not None else None,
     }
 
     # Rivals: every other driver still CLASSIFIED on this lap, with real gaps.
@@ -570,7 +581,7 @@ def get_lap_state(
     rivals = []
     for _, rr in rivals_df.iterrows():
         rival_pos = int(rr["Position"])
-        rival_gap = 0.0
+        rival_gap: Optional[float] = None  # the same absence rule as the driver slot
         if rival_pos > 1:
             ahead = lap_snapshot[lap_snapshot["Position"] == rival_pos - 1]
             if not ahead.empty:
@@ -593,7 +604,7 @@ def get_lap_state(
                 "lap_time_s": float(_safe(rr.get("LapTime_s", 0))),
                 "compound": str(rr.get("Compound", "")),
                 "tyre_life": _safe_none(rr.get("TyreLife")),
-                "gap_ahead_s": round(rival_gap, 3),
+                "gap_ahead_s": round(rival_gap, 3) if rival_gap is not None else None,
                 "interval_to_driver_s": interval_to_driver,
                 # An overcut needs someone in the pit lane, and this producer was
                 # not saying whether anyone was. The projection reads the key with
@@ -704,7 +715,9 @@ def predict_pace_range(request: PaceRangeRequest):
     # holds, and a bare mask 404s on data that is present — 'Miami Gardens' against a
     # frame that stores 'Miami' matches nothing. Loud rather than corrupting, but still
     # a route refusing a race it has.
-    gp_df = df[df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)]
+    gp_df = df[
+        df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)
+    ]
     if gp_df.empty:
         raise HTTPException(404, detail=f"GP '{request.gp}' not found")
 
@@ -1037,7 +1050,9 @@ def predict_tire_range(
     # holds, and a bare mask 404s on data that is present — 'Miami Gardens' against a
     # frame that stores 'Miami' matches nothing. Loud rather than corrupting, but still
     # a route refusing a race it has.
-    gp_df = df[df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)]
+    gp_df = df[
+        df["GP_Name"] == _resolve_gp_key(set(df["GP_Name"].dropna().astype(str)), request.gp)
+    ]
     if gp_df.empty:
         raise HTTPException(404, detail=f"GP '{request.gp}' not found")
     drv_df = gp_df[gp_df["Driver"] == request.driver].sort_values("LapNumber")

--- a/backend/mcp_tools.py
+++ b/backend/mcp_tools.py
@@ -18,7 +18,6 @@ import functools
 import json
 import logging
 import sys
-from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
 from typing import Any
 
 from fastmcp import FastMCP
@@ -603,14 +602,17 @@ def recommend_strategy(
     # after pit stops. Default to 0.0 (unknown) to report only what is known.
     # The shared build_race_state handles rival-relative recomputation when a
     # rival is selected; the MCP bridge doesn't have that user context.
-    driver_state = lap_state.get("driver", {})
     pace_delta_s = 0.0
 
     race_state = build_race_state(
         lap_state,
-        # Note the two-arg .get: a key that is PRESENT and None returns None, not
-        # the fallback, so the `or` is what actually catches an unmeasured gap.
-        gap_ahead_s=driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S,
+        # gap_ahead_s is deliberately NOT passed: None-means-compute lets the
+        # canonical builder derive the car-ahead gap from this lap_state's own
+        # rivals list. Those are the same numbers this bridge used to echo,
+        # minus the falsy `or` that rewrote the leader's 0.0 - and any
+        # measured 0.0 - into a fabricated 2.0 rival on every lap they led
+        # (#878). The builder answers None when no car is directly ahead, and
+        # the prompt renders that absence instead of a number.
         pace_delta_s=pace_delta_s,
         risk_tolerance=_normalize_risk_tolerance(risk_tolerance),
         radio_msgs=None,

--- a/tests/test_strategy_audit_fixes.py
+++ b/tests/test_strategy_audit_fixes.py
@@ -207,9 +207,7 @@ def test_build_lap_state_from_row_nan_tyre_life_stays_none():
 
     # The /pace-range gate (Prev_LapTime >= 60) is what lets a NaN-TyreLife row
     # actually reach the builder; without it the row is skipped upstream.
-    nan_rows = df[
-        df["TyreLife"].isna() & df["Prev_LapTime"].notna() & (df["Prev_LapTime"] >= 60)
-    ]
+    nan_rows = df[df["TyreLife"].isna() & df["Prev_LapTime"].notna() & (df["Prev_LapTime"] >= 60)]
     if nan_rows.empty:
         pytest.skip("no gate-surviving NaN-TyreLife row in this parquet")
 
@@ -251,3 +249,73 @@ def test_get_lap_state_carries_the_mandatory_stop_flags_for_us_and_every_rival()
     pending = state["rival_stop_pending"]
     listed = {r["driver"] for r in state["rivals"] if r.get("driver")}
     assert listed <= set(pending), f"rivals with no obligation verdict: {listed - set(pending)}"
+
+
+# ---------------------------------------------------------------------------
+# #878 -- no car ahead is an ABSENCE, and nothing may rewrite it into a number
+# ---------------------------------------------------------------------------
+
+
+def _first_lap_at_position(df, position: float):
+    """One (gp, driver, lap) at the given classified position, from the real frame."""
+    row = df[df["Position"] == position].iloc[0]
+    return str(row["GP_Name"]), str(row["Driver"]), int(row["LapNumber"])
+
+
+def test_the_leaders_gap_ahead_is_absent_rather_than_zero():
+    """The producer emits an absence for a car with nobody in front.
+
+    It used to emit 0.0, which is ALSO what it measures for two cars side by
+    side, and a falsy `or` downstream then rewrote that zero into a
+    fabricated 2.0 rival. 1,262 laps of the served 2025 season are this case.
+    """
+    df = get_laps_df(2025)
+    if df is None:
+        pytest.skip("featured parquet not present")
+
+    gp, driver, lap = _first_lap_at_position(df, 1.0)
+    state = get_lap_state(gp, driver, lap, 2025)
+
+    assert state["driver"]["gap_ahead_s"] is None, "the leader has no car ahead to measure"
+
+
+def test_a_car_with_someone_in_front_still_reports_a_measurement():
+    """The twin guard: making absence explicit must not stop measuring.
+
+    Without this, emitting None unconditionally would pass the test above and
+    destroy every real gap in the product.
+    """
+    df = get_laps_df(2025)
+    if df is None:
+        pytest.skip("featured parquet not present")
+
+    for _, row in df[df["Position"] == 2.0].head(20).iterrows():
+        state = get_lap_state(str(row["GP_Name"]), str(row["Driver"]), int(row["LapNumber"]), 2025)
+        gap = state["driver"]["gap_ahead_s"]
+        if gap is not None:
+            assert isinstance(gap, float) and gap >= 0.0
+            return
+    pytest.fail("no P2 lap in twenty had a classified car ahead; the producer stopped measuring")
+
+
+def test_the_bridge_derives_the_gap_instead_of_echoing_a_fallback():
+    """The seam the bug actually lived on, asserted on what the builder returns.
+
+    `mcp_tools.recommend_strategy` used to pass
+    `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S`, and Python's
+    falsy 0.0 made that a 2.0 rival for the race leader on every lap they led.
+    It now passes nothing and lets the canonical builder derive it, so the
+    absence survives all the way to the RaceState the prompt is built from.
+    """
+    from src.agents.race_state_builder import build_race_state
+
+    df = get_laps_df(2025)
+    if df is None:
+        pytest.skip("featured parquet not present")
+
+    gp, driver, lap = _first_lap_at_position(df, 1.0)
+    lap_state = get_lap_state(gp, driver, lap, 2025)
+
+    race_state = build_race_state(lap_state, pace_delta_s=0.0)  # mcp_tools' exact call shape
+
+    assert race_state.gap_ahead_s is None, "the leader reaches the prompt without a fake rival"

--- a/webapp/src/lib/api/schema.ts
+++ b/webapp/src/lib/api/schema.ts
@@ -4,2386 +4,2397 @@
  */
 
 export interface paths {
-    "/api/v1/telemetry/data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Telemetry Data */
-        get: operations["get_telemetry_data_api_v1_telemetry_data_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/prewarm": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Prewarm
-         * @description Warm the FastF1 session cache for (year, gp, session) in the background.
-         *
-         *     The frontend calls this when the user picks a session, so the ~2-15s parse
-         *     starts while they choose drivers — by the time lap-times/telemetry fire, the
-         *     session is already loaded and the charts fall in instead of hanging.
-         *     Returns 202 immediately; the load runs after the response is sent.
-         */
-        post: operations["prewarm_api_v1_telemetry_prewarm_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/gps": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Gps
-         * @description Get available Grand Prix events for a specific year.
-         */
-        get: operations["get_gps_api_v1_telemetry_gps_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/sessions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Sessions
-         * @description Get available sessions for a specific Grand Prix.
-         */
-        get: operations["get_sessions_api_v1_telemetry_sessions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/drivers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Drivers
-         * @description Get available drivers for a specific session.
-         */
-        get: operations["get_drivers_api_v1_telemetry_drivers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/lap-times": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Lap-time series for one or more drivers (pace comparison chart)
-         * @description Use this tool when the user wants a CHART of lap times across a stint or race — pace evolution, who was faster lap-by-lap, tyre-life effects on lap time.  Accepts one driver (single trace) or several comma-separated codes (overlay).  Returns the full lap-time list per driver; the frontend renders a Plotly line chart inline.  Prefer this over predict_pace for historical pace comparison; use predict_pace only when the user asks to FORECAST a future race lap.
-         */
-        get: operations["get_lap_times"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/lap-telemetry": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Speed / throttle / brake trace for ONE driver on ONE lap
-         * @description Use this tool when the user wants the telemetry of a SPECIFIC lap for a single driver — speed graph, throttle / brake / RPM trace, gear shifts, DRS activations.  Requires a concrete lap number (1-80).  Lap 1 typically has no data (formation lap) — do not default to 1; either pick a sensible mid-race lap or ask the user.  For comparing telemetry of two drivers use compare_drivers instead.
-         */
-        get: operations["get_telemetry"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/telemetry/race-data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Full race overview — positions and lap times for a Grand Prix
-         * @description Use this tool when the user wants a HIGH-LEVEL view of a race (position evolution lap-by-lap, multi-driver pace overview, stint-by-stint chart) rather than a single driver's telemetry or a head-to-head comparison.  Reads the pre-built featured parquet so it's fast and covers the whole field by default; pass driver codes to restrict.  Frontend renders position + lap-time subplots.
-         */
-        get: operations["get_race_data"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/circuit-domination": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Circuit Domination
-         * @description Get circuit domination visualization data.
-         *
-         *     Returns GPS coordinates and colors for each microsector based on
-         *     which driver was fastest in that section of the track.
-         *
-         *     **Parameters:**
-         *     - **year**: Racing season year (2018-2030)
-         *     - **gp**: Grand Prix name (must match FastF1 naming)
-         *     - **session**: Session type (FP1, FP2, FP3, Q, R, S, SQ)
-         *     - **drivers**: Comma-separated driver codes (max 3)
-         *
-         *     **Returns:**
-         *     ```json
-         *     {
-         *         "x": [100.5, 101.2, ...],
-         *         "y": [50.3, 51.1, ...],
-         *         "colors": ["#A259F7", "#00B4D8", ...],
-         *         "drivers": [
-         *             {"driver": "VER", "color": "#A259F7"},
-         *             {"driver": "NOR", "color": "#00B4D8"}
-         *         ]
-         *     }
-         *     ```
-         *
-         *     **Example:**
-         *     ```
-         *     GET /api/v1/circuit-domination?year=2024&gp=Spain&session=Q&drivers=VER,LEC
-         *     ```
-         */
-        get: operations["get_circuit_domination_api_v1_circuit_domination_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/comparison/compare": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Compare two drivers' fastest-lap telemetry head-to-head
-         * @description Use this tool whenever the user asks to compare two drivers, their fastest laps, qualifying laps, race pace head-to-head, speed traces, throttle, brake or microsector dominance.  Returns synchronised telemetry overlay plus a delta-time series the frontend renders as an inline chart.  Picks the fastest lap of each driver in the requested session automatically — the caller does NOT need to know specific lap numbers.  Prefer this over predict_pace whenever the user asks for telemetry comparison (predict_pace is for race lap-time forecasting, not historical qualifying telemetry).
-         */
-        get: operations["compare_drivers"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health Check
-         * @description Check if LM Studio is accessible and healthy.
-         *
-         *     Returns:
-         *         Health status information
-         */
-        get: operations["health_check_api_v1_chat_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Models
-         * @description Get list of available models from LM Studio.
-         *
-         *     Returns:
-         *         List of model names
-         */
-        get: operations["get_models_api_v1_chat_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/message": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Send Chat Message
-         * @description Send a message to LM Studio and get the complete response (non-streaming).
-         *
-         *     Args:
-         *         request: Chat request with message, history, and parameters
-         *
-         *     Returns:
-         *         Complete chat response
-         */
-        post: operations["send_chat_message_api_v1_chat_message_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/stream": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Stream Chat Message
-         * @description Send a message to LM Studio and stream the response.
-         *
-         *     Args:
-         *         request: Chat request with message, history, and parameters
-         *
-         *     Returns:
-         *         Streaming response with text chunks
-         */
-        post: operations["stream_chat_message_api_v1_chat_stream_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Chat Status
-         * @description Return the latest backend stage for *request_id* (smart-spinner poll target).
-         *
-         *     The Streamlit chat polls this endpoint every ~1s while a message is in
-         *     flight so the spinner label can mirror the real backend stage instead
-         *     of rotating fake placeholders.
-         */
-        get: operations["chat_status_api_v1_chat_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/tool-message": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Tool Message
-         * @description Tool-aware chat — non-streaming JSON variant.
-         *
-         *     Drives ``chat_engine.get_response`` and packages the result into the
-         *     ``ToolMessageResponse`` shape the rest of the API expects.  The
-         *     optional ``X-Request-Id`` header is echoed into the stage tracker so
-         *     the frontend's smart-spinner poll target (``/chat/status``) keeps
-         *     working even for non-streaming consumers.
-         */
-        post: operations["tool_message_api_v1_chat_tool_message_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/chat/tool-message-stream": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Tool Message Stream
-         * @description Tool-aware chat — Server-Sent Events streaming variant.
-         *
-         *     Yields the same event sequence the frontend has consumed since v1.3:
-         *     ``stage`` (whenever the backend phase advances), ``tool_result`` (rich
-         *     structured payload that maps to the chat's tool renderers), ``token``
-         *     (LLM text chunks for the live-typing UX), and ``done`` (final marker
-         *     with provider metadata).  All formatting concerns live in this module;
-         *     the ``chat_engine`` only produces (event, payload) tuples.
-         */
-        post: operations["tool_message_stream_api_v1_chat_tool_message_stream_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/available-gps": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Available Gps
-         * @description Return the list of GP names available in the featured parquet.
-         */
-        get: operations["available_gps_api_v1_strategy_available_gps_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/available-drivers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Available Drivers
-         * @description Return driver codes for a specific GP in the featured parquet.
-         */
-        get: operations["available_drivers_api_v1_strategy_available_drivers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/lap-range": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Lap Range
-         * @description Return the min/max lap numbers for a driver in a GP.
-         */
-        get: operations["lap_range_api_v1_strategy_lap_range_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/lap-state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Lap State
-         * @description Build the canonical lap_state dict for one (gp, driver, lap).
-         *
-         *     Reads the featured parquet first; when that lap was dropped from it
-         *     (Safety Car / pit / out lap), falls back to the raw per-race parquet so any
-         *     lap is runnable, exactly like the arcade replay. The returned structure
-         *     matches RaceStateManager.get_lap_state() either way, so it can be passed
-         *     directly to any agent endpoint.
-         */
-        get: operations["get_lap_state_api_v1_strategy_lap_state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/pace": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Pace
-         * @description Run the Pace Agent (N25) for a single lap.
-         */
-        post: operations["predict_pace_api_v1_strategy_pace_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/pace-range": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Pace Range
-         * @description Run Pace Agent across a lap range and return actual vs predicted.
-         */
-        post: operations["predict_pace_range_api_v1_strategy_pace_range_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/tire-range": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Tire Range
-         * @description Run the TireDegTCN across a lap range for the Tyres agent-tab chart.
-         *
-         *     Returns, per lap in the window, the ACTUAL cumulative fuel-adjusted degradation
-         *     (the parquet's `FuelAdjustedDegAbsolute`, i.e. the TCN's own training target)
-         *     and the model's PREDICTED value (a deterministic forward pass over the stint up
-         *     to that lap). Laps the featured parquet dropped (Safety Car / out laps) are
-         *     simply absent from the series, so the lines break there rather than erroring.
-         *
-         *     The tire agent is set up once (its `laps_df`/`session_meta`), then only the
-         *     cheap deterministic predict path runs per lap — no per-lap MC Dropout.
-         */
-        post: operations["predict_tire_range_api_v1_strategy_tire_range_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/tire": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Tire
-         * @description Run the Tire Agent (N26) for a single lap.
-         */
-        post: operations["predict_tire_api_v1_strategy_tire_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/situation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Situation
-         * @description Run the Race Situation Agent (N27) for a single lap.
-         */
-        post: operations["predict_situation_api_v1_strategy_situation_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/pit": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Predict Pit
-         * @description Run the Pit Strategy Agent (N28) for a single lap.
-         */
-        post: operations["predict_pit_api_v1_strategy_pit_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/radio": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Analyze Radio
-         * @description Run the Radio Agent (N29) for a single lap.
-         */
-        post: operations["analyze_radio_api_v1_strategy_radio_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/rag": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Query Rag
-         * @description Run the RAG Agent (N30) to answer a regulation question.
-         */
-        post: operations["query_rag_api_v1_strategy_rag_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/recommend": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Recommend Strategy
-         * @description Run the full Strategy Orchestrator (N31) for a single lap.
-         */
-        post: operations["recommend_strategy_api_v1_strategy_recommend_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/radio-available-gps": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Radio Available Gps
-         * @description Return GP names that have a radio corpus for the given year.
-         */
-        get: operations["radio_available_gps_api_v1_strategy_radio_available_gps_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/radio-laps": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Radio Laps
-         * @description Return drivers and their laps that have radio messages.
-         *
-         *     If *driver* is provided (3-letter code, e.g. 'VER'), only that driver's
-         *     laps are returned.  Otherwise all drivers with radio are listed.
-         */
-        get: operations["radio_laps_api_v1_strategy_radio_laps_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/radio-transcript": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Radio Transcript
-         * @description Return the transcript text for a specific driver/lap radio message.
-         */
-        get: operations["radio_transcript_api_v1_strategy_radio_transcript_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/strategy/simulate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Simulate
-         * @description Stream per-lap strategy decisions as Server-Sent Events.
-         *
-         *     Each event is a JSON blob in the ``data: ...\n\n`` SSE frame format. The
-         *     stream begins with a single ``start`` event, then emits one ``lap`` (or
-         *     ``error``) event per processed lap, and closes with a ``summary``. A
-         *     heartbeat comment is sent every 15 lap events so long runs survive proxy
-         *     idle timeouts.
-         */
-        post: operations["simulate_api_v1_strategy_simulate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Root */
-        get: operations["root__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health
-         * @description Unauthenticated liveness probe (open path — see core/auth.py OPEN_PATHS).
-         */
-        get: operations["health_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  '/api/v1/telemetry/data': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get Telemetry Data */
+    get: operations['get_telemetry_data_api_v1_telemetry_data_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/prewarm': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Prewarm
+     * @description Warm the FastF1 session cache for (year, gp, session) in the background.
+     *
+     *     The frontend calls this when the user picks a session, so the ~2-15s parse
+     *     starts while they choose drivers — by the time lap-times/telemetry fire, the
+     *     session is already loaded and the charts fall in instead of hanging.
+     *     Returns 202 immediately; the load runs after the response is sent.
+     */
+    post: operations['prewarm_api_v1_telemetry_prewarm_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/gps': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Gps
+     * @description Get available Grand Prix events for a specific year.
+     */
+    get: operations['get_gps_api_v1_telemetry_gps_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/sessions': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Sessions
+     * @description Get available sessions for a specific Grand Prix.
+     */
+    get: operations['get_sessions_api_v1_telemetry_sessions_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/drivers': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Drivers
+     * @description Get available drivers for a specific session.
+     */
+    get: operations['get_drivers_api_v1_telemetry_drivers_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/lap-times': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Lap-time series for one or more drivers (pace comparison chart)
+     * @description Use this tool when the user wants a CHART of lap times across a stint or race — pace evolution, who was faster lap-by-lap, tyre-life effects on lap time.  Accepts one driver (single trace) or several comma-separated codes (overlay).  Returns the full lap-time list per driver; the frontend renders a Plotly line chart inline.  Prefer this over predict_pace for historical pace comparison; use predict_pace only when the user asks to FORECAST a future race lap.
+     */
+    get: operations['get_lap_times']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/lap-telemetry': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Speed / throttle / brake trace for ONE driver on ONE lap
+     * @description Use this tool when the user wants the telemetry of a SPECIFIC lap for a single driver — speed graph, throttle / brake / RPM trace, gear shifts, DRS activations.  Requires a concrete lap number (1-80).  Lap 1 typically has no data (formation lap) — do not default to 1; either pick a sensible mid-race lap or ask the user.  For comparing telemetry of two drivers use compare_drivers instead.
+     */
+    get: operations['get_telemetry']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/telemetry/race-data': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Full race overview — positions and lap times for a Grand Prix
+     * @description Use this tool when the user wants a HIGH-LEVEL view of a race (position evolution lap-by-lap, multi-driver pace overview, stint-by-stint chart) rather than a single driver's telemetry or a head-to-head comparison.  Reads the pre-built featured parquet so it's fast and covers the whole field by default; pass driver codes to restrict.  Frontend renders position + lap-time subplots.
+     */
+    get: operations['get_race_data']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/circuit-domination': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Circuit Domination
+     * @description Get circuit domination visualization data.
+     *
+     *     Returns GPS coordinates and colors for each microsector based on
+     *     which driver was fastest in that section of the track.
+     *
+     *     **Parameters:**
+     *     - **year**: Racing season year (2018-2030)
+     *     - **gp**: Grand Prix name (must match FastF1 naming)
+     *     - **session**: Session type (FP1, FP2, FP3, Q, R, S, SQ)
+     *     - **drivers**: Comma-separated driver codes (max 3)
+     *
+     *     **Returns:**
+     *     ```json
+     *     {
+     *         "x": [100.5, 101.2, ...],
+     *         "y": [50.3, 51.1, ...],
+     *         "colors": ["#A259F7", "#00B4D8", ...],
+     *         "drivers": [
+     *             {"driver": "VER", "color": "#A259F7"},
+     *             {"driver": "NOR", "color": "#00B4D8"}
+     *         ]
+     *     }
+     *     ```
+     *
+     *     **Example:**
+     *     ```
+     *     GET /api/v1/circuit-domination?year=2024&gp=Spain&session=Q&drivers=VER,LEC
+     *     ```
+     */
+    get: operations['get_circuit_domination_api_v1_circuit_domination_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/comparison/compare': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Compare two drivers' fastest-lap telemetry head-to-head
+     * @description Use this tool whenever the user asks to compare two drivers, their fastest laps, qualifying laps, race pace head-to-head, speed traces, throttle, brake or microsector dominance.  Returns synchronised telemetry overlay plus a delta-time series the frontend renders as an inline chart.  Picks the fastest lap of each driver in the requested session automatically — the caller does NOT need to know specific lap numbers.  Prefer this over predict_pace whenever the user asks for telemetry comparison (predict_pace is for race lap-time forecasting, not historical qualifying telemetry).
+     */
+    get: operations['compare_drivers']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/health': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Health Check
+     * @description Check if LM Studio is accessible and healthy.
+     *
+     *     Returns:
+     *         Health status information
+     */
+    get: operations['health_check_api_v1_chat_health_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/models': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Models
+     * @description Get list of available models from LM Studio.
+     *
+     *     Returns:
+     *         List of model names
+     */
+    get: operations['get_models_api_v1_chat_models_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/message': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Send Chat Message
+     * @description Send a message to LM Studio and get the complete response (non-streaming).
+     *
+     *     Args:
+     *         request: Chat request with message, history, and parameters
+     *
+     *     Returns:
+     *         Complete chat response
+     */
+    post: operations['send_chat_message_api_v1_chat_message_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/stream': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Stream Chat Message
+     * @description Send a message to LM Studio and stream the response.
+     *
+     *     Args:
+     *         request: Chat request with message, history, and parameters
+     *
+     *     Returns:
+     *         Streaming response with text chunks
+     */
+    post: operations['stream_chat_message_api_v1_chat_stream_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Chat Status
+     * @description Return the latest backend stage for *request_id* (smart-spinner poll target).
+     *
+     *     The Streamlit chat polls this endpoint every ~1s while a message is in
+     *     flight so the spinner label can mirror the real backend stage instead
+     *     of rotating fake placeholders.
+     */
+    get: operations['chat_status_api_v1_chat_status_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/tool-message': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Tool Message
+     * @description Tool-aware chat — non-streaming JSON variant.
+     *
+     *     Drives ``chat_engine.get_response`` and packages the result into the
+     *     ``ToolMessageResponse`` shape the rest of the API expects.  The
+     *     optional ``X-Request-Id`` header is echoed into the stage tracker so
+     *     the frontend's smart-spinner poll target (``/chat/status``) keeps
+     *     working even for non-streaming consumers.
+     */
+    post: operations['tool_message_api_v1_chat_tool_message_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/chat/tool-message-stream': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Tool Message Stream
+     * @description Tool-aware chat — Server-Sent Events streaming variant.
+     *
+     *     Yields the same event sequence the frontend has consumed since v1.3:
+     *     ``stage`` (whenever the backend phase advances), ``tool_result`` (rich
+     *     structured payload that maps to the chat's tool renderers), ``token``
+     *     (LLM text chunks for the live-typing UX), and ``done`` (final marker
+     *     with provider metadata).  All formatting concerns live in this module;
+     *     the ``chat_engine`` only produces (event, payload) tuples.
+     */
+    post: operations['tool_message_stream_api_v1_chat_tool_message_stream_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/available-gps': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Available Gps
+     * @description Return the list of GP names available in the featured parquet.
+     */
+    get: operations['available_gps_api_v1_strategy_available_gps_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/available-drivers': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Available Drivers
+     * @description Return driver codes for a specific GP in the featured parquet.
+     */
+    get: operations['available_drivers_api_v1_strategy_available_drivers_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/lap-range': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Lap Range
+     * @description Return the min/max lap numbers for a driver in a GP.
+     */
+    get: operations['lap_range_api_v1_strategy_lap_range_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/lap-state': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Lap State
+     * @description Build a lap_state dict for one (gp, driver, lap), agent-ready either way.
+     *
+     *     Reads the featured parquet first; when that lap was dropped from it
+     *     (Safety Car / pit / out lap), falls back to the raw per-race parquet so any
+     *     lap is runnable, exactly like the arcade replay. Both paths return the same
+     *     shape, and any agent endpoint accepts it.
+     *
+     *     It is NOT field-identical to RaceStateManager.get_lap_state(), and this
+     *     docstring used to claim it was. Measured on Lusail 2025 lap 30, the manager
+     *     additionally emits gap_to_leader_s / track_status / is_in_lap / is_out_lap
+     *     on the driver and gap_to_leader_s / speed_st / stint on each rival, while
+     *     this producer adds driver_number and gap_ahead_s to both; weather.rainfall
+     *     is coerced to int here and left None there when the reading is absent.
+     *
+     *     The distinction matters because a key this producer omits is not read as
+     *     "unknown" downstream, it is read as its falsy default. That is how
+     *     is_pitting went missing here and made OVERCUT permanently ineligible on
+     *     this path while every other surface could reach it. Before adding a
+     *     consumer, check the field against both producers rather than assuming
+     *     parity.
+     */
+    get: operations['get_lap_state_api_v1_strategy_lap_state_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/pace': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Pace
+     * @description Run the Pace Agent (N25) for a single lap.
+     */
+    post: operations['predict_pace_api_v1_strategy_pace_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/pace-range': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Pace Range
+     * @description Run Pace Agent across a lap range and return actual vs predicted.
+     */
+    post: operations['predict_pace_range_api_v1_strategy_pace_range_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/tire-range': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Tire Range
+     * @description Run the TireDegTCN across a lap range for the Tyres agent-tab chart.
+     *
+     *     Returns, per lap in the window, the ACTUAL cumulative fuel-adjusted degradation
+     *     (the parquet's `FuelAdjustedDegAbsolute`, i.e. the TCN's own training target)
+     *     and the model's PREDICTED value (a deterministic forward pass over the stint up
+     *     to that lap). Laps the featured parquet dropped (Safety Car / out laps) are
+     *     simply absent from the series, so the lines break there rather than erroring.
+     *
+     *     The tire agent is set up once (its `laps_df`/`session_meta`), then only the
+     *     cheap deterministic predict path runs per lap — no per-lap MC Dropout.
+     */
+    post: operations['predict_tire_range_api_v1_strategy_tire_range_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/tire': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Tire
+     * @description Run the Tire Agent (N26) for a single lap.
+     */
+    post: operations['predict_tire_api_v1_strategy_tire_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/situation': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Situation
+     * @description Run the Race Situation Agent (N27) for a single lap.
+     */
+    post: operations['predict_situation_api_v1_strategy_situation_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/pit': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Predict Pit
+     * @description Run the Pit Strategy Agent (N28) for a single lap.
+     */
+    post: operations['predict_pit_api_v1_strategy_pit_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/radio': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Analyze Radio
+     * @description Run the Radio Agent (N29) for a single lap.
+     */
+    post: operations['analyze_radio_api_v1_strategy_radio_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/rag': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Query Rag
+     * @description Run the RAG Agent (N30) to answer a regulation question.
+     */
+    post: operations['query_rag_api_v1_strategy_rag_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/recommend': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Recommend Strategy
+     * @description Run the full Strategy Orchestrator (N31) for a single lap.
+     */
+    post: operations['recommend_strategy_api_v1_strategy_recommend_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/radio-available-gps': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Radio Available Gps
+     * @description Return GP names that have a radio corpus for the given year.
+     */
+    get: operations['radio_available_gps_api_v1_strategy_radio_available_gps_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/radio-laps': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Radio Laps
+     * @description Return drivers and their laps that have radio messages.
+     *
+     *     If *driver* is provided (3-letter code, e.g. 'VER'), only that driver's
+     *     laps are returned.  Otherwise all drivers with radio are listed.
+     */
+    get: operations['radio_laps_api_v1_strategy_radio_laps_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/radio-transcript': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Radio Transcript
+     * @description Return the transcript text for a specific driver/lap radio message.
+     */
+    get: operations['radio_transcript_api_v1_strategy_radio_transcript_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/strategy/simulate': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Simulate
+     * @description Stream per-lap strategy decisions as Server-Sent Events.
+     *
+     *     Each event is a JSON blob in the ``data: ...\n\n`` SSE frame format. The
+     *     stream begins with a single ``start`` event, then emits one ``lap`` (or
+     *     ``error``) event per processed lap, and closes with a ``summary``. A
+     *     heartbeat comment is sent every 15 lap events so long runs survive proxy
+     *     idle timeouts.
+     */
+    post: operations['simulate_api_v1_strategy_simulate_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Root */
+    get: operations['root__get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/health': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Health
+     * @description Unauthenticated liveness probe (open path — see core/auth.py OPEN_PATHS).
+     */
+    get: operations['health_health_get']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 export interface components {
-    schemas: {
-        /**
-         * ChatRequest
-         * @description Request model for chat messages.
-         */
-        ChatRequest: {
-            /** Text */
-            text: string;
-            /** Image */
-            image?: string | null;
-            /** Chat History */
-            chat_history?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Context */
-            context?: {
-                [key: string]: unknown;
-            } | null;
-            /** Model */
-            model?: string | null;
-            /**
-             * Temperature
-             * @default 0.7
-             */
-            temperature: number;
-            /**
-             * Max Tokens
-             * @default 1000
-             */
-            max_tokens: number;
-        };
-        /**
-         * ChatResponse
-         * @description Response model for chat messages.
-         */
-        ChatResponse: {
-            /** Response */
-            response: string;
-            /** Llm Model */
-            llm_model?: string | null;
-            /** Tokens Used */
-            tokens_used?: number | null;
-        };
-        /**
-         * DisplayType
-         * @description How the frontend should render a tool result inside a chat bubble.
-         * @enum {string}
-         */
-        DisplayType: "metrics" | "strategy_card" | "table" | "chart" | "text";
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /**
-         * HealthResponse
-         * @description Response model for health check.
-         */
-        HealthResponse: {
-            /** Status */
-            status: string;
-            /** Lm Studio Reachable */
-            lm_studio_reachable: boolean;
-            /** Message */
-            message: string;
-            /** Models Available */
-            models_available?: number | null;
-        };
-        /**
-         * PaceRangeRequest
-         * @description Batch pace predictions across a lap range.
-         */
-        PaceRangeRequest: {
-            /**
-             * Year
-             * @default 2025
-             */
-            year: number;
-            /** Gp */
-            gp: string;
-            /** Driver */
-            driver: string;
-            /** Lap Start */
-            lap_start: number;
-            /** Lap End */
-            lap_end: number;
-        };
-        /**
-         * PaceRequest
-         * @description Request body for the /pace endpoint (N25 XGBoost lap-time prediction).
-         */
-        PaceRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * PitRequest
-         * @description Request body for the /pit endpoint (N28 stop duration + N16 undercut).
-         */
-        PitRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * RadioRequest
-         * @description Request body for the /radio endpoint (N29 NLP pipeline + RCM parser).
-         *
-         *     radio_msgs and rcm_events must be lists of plain dicts matching the
-         *     RadioMessage / RCMEvent field names respectively.
-         */
-        RadioRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-            /** Radio Msgs */
-            radio_msgs?: {
-                [key: string]: unknown;
-            }[];
-            /** Rcm Events */
-            rcm_events?: {
-                [key: string]: unknown;
-            }[];
-        };
-        /**
-         * RagRequest
-         * @description Request body for the /rag regulation-lookup endpoint.
-         */
-        RagRequest: {
-            /** Question */
-            question: string;
-        };
-        /**
-         * RecommendRequest
-         * @description Request body for the full orchestrator endpoint (/recommend).
-         *
-         *     Accepts the raw lap_state dict produced by RaceStateManager.  The
-         *     endpoint derives RaceState from it internally so the caller does not
-         *     need to know the RaceState schema.
-         */
-        RecommendRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-            /**
-             * Gp Name
-             * @default
-             */
-            gp_name: string;
-            /**
-             * Year
-             * @default 2025
-             */
-            year: number;
-            /**
-             * Gap Ahead S
-             * @default 2
-             */
-            gap_ahead_s: number;
-            /**
-             * Pace Delta S
-             * @default 0
-             */
-            pace_delta_s: number;
-            /**
-             * Risk Tolerance
-             * @default 0.5
-             */
-            risk_tolerance: number;
-            /** Radio Msgs */
-            radio_msgs?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Rcm Events */
-            rcm_events?: {
-                [key: string]: unknown;
-            }[] | null;
-            /** Rival */
-            rival?: string | null;
-        };
-        /**
-         * SimulateRequest
-         * @description Inputs for a streamed race simulation run.
-         *
-         *     Mirrors the ``SimConfig`` dataclass in the simulation service; we keep a
-         *     Pydantic equivalent here so FastAPI can validate and document the payload
-         *     without importing the service module at schema-generation time.
-         */
-        SimulateRequest: {
-            /**
-             * Year
-             * @default 2025
-             */
-            year: number;
-            /** Gp */
-            gp: string;
-            /** Driver */
-            driver: string;
-            /** Team */
-            team: string;
-            /** Driver2 */
-            driver2?: string | null;
-            /** Lap Range */
-            lap_range?: [
-                number,
-                number
-            ] | null;
-            /**
-             * Risk Tolerance
-             * @default 0.5
-             */
-            risk_tolerance: number;
-            /**
-             * No Llm
-             * @default false
-             */
-            no_llm: boolean;
-            /**
-             * Provider
-             * @default lmstudio
-             */
-            provider: string;
-            /**
-             * Interval S
-             * @default 0
-             */
-            interval_s: number;
-        };
-        /**
-         * SituationRequest
-         * @description Request body for the /situation endpoint (N27 overtake + SC probability).
-         */
-        SituationRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * StrategyResponse
-         * @description Generic envelope returned by every strategy endpoint.
-         */
-        StrategyResponse: {
-            /** Agent */
-            agent: string;
-            /** Result */
-            result: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * TireRequest
-         * @description Request body for the /tire endpoint (N26 TireDegTCN cliff estimation).
-         */
-        TireRequest: {
-            /** Lap State */
-            lap_state: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * ToolMessageRequest
-         * @description Request body for POST /api/v1/chat/tool-message.
-         *
-         *     Identical to ChatRequest but explicitly typed so FastAPI generates
-         *     a separate OpenAPI schema (easier to version independently).
-         */
-        ToolMessageRequest: {
-            /**
-             * Text
-             * @description User message.
-             */
-            text: string;
-            /**
-             * Image
-             * @description Base64-encoded image for multimodal models.
-             */
-            image?: string | null;
-            /**
-             * Chat History
-             * @description Prior messages for context.
-             */
-            chat_history?: {
-                [key: string]: unknown;
-            }[] | null;
-            /**
-             * Context
-             * @description Arbitrary context (e.g. current GP/driver).
-             */
-            context?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model
-             * @description Override LM Studio model.
-             */
-            model?: string | null;
-            /**
-             * Temperature
-             * @default 0.7
-             */
-            temperature: number;
-            /**
-             * Max Tokens
-             * @default 1000
-             */
-            max_tokens: number;
-            /**
-             * Stream Tokens
-             * @description Stream the tool-summary reply as live token deltas instead of one full-text event. Only changes the second LLM call (the summary of a dispatched tool's result) — the first call, which decides whether to call a tool at all, always stays non-streaming. Default False keeps today's single-token behaviour for callers that never send this flag.
-             * @default false
-             */
-            stream_tokens: boolean;
-        };
-        /**
-         * ToolMessageResponse
-         * @description Response for the tool-aware chat endpoint.
-         *
-         *     Always contains a human-readable *response*.  When a tool was invoked
-         *     successfully, *tool_result* carries the structured data for rich rendering.
-         */
-        ToolMessageResponse: {
-            /**
-             * Response
-             * @description Natural-language assistant reply.
-             */
-            response: string;
-            /** Llm Model */
-            llm_model?: string | null;
-            /** Tokens Used */
-            tokens_used?: number | null;
-            /** @description Present only when a strategy tool was invoked and returned data. */
-            tool_result?: components["schemas"]["ToolResultData"] | null;
-        };
-        /**
-         * ToolResultData
-         * @description Structured output attached to a chat response when a tool was invoked.
-         *
-         *     The frontend inspects *display_type* to decide how to render *data*:
-         *     - metrics → st.metric columns
-         *     - strategy_card → bordered container with action / confidence / compound
-         *     - table → st.dataframe
-         *     - chart → st.plotly_chart (data contains figure JSON or base64 image)
-         *     - text → st.markdown
-         */
-        ToolResultData: {
-            /**
-             * Tool Name
-             * @description Which tool produced this result.
-             */
-            tool_name: string;
-            /** @description Rendering hint for the frontend. */
-            display_type: components["schemas"]["DisplayType"];
-            /**
-             * Data
-             * @description Agent output payload.
-             */
-            data?: {
-                [key: string]: unknown;
-            };
-            /**
-             * Summary
-             * @description Natural-language summary produced by LM Studio.
-             * @default
-             */
-            summary: string;
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
-        };
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+  schemas: {
+    /**
+     * ChatRequest
+     * @description Request model for chat messages.
+     */
+    ChatRequest: {
+      /** Text */
+      text: string
+      /** Image */
+      image?: string | null
+      /** Chat History */
+      chat_history?:
+        | {
+            [key: string]: unknown
+          }[]
+        | null
+      /** Context */
+      context?: {
+        [key: string]: unknown
+      } | null
+      /** Model */
+      model?: string | null
+      /**
+       * Temperature
+       * @default 0.7
+       */
+      temperature: number
+      /**
+       * Max Tokens
+       * @default 1000
+       */
+      max_tokens: number
+    }
+    /**
+     * ChatResponse
+     * @description Response model for chat messages.
+     */
+    ChatResponse: {
+      /** Response */
+      response: string
+      /** Llm Model */
+      llm_model?: string | null
+      /** Tokens Used */
+      tokens_used?: number | null
+    }
+    /**
+     * DisplayType
+     * @description How the frontend should render a tool result inside a chat bubble.
+     * @enum {string}
+     */
+    DisplayType: 'metrics' | 'strategy_card' | 'table' | 'chart' | 'text'
+    /** HTTPValidationError */
+    HTTPValidationError: {
+      /** Detail */
+      detail?: components['schemas']['ValidationError'][]
+    }
+    /**
+     * HealthResponse
+     * @description Response model for health check.
+     */
+    HealthResponse: {
+      /** Status */
+      status: string
+      /** Lm Studio Reachable */
+      lm_studio_reachable: boolean
+      /** Message */
+      message: string
+      /** Models Available */
+      models_available?: number | null
+    }
+    /**
+     * PaceRangeRequest
+     * @description Batch pace predictions across a lap range.
+     */
+    PaceRangeRequest: {
+      /**
+       * Year
+       * @default 2025
+       */
+      year: number
+      /** Gp */
+      gp: string
+      /** Driver */
+      driver: string
+      /** Lap Start */
+      lap_start: number
+      /** Lap End */
+      lap_end: number
+    }
+    /**
+     * PaceRequest
+     * @description Request body for the /pace endpoint (N25 XGBoost lap-time prediction).
+     */
+    PaceRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+    }
+    /**
+     * PitRequest
+     * @description Request body for the /pit endpoint (N28 stop duration + N16 undercut).
+     */
+    PitRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+    }
+    /**
+     * RadioRequest
+     * @description Request body for the /radio endpoint (N29 NLP pipeline + RCM parser).
+     *
+     *     radio_msgs and rcm_events must be lists of plain dicts matching the
+     *     RadioMessage / RCMEvent field names respectively.
+     */
+    RadioRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+      /** Radio Msgs */
+      radio_msgs?: {
+        [key: string]: unknown
+      }[]
+      /** Rcm Events */
+      rcm_events?: {
+        [key: string]: unknown
+      }[]
+    }
+    /**
+     * RagRequest
+     * @description Request body for the /rag regulation-lookup endpoint.
+     */
+    RagRequest: {
+      /** Question */
+      question: string
+    }
+    /**
+     * RecommendRequest
+     * @description Request body for the full orchestrator endpoint (/recommend).
+     *
+     *     Accepts the raw lap_state dict produced by RaceStateManager.  The
+     *     endpoint derives RaceState from it internally so the caller does not
+     *     need to know the RaceState schema.
+     */
+    RecommendRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+      /**
+       * Gp Name
+       * @default
+       */
+      gp_name: string
+      /**
+       * Year
+       * @default 2025
+       */
+      year: number
+      /** Gap Ahead S */
+      gap_ahead_s?: number | null
+      /**
+       * Pace Delta S
+       * @default 0
+       */
+      pace_delta_s: number
+      /**
+       * Risk Tolerance
+       * @default 0.5
+       */
+      risk_tolerance: number
+      /** Radio Msgs */
+      radio_msgs?:
+        | {
+            [key: string]: unknown
+          }[]
+        | null
+      /** Rcm Events */
+      rcm_events?:
+        | {
+            [key: string]: unknown
+          }[]
+        | null
+      /** Rival */
+      rival?: string | null
+    }
+    /**
+     * SimulateRequest
+     * @description Inputs for a streamed race simulation run.
+     *
+     *     Mirrors the ``SimConfig`` dataclass in the simulation service; we keep a
+     *     Pydantic equivalent here so FastAPI can validate and document the payload
+     *     without importing the service module at schema-generation time.
+     */
+    SimulateRequest: {
+      /**
+       * Year
+       * @default 2025
+       */
+      year: number
+      /** Gp */
+      gp: string
+      /** Driver */
+      driver: string
+      /** Team */
+      team: string
+      /** Driver2 */
+      driver2?: string | null
+      /** Lap Range */
+      lap_range?: [number, number] | null
+      /**
+       * Risk Tolerance
+       * @default 0.5
+       */
+      risk_tolerance: number
+      /**
+       * No Llm
+       * @default false
+       */
+      no_llm: boolean
+      /**
+       * Provider
+       * @default lmstudio
+       */
+      provider: string
+      /**
+       * Interval S
+       * @default 0
+       */
+      interval_s: number
+    }
+    /**
+     * SituationRequest
+     * @description Request body for the /situation endpoint (N27 overtake + SC probability).
+     */
+    SituationRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+    }
+    /**
+     * StrategyResponse
+     * @description Generic envelope returned by every strategy endpoint.
+     */
+    StrategyResponse: {
+      /** Agent */
+      agent: string
+      /** Result */
+      result: {
+        [key: string]: unknown
+      }
+    }
+    /**
+     * TireRequest
+     * @description Request body for the /tire endpoint (N26 TireDegTCN cliff estimation).
+     */
+    TireRequest: {
+      /** Lap State */
+      lap_state: {
+        [key: string]: unknown
+      }
+    }
+    /**
+     * ToolMessageRequest
+     * @description Request body for POST /api/v1/chat/tool-message.
+     *
+     *     Identical to ChatRequest but explicitly typed so FastAPI generates
+     *     a separate OpenAPI schema (easier to version independently).
+     */
+    ToolMessageRequest: {
+      /**
+       * Text
+       * @description User message.
+       */
+      text: string
+      /**
+       * Image
+       * @description Base64-encoded image for multimodal models.
+       */
+      image?: string | null
+      /**
+       * Chat History
+       * @description Prior messages for context.
+       */
+      chat_history?:
+        | {
+            [key: string]: unknown
+          }[]
+        | null
+      /**
+       * Context
+       * @description Arbitrary context (e.g. current GP/driver).
+       */
+      context?: {
+        [key: string]: unknown
+      } | null
+      /**
+       * Model
+       * @description Override LM Studio model.
+       */
+      model?: string | null
+      /**
+       * Temperature
+       * @default 0.7
+       */
+      temperature: number
+      /**
+       * Max Tokens
+       * @default 1000
+       */
+      max_tokens: number
+      /**
+       * Stream Tokens
+       * @description Stream the tool-summary reply as live token deltas instead of one full-text event. Only changes the second LLM call (the summary of a dispatched tool's result) — the first call, which decides whether to call a tool at all, always stays non-streaming. Default False keeps today's single-token behaviour for callers that never send this flag.
+       * @default false
+       */
+      stream_tokens: boolean
+    }
+    /**
+     * ToolMessageResponse
+     * @description Response for the tool-aware chat endpoint.
+     *
+     *     Always contains a human-readable *response*.  When a tool was invoked
+     *     successfully, *tool_result* carries the structured data for rich rendering.
+     */
+    ToolMessageResponse: {
+      /**
+       * Response
+       * @description Natural-language assistant reply.
+       */
+      response: string
+      /** Llm Model */
+      llm_model?: string | null
+      /** Tokens Used */
+      tokens_used?: number | null
+      /** @description Present only when a strategy tool was invoked and returned data. */
+      tool_result?: components['schemas']['ToolResultData'] | null
+    }
+    /**
+     * ToolResultData
+     * @description Structured output attached to a chat response when a tool was invoked.
+     *
+     *     The frontend inspects *display_type* to decide how to render *data*:
+     *     - metrics → st.metric columns
+     *     - strategy_card → bordered container with action / confidence / compound
+     *     - table → st.dataframe
+     *     - chart → st.plotly_chart (data contains figure JSON or base64 image)
+     *     - text → st.markdown
+     */
+    ToolResultData: {
+      /**
+       * Tool Name
+       * @description Which tool produced this result.
+       */
+      tool_name: string
+      /** @description Rendering hint for the frontend. */
+      display_type: components['schemas']['DisplayType']
+      /**
+       * Data
+       * @description Agent output payload.
+       */
+      data?: {
+        [key: string]: unknown
+      }
+      /**
+       * Summary
+       * @description Natural-language summary produced by LM Studio.
+       * @default
+       */
+      summary: string
+    }
+    /** ValidationError */
+    ValidationError: {
+      /** Location */
+      loc: (string | number)[]
+      /** Message */
+      msg: string
+      /** Error Type */
+      type: string
+    }
+  }
+  responses: never
+  parameters: never
+  requestBodies: never
+  headers: never
+  pathItems: never
 }
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 export interface operations {
-    get_telemetry_data_api_v1_telemetry_data_get: {
-        parameters: {
-            query: {
-                year: number;
-                gp: string;
-                session: string;
-                drivers: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    prewarm_api_v1_telemetry_prewarm_post: {
-        parameters: {
-            query: {
-                year: number;
-                gp: string;
-                session: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_gps_api_v1_telemetry_gps_get: {
-        parameters: {
-            query: {
-                /** @description Year of the season (e.g., 2024) */
-                year: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_sessions_api_v1_telemetry_sessions_get: {
-        parameters: {
-            query: {
-                /** @description Year of the season */
-                year: number;
-                /** @description Grand Prix name */
-                gp: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_drivers_api_v1_telemetry_drivers_get: {
-        parameters: {
-            query: {
-                /** @description Year of the season */
-                year: number;
-                /** @description Grand Prix name */
-                gp: string;
-                /** @description Session type (FP1, FP2, FP3, SQ, Q, S, R) */
-                session: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_lap_times: {
-        parameters: {
-            query: {
-                /** @description Season year (2023, 2024 or 2025). */
-                year: number;
-                /** @description Grand Prix name (city/circuit form preferred, country names also accepted). */
-                gp: string;
-                /** @description Session code: R (race), Q (qualifying), S (sprint), SQ (sprint qualifying), FP1 / FP2 / FP3.  Default to R unless the user explicitly mentions another session. */
-                session: string;
-                /** @description Comma-separated 3-letter driver codes, e.g. 'VER,HAM,LEC'.  Pass a single code for a single-driver trace. */
-                drivers: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_telemetry: {
-        parameters: {
-            query: {
-                /** @description Season year (2023, 2024 or 2025). */
-                year: number;
-                /** @description Grand Prix name (city/circuit form preferred). */
-                gp: string;
-                /** @description Session code: R, Q, S, SQ, FP1, FP2, FP3.  Default R for race telemetry. */
-                session: string;
-                /** @description Driver — 3-letter code (VER, HAM, LEC, NOR, PIA, …). */
-                driver: string;
-                /** @description Lap number, integer between 2 and the race length.  Avoid lap 1 — usually no telemetry. */
-                lap_number: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_race_data: {
-        parameters: {
-            query: {
-                /** @description Season year (2023, 2024 or 2025). */
-                year?: number;
-                /** @description Grand Prix name (city/circuit form preferred, country names also accepted). */
-                gp: string;
-                /** @description Optional comma-separated 3-letter driver codes (e.g. 'VER,LEC').  Omit to get the whole field. */
-                driver?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_circuit_domination_api_v1_circuit_domination_get: {
-        parameters: {
-            query: {
-                /** @description Racing season year */
-                year: number;
-                /** @description Grand Prix name (e.g., 'Spain', 'Belgium') */
-                gp: string;
-                /** @description Session type */
-                session: string;
-                /** @description Comma-separated driver codes (e.g., 'VER,LEC,HAM') */
-                drivers: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    compare_drivers: {
-        parameters: {
-            query: {
-                /** @description Season year (2023, 2024 or 2025). */
-                year: number;
-                /** @description Grand Prix name (city/circuit form, e.g. 'Monaco', 'Monza', 'Spa-Francorchamps').  Country names like 'Italy' or 'Belgium' also accepted. */
-                gp: string;
-                /** @description Session code: FP1 / FP2 / FP3 (free practice), SQ (sprint qualifying), Q (qualifying), S (sprint race), R (race).  Use 'Q' for qualifying-lap comparisons, 'R' for race fastest-lap comparisons. */
-                session: string;
-                /** @description First driver — 3-letter code (VER, HAM, LEC, NOR, PIA, ALO, …). */
-                driver1: string;
-                /** @description Second driver — 3-letter code (VER, HAM, LEC, NOR, PIA, ALO, …). */
-                driver2: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    health_check_api_v1_chat_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthResponse"];
-                };
-            };
-        };
-    };
-    get_models_api_v1_chat_models_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    send_chat_message_api_v1_chat_message_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ChatRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ChatResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    stream_chat_message_api_v1_chat_stream_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ChatRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    chat_status_api_v1_chat_status_get: {
-        parameters: {
-            query: {
-                request_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    tool_message_api_v1_chat_tool_message_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Request-Id"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ToolMessageRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ToolMessageResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    tool_message_stream_api_v1_chat_tool_message_stream_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Request-Id"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ToolMessageRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    available_gps_api_v1_strategy_available_gps_get: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    available_drivers_api_v1_strategy_available_drivers_get: {
-        parameters: {
-            query: {
-                gp: string;
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    lap_range_api_v1_strategy_lap_range_get: {
-        parameters: {
-            query: {
-                gp: string;
-                driver: string;
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_lap_state_api_v1_strategy_lap_state_get: {
-        parameters: {
-            query: {
-                gp: string;
-                driver: string;
-                lap: number;
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_pace_api_v1_strategy_pace_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PaceRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_pace_range_api_v1_strategy_pace_range_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PaceRangeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_tire_range_api_v1_strategy_tire_range_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PaceRangeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_tire_api_v1_strategy_tire_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TireRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_situation_api_v1_strategy_situation_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SituationRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    predict_pit_api_v1_strategy_pit_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PitRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    analyze_radio_api_v1_strategy_radio_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RadioRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    query_rag_api_v1_strategy_rag_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RagRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    recommend_strategy_api_v1_strategy_recommend_post: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RecommendRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StrategyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    radio_available_gps_api_v1_strategy_radio_available_gps_get: {
-        parameters: {
-            query?: {
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    radio_laps_api_v1_strategy_radio_laps_get: {
-        parameters: {
-            query: {
-                gp: string;
-                year?: number;
-                driver?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    radio_transcript_api_v1_strategy_radio_transcript_get: {
-        parameters: {
-            query: {
-                gp: string;
-                driver: string;
-                lap: number;
-                year?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    simulate_api_v1_strategy_simulate_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SimulateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    root__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    health_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
+  get_telemetry_data_api_v1_telemetry_data_get: {
+    parameters: {
+      query: {
+        year: number
+        gp: string
+        session: string
+        drivers: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  prewarm_api_v1_telemetry_prewarm_post: {
+    parameters: {
+      query: {
+        year: number
+        gp: string
+        session: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      202: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_gps_api_v1_telemetry_gps_get: {
+    parameters: {
+      query: {
+        /** @description Year of the season (e.g., 2024) */
+        year: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_sessions_api_v1_telemetry_sessions_get: {
+    parameters: {
+      query: {
+        /** @description Year of the season */
+        year: number
+        /** @description Grand Prix name */
+        gp: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_drivers_api_v1_telemetry_drivers_get: {
+    parameters: {
+      query: {
+        /** @description Year of the season */
+        year: number
+        /** @description Grand Prix name */
+        gp: string
+        /** @description Session type (FP1, FP2, FP3, SQ, Q, S, R) */
+        session: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_lap_times: {
+    parameters: {
+      query: {
+        /** @description Season year (2023, 2024 or 2025). */
+        year: number
+        /** @description Grand Prix name (city/circuit form preferred, country names also accepted). */
+        gp: string
+        /** @description Session code: R (race), Q (qualifying), S (sprint), SQ (sprint qualifying), FP1 / FP2 / FP3.  Default to R unless the user explicitly mentions another session. */
+        session: string
+        /** @description Comma-separated 3-letter driver codes, e.g. 'VER,HAM,LEC'.  Pass a single code for a single-driver trace. */
+        drivers: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_telemetry: {
+    parameters: {
+      query: {
+        /** @description Season year (2023, 2024 or 2025). */
+        year: number
+        /** @description Grand Prix name (city/circuit form preferred). */
+        gp: string
+        /** @description Session code: R, Q, S, SQ, FP1, FP2, FP3.  Default R for race telemetry. */
+        session: string
+        /** @description Driver — 3-letter code (VER, HAM, LEC, NOR, PIA, …). */
+        driver: string
+        /** @description Lap number, integer between 2 and the race length.  Avoid lap 1 — usually no telemetry. */
+        lap_number: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_race_data: {
+    parameters: {
+      query: {
+        /** @description Season year (2023, 2024 or 2025). */
+        year?: number
+        /** @description Grand Prix name (city/circuit form preferred, country names also accepted). */
+        gp: string
+        /** @description Optional comma-separated 3-letter driver codes (e.g. 'VER,LEC').  Omit to get the whole field. */
+        driver?: string | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_circuit_domination_api_v1_circuit_domination_get: {
+    parameters: {
+      query: {
+        /** @description Racing season year */
+        year: number
+        /** @description Grand Prix name (e.g., 'Spain', 'Belgium') */
+        gp: string
+        /** @description Session type */
+        session: string
+        /** @description Comma-separated driver codes (e.g., 'VER,LEC,HAM') */
+        drivers: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  compare_drivers: {
+    parameters: {
+      query: {
+        /** @description Season year (2023, 2024 or 2025). */
+        year: number
+        /** @description Grand Prix name (city/circuit form, e.g. 'Monaco', 'Monza', 'Spa-Francorchamps').  Country names like 'Italy' or 'Belgium' also accepted. */
+        gp: string
+        /** @description Session code: FP1 / FP2 / FP3 (free practice), SQ (sprint qualifying), Q (qualifying), S (sprint race), R (race).  Use 'Q' for qualifying-lap comparisons, 'R' for race fastest-lap comparisons. */
+        session: string
+        /** @description First driver — 3-letter code (VER, HAM, LEC, NOR, PIA, ALO, …). */
+        driver1: string
+        /** @description Second driver — 3-letter code (VER, HAM, LEC, NOR, PIA, ALO, …). */
+        driver2: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            [key: string]: unknown
+          }
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  health_check_api_v1_chat_health_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HealthResponse']
+        }
+      }
+    }
+  }
+  get_models_api_v1_chat_models_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  send_chat_message_api_v1_chat_message_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ChatRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ChatResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  stream_chat_message_api_v1_chat_stream_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ChatRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  chat_status_api_v1_chat_status_get: {
+    parameters: {
+      query: {
+        request_id: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  tool_message_api_v1_chat_tool_message_post: {
+    parameters: {
+      query?: never
+      header?: {
+        'X-Request-Id'?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ToolMessageRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ToolMessageResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  tool_message_stream_api_v1_chat_tool_message_stream_post: {
+    parameters: {
+      query?: never
+      header?: {
+        'X-Request-Id'?: string | null
+      }
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ToolMessageRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  available_gps_api_v1_strategy_available_gps_get: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  available_drivers_api_v1_strategy_available_drivers_get: {
+    parameters: {
+      query: {
+        gp: string
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  lap_range_api_v1_strategy_lap_range_get: {
+    parameters: {
+      query: {
+        gp: string
+        driver: string
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  get_lap_state_api_v1_strategy_lap_state_get: {
+    parameters: {
+      query: {
+        gp: string
+        driver: string
+        lap: number
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_pace_api_v1_strategy_pace_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PaceRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_pace_range_api_v1_strategy_pace_range_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PaceRangeRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_tire_range_api_v1_strategy_tire_range_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PaceRangeRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_tire_api_v1_strategy_tire_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TireRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_situation_api_v1_strategy_situation_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SituationRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  predict_pit_api_v1_strategy_pit_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PitRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  analyze_radio_api_v1_strategy_radio_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RadioRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  query_rag_api_v1_strategy_rag_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RagRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  recommend_strategy_api_v1_strategy_recommend_post: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RecommendRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['StrategyResponse']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  radio_available_gps_api_v1_strategy_radio_available_gps_get: {
+    parameters: {
+      query?: {
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  radio_laps_api_v1_strategy_radio_laps_get: {
+    parameters: {
+      query: {
+        gp: string
+        year?: number
+        driver?: string | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  radio_transcript_api_v1_strategy_radio_transcript_get: {
+    parameters: {
+      query: {
+        gp: string
+        driver: string
+        lap: number
+        year?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  simulate_api_v1_strategy_simulate_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SimulateRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  root__get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  health_health_get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
 }

--- a/webapp/src/lib/api/strategy.ts
+++ b/webapp/src/lib/api/strategy.ts
@@ -349,7 +349,10 @@ export async function runAgent<A extends AgentName>(
 /**
  * Run the full N31 orchestrator (all sub-agents + 500-sample MC + LLM synthesis).
  * Rate-limited to 5/min on the backend → surfaces as a 429 StrategyApiError.
- * `gap_ahead_s` defaults to the driver's own gap (2.0 fallback, as Streamlit).
+ * `gap_ahead_s` is deliberately omitted: the backend derives it from the
+ * lap_state in this same body, which is strictly better information than a
+ * client echo. The old `|| 2.0` rewrote the leader's absent gap - and any
+ * genuinely measured 0.0 - into a fabricated 2.0 rival (#878).
  *
  * When `rival` is set (the car the user picked in the Strategy tab), the backend
  * recomputes gap_ahead_s / pace_delta_s against that specific car, so the
@@ -366,7 +369,6 @@ export async function runRecommend(
     lap_state: lapState,
     gp_name: lapState.session_meta.gp_name,
     year: lapState.session_meta.year,
-    gap_ahead_s: lapState.driver.gap_ahead_s || 2.0,
     pace_delta_s: 0,
     risk_tolerance: riskTolerance,
     rival,


### PR DESCRIPTION
Step C of VforVitorio/F1-StratLab#878. Must land **after** the parent's step B, which is already merged: with the producer emitting `None` but the old builder still live, removing the `or` would have turned the leader's 2.0 into the builder's 0.0 — the trap the issue names.

## What

| Where | Change |
|---|---|
| `endpoints/strategy.py` producer | `None` for the driver slot **and the rival slot**, instead of 0.0 |
| `mcp_tools.py` | stops echoing the client value through a falsy `or`; passes nothing and lets the canonical builder derive it |
| `RecommendRequest.gap_ahead_s` | `Optional` — widening a **request** field is non-breaking |
| `SituationResult.gap_ahead_s` | `Optional` — the `float \| None` migration two closed issues each said the other was tracking |
| `webapp/.../strategy.ts` | the same `\|\| 2.0`, in TypeScript |
| `webapp/.../schema.ts` | regenerated from the real OpenAPI document |

The rival slot mattered: it carried the identical defect and only the driver slot was in the original report.

## Measured, on the served 2025 season

22,760 driver-laps through the real producer: **2,315** carried the zero — **1,262** the leader, **1,049** a car whose rival one place ahead simply had no classified row that lap, and **4** a genuinely measured side-by-side gap that the collapse destroyed.

## Verified here, on real data

```
test_the_leaders_gap_ahead_is_absent_rather_than_zero          PASSED
test_a_car_with_someone_in_front_still_reports_a_measurement   PASSED
```

The second is the twin guard: without it, emitting `None` unconditionally would pass the first and destroy every real gap in the product.

## What CI here cannot see, said plainly

The lite CI installs neither pandas nor fastmcp, so `test_strategy_audit_fixes.py` **skips entirely** — which is how a defect worth 10 % of the served season lived in this file's territory. The two tests above were run locally against the real 2025 parquet. The third (`test_the_bridge_derives_...`) needs the parent's model stack and skips in both environments; the chain it covers is verified link by link in the parent PR.

`schema.ts` was regenerated by dumping `app.openapi()` in-process — the backend will not boot here because `RaceSituationConfig` reads a parquet the curated download omits, so that one read was stubbed **in memory**, with nothing written to `data/`.

## Checks

`tsc --noEmit` clean · `vitest` 188 passed · lint 0 errors · `ruff check` clean on both changed backend files (the one remaining `E402` in `mcp_tools.py` is pre-existing on `main`, verified) · prettier 3.9.5